### PR TITLE
feat(LOM-271): add process.log file management to worker agent

### DIFF
--- a/docker/worker-agent/cmd/process_log.go
+++ b/docker/worker-agent/cmd/process_log.go
@@ -1,0 +1,166 @@
+package cmd
+
+import (
+	"bufio"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/signal"
+	"strings"
+	"syscall"
+	"time"
+
+	"lombok-worker-agent/internal/config"
+	"lombok-worker-agent/internal/logs"
+
+	"github.com/spf13/cobra"
+)
+
+var (
+	processLogTail   int
+	processLogGrep   string
+	processLogFollow bool
+)
+
+var processLogCmd = &cobra.Command{
+	Use:   "process-log",
+	Short: "Read the secondary process log",
+	Long: `Read Docker-engine-compatible JSON log entries written by JavaScript processes.
+These logs are written to a dedicated file separate from the main worker-agent
+stdout, which is reserved for the job protocol.
+
+Use --follow to tail the log in real time (like 'docker logs -f').`,
+	RunE: readProcessLog,
+}
+
+func init() {
+	processLogCmd.Flags().IntVar(&processLogTail, "tail", 0, "Number of lines to tail (0 = all)")
+	processLogCmd.Flags().StringVar(&processLogGrep, "grep", "", "Filter lines containing this pattern")
+	processLogCmd.Flags().BoolVarP(&processLogFollow, "follow", "f", false, "Follow log output (like tail -f)")
+}
+
+func readProcessLog(cmd *cobra.Command, args []string) error {
+	logPath := config.ProcessLogPath()
+
+	if !processLogFollow {
+		return logs.ReadLogFile(logPath, logs.ReadOptions{
+			Tail: processLogTail,
+			Grep: processLogGrep,
+		})
+	}
+
+	// --follow mode: print existing lines then tail
+	return followProcessLog(logPath)
+}
+
+const processLogPollInterval = 250 * time.Millisecond
+
+func followProcessLog(path string) error {
+	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer cancel()
+
+	// Wait for the file to exist if it doesn't yet.
+	for {
+		if _, err := os.Stat(path); err == nil {
+			break
+		}
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-time.After(processLogPollInterval):
+		}
+	}
+
+	file, err := os.Open(path)
+	if err != nil {
+		return fmt.Errorf("failed to open process log: %w", err)
+	}
+	defer file.Close()
+
+	// If --tail is set, skip to the appropriate position first.
+	if processLogTail > 0 {
+		if err := printTailAndSeekEnd(file, processLogTail); err != nil {
+			return err
+		}
+	} else {
+		// Print all existing content, then follow.
+		if _, err := io.Copy(os.Stdout, file); err != nil {
+			return fmt.Errorf("failed to read process log: %w", err)
+		}
+	}
+
+	reader := bufio.NewReader(file)
+	offset, _ := file.Seek(0, io.SeekCurrent)
+
+	for {
+		select {
+		case <-ctx.Done():
+			return nil
+		default:
+		}
+
+		rawLine, err := reader.ReadString('\n')
+		if len(rawLine) > 0 {
+			if processLogGrep == "" || strings.Contains(rawLine, processLogGrep) {
+				_, _ = io.WriteString(os.Stdout, rawLine)
+			}
+			offset += int64(len(rawLine))
+		}
+
+		if err == nil {
+			continue
+		}
+
+		if errors.Is(err, io.EOF) {
+			// Check for file truncation (e.g. log rotation).
+			info, statErr := file.Stat()
+			if statErr == nil && info.Size() < offset {
+				if _, seekErr := file.Seek(0, io.SeekStart); seekErr == nil {
+					reader.Reset(file)
+					offset = 0
+				}
+			}
+			select {
+			case <-ctx.Done():
+				return nil
+			case <-time.After(processLogPollInterval):
+			}
+			continue
+		}
+
+		return fmt.Errorf("process-log: stopped following: %w", err)
+	}
+}
+
+// printTailAndSeekEnd prints the last N lines then leaves the file cursor at the end.
+func printTailAndSeekEnd(file *os.File, n int) error {
+	var lines []string
+	reader := bufio.NewReader(file)
+
+	for {
+		line, err := reader.ReadString('\n')
+		if len(line) > 0 {
+			if processLogGrep == "" || strings.Contains(line, processLogGrep) {
+				lines = append(lines, line)
+			}
+		}
+		if err != nil {
+			if errors.Is(err, io.EOF) {
+				break
+			}
+			return fmt.Errorf("failed to read process log: %w", err)
+		}
+	}
+
+	start := 0
+	if len(lines) > n {
+		start = len(lines) - n
+	}
+	for i := start; i < len(lines); i++ {
+		_, _ = io.WriteString(os.Stdout, lines[i])
+	}
+
+	return nil
+}

