### PR TITLE
fix(LOM-270): fix issue with objects in data template

### DIFF
--- a/packages/api/src/core/utils/data-template.util.ts
+++ b/packages/api/src/core/utils/data-template.util.ts
@@ -5,7 +5,7 @@ import type {
 import { validateConditionExpression } from '@lombokapp/types'
 import { EvalAstFactory, parse } from 'jexpr'
 
-const TEMPLATE_EXPRESSION = /\{\{\s*(?<expression>.+?)\s*\}\}/g
+const TEMPLATE_EXPRESSION = /\{\{\s*(?<expression>.+?)\s*(?<!\{)\}\}/g
 const FUNCTION_EXPRESSION = /^(?<functionName>[a-zA-Z_][\w]*)\((?<args>.*)\)$/
 const STRING_LITERAL = /^(['"])(?<literal>.*)\1$/
 

--- a/packages/api/src/core/utils/data-template.util.unit-spec.ts
+++ b/packages/api/src/core/utils/data-template.util.unit-spec.ts
@@ -753,6 +753,102 @@ describe('dataFromTemplate', () => {
     })
   })
 
+  describe('object literals in expressions (empty object fallback)', () => {
+    it('resolves ternary with empty object fallback when condition is true', () => {
+      expect(
+        dataFromTemplate(
+          {
+            result: '{{task.success ? task.result.storageKeys : {}}}',
+          },
+          {
+            objects: {
+              task: {
+                success: true,
+                result: {
+                  storageKeys: {
+                    thumbnail: 'previews/abc/thumbnail.png',
+                    card: 'previews/abc/card.png',
+                    full: 'previews/abc/full.png',
+                  },
+                },
+              },
+            },
+          },
+        ),
+      ).resolves.toEqual({
+        result: {
+          thumbnail: 'previews/abc/thumbnail.png',
+          card: 'previews/abc/card.png',
+          full: 'previews/abc/full.png',
+        },
+      })
+    })
+
+    it('resolves ternary with empty object fallback when condition is false', () => {
+      expect(
+        dataFromTemplate(
+          {
+            result: '{{task.success ? task.result.storageKeys : {}}}',
+          },
+          {
+            objects: {
+              task: {
+                success: false,
+                result: undefined,
+              },
+            },
+          },
+        ),
+      ).resolves.toEqual({
+        result: {},
+      })
+    })
+
+    it('handles empty object in ternary alongside other templates in same object', () => {
+      expect(
+        dataFromTemplate(
+          {
+            status: '{{task.success ? "complete" : "error"}}',
+            keys: '{{task.success ? task.result.data : {}}}',
+          },
+          {
+            objects: {
+              task: {
+                success: true,
+                result: { data: { a: 1, b: 2 } },
+              },
+            },
+          },
+        ),
+      ).resolves.toEqual({
+        status: 'complete',
+        keys: { a: 1, b: 2 },
+      })
+    })
+
+    it('handles empty object fallback with multiple templates in one string', () => {
+      expect(
+        dataFromTemplate(
+          {
+            path: 'prefix/{{task.result.id}}/suffix',
+            fallback: '{{task.success ? task.result.meta : {}}}',
+          },
+          {
+            objects: {
+              task: {
+                success: false,
+                result: { id: 'abc' },
+              },
+            },
+          },
+        ),
+      ).resolves.toEqual({
+        path: 'prefix/abc/suffix',
+        fallback: {},
+      })
+    })
+  })
+
   describe('function calls with expressions', () => {
     it('handles function calls with expression arguments', () => {
       const formatPath = (


### PR DESCRIPTION
## Summary
- Fixes data template utility not correctly handling object values during template processing
- Adds unit test coverage for the fix

## Linked issue
LOM-270