--- a/docker/worker-agent/cmd/root.go
+++ b/docker/worker-agent/cmd/root.go
@@ -44,4 +44,5 @@ func init() {
 	rootCmd.AddCommand(purgeJobsCmd)
 	rootCmd.AddCommand(rotateLogsCmd)
 	rootCmd.AddCommand(setContextCmd)
+	rootCmd.AddCommand(processLogCmd)
 }

--- a/docker/worker-agent/internal/config/paths.go
+++ b/docker/worker-agent/internal/config/paths.go
@@ -37,6 +37,12 @@ func UnifiedLogPath() string {
 	return filepath.Join(LogBaseDir, "lombok-worker-agent.log")
 }
 
+// ProcessLogPath returns the path to the secondary process log file.
+// JavaScript processes write Docker-engine-compatible JSON entries here.
+func ProcessLogPath() string {
+	return filepath.Join(LogBaseDir, "process.log")
+}
+
 // JobLogPath returns the structured log path for a specific job
 func JobLogPath(jobID string) string {
 	return filepath.Join(LogBaseDir, "jobs", fmt.Sprintf("%s.log", jobID))

--- a/docker/worker-agent/internal/logs/rotation.go
+++ b/docker/worker-agent/internal/logs/rotation.go
@@ -65,6 +65,13 @@ func performRotation(
 			fmt.Fprintf(os.Stderr, "log rotation error for %s: %v\n", target.name, err)
 		}
 	}
+
+	// Rotate externally-written log files (no file handle held by the agent).
+	for _, ext := range externalRotationPaths() {
+		if err := rotateExternalFile(ext.path, cfg); err != nil {
+			fmt.Fprintf(os.Stderr, "log rotation error for %s: %v\n", ext.name, err)
+		}
+	}
 }
 
 func rotateTarget(target rotationTarget, cfg config.LogRotationConfig) error {
@@ -117,6 +124,44 @@ func rotateTarget(target rotationTarget, cfg config.LogRotationConfig) error {
 	target.setFile(newFile)
 
 	return nil
+}
+
+// rotateExternalFile rotates a log file written by an external process.
+// Unlike rotateTarget, no file handle is held — we stat by path, rename the
+// chain, and the next write from the external process creates a fresh file.
+func rotateExternalFile(path string, cfg config.LogRotationConfig) error {
+	info, err := os.Stat(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil // file doesn't exist yet — nothing to rotate
+		}
+		return err
+	}
+
+	maxSizeBytes := int64(cfg.MaxSizeMB) * 1024 * 1024
+	if maxSizeBytes <= 0 {
+		maxSizeBytes = 1
+	}
+	if info.Size() < maxSizeBytes {
+		return nil
+	}
+
+	maxFiles := cfg.MaxFiles
+	if maxFiles < 1 {
+		maxFiles = 1
+	}
+
+	oldest := fmt.Sprintf("%s.%d", path, maxFiles)
+	_ = os.Remove(oldest)
+	for i := maxFiles - 1; i >= 1; i-- {
+		src := fmt.Sprintf("%s.%d", path, i)
+		dst := fmt.Sprintf("%s.%d", path, i+1)
+		if err := renameIfExists(src, dst); err != nil {
+			return err
+		}
+	}
+
+	return renameIfExists(path, fmt.Sprintf("%s.1", path))
 }
 
 func renameIfExists(src, dst string) error {

--- a/docker/worker-agent/internal/logs/writer.go
+++ b/docker/worker-agent/internal/logs/writer.go
@@ -47,6 +47,20 @@ func rotationTargets() []rotationTarget {
 	}
 }
 
+// externalRotationPaths returns log file paths written by external processes
+// (not the Go agent). These are rotated by path — no file handle is held.
+func externalRotationPaths() []struct {
+	name string
+	path string
+} {
+	return []struct {
+		name string
+		path string
+	}{
+		{name: "process log", path: config.ProcessLogPath()},
+	}
+}
+
 // InitAgentLog initializes the agent log file for writing.
 // It ensures the log directory exists and opens the log file in append mode.
 // This should be called once at startup.


### PR DESCRIPTION
## Summary
- Adds `process-log` subcommand to the Go worker-agent binary for managing container process logs
- Includes log rotation and a dedicated writer
- New files: `process_log.go`, `rotation.go`, `writer.go`, updated `paths.go` and `root.go`

## Linked issue
LOM-271