### PR TITLE
test(LOM-274): expand API e2e test coverage

### DIFF
--- a/packages/api/src/app/tests/app-access-settings.e2e-spec.ts
+++ b/packages/api/src/app/tests/app-access-settings.e2e-spec.ts
@@ -1,0 +1,153 @@
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'bun:test'
+import type { TestApiClient, TestModule } from 'src/test/test.types'
+import { buildTestModule, createTestUser } from 'src/test/test.util'
+import { DUMMY_APP_SLUG } from 'test/e2e.contants'
+
+const TEST_MODULE_KEY = 'app_access_set'
+
+describe('App Access Settings', () => {
+  let testModule: TestModule | undefined
+  let apiClient: TestApiClient
+  let appIdentifier: string
+
+  beforeAll(async () => {
+    testModule = await buildTestModule({ testModuleKey: TEST_MODULE_KEY })
+    apiClient = testModule.apiClient
+
+    await testModule.installLocalAppBundles([DUMMY_APP_SLUG])
+    appIdentifier = await testModule.getAppIdentifierBySlug(DUMMY_APP_SLUG)
+
+    const {
+      session: { accessToken: adminToken },
+    } = await createTestUser(testModule, {
+      username: 'as_admin',
+      password: '123',
+      admin: true,
+    })
+
+    await apiClient(adminToken).PUT(
+      '/api/v1/server/apps/{appIdentifier}/enabled',
+      {
+        params: { path: { appIdentifier } },
+        body: { enabled: true },
+      },
+    )
+  })
+
+  afterEach(async () => {
+    await testModule?.resetAppState()
+  })
+
+  afterAll(async () => {
+    await testModule?.shutdown()
+  })
+
+  it('should require admin for access settings', async () => {
+    const {
+      session: { accessToken },
+    } = await createTestUser(testModule!, {
+      username: 'as_nonadmin',
+      password: '123',
+    })
+
+    const res = await apiClient(accessToken).PUT(
+      '/api/v1/server/apps/{appIdentifier}/access-settings',
+      {
+        params: { path: { appIdentifier } },
+        body: {
+          userScopeEnabledDefault: true,
+          folderScopeEnabledDefault: true,
+        },
+      },
+    )
+    expect(res.response.status).toBe(401)
+  })
+
+  it('should require authentication', async () => {
+    const res = await apiClient().PUT(
+      '/api/v1/server/apps/{appIdentifier}/access-settings',
+      {
+        params: { path: { appIdentifier } },
+        body: {
+          userScopeEnabledDefault: true,
+          folderScopeEnabledDefault: true,
+        },
+      },
+    )
+    expect(res.response.status).toBe(401)
+  })
+
+  it('should update access settings as admin', async () => {
+    await testModule!.installLocalAppBundles([DUMMY_APP_SLUG])
+    appIdentifier = await testModule!.getAppIdentifierBySlug(DUMMY_APP_SLUG)
+
+    const {
+      session: { accessToken },
+    } = await createTestUser(testModule!, {
+      username: 'as_admin2',
+      password: '123',
+      admin: true,
+    })
+
+    await apiClient(accessToken).PUT(
+      '/api/v1/server/apps/{appIdentifier}/enabled',
+      {
+        params: { path: { appIdentifier } },
+        body: { enabled: true },
+      },
+    )
+
+    const res = await apiClient(accessToken).PUT(
+      '/api/v1/server/apps/{appIdentifier}/access-settings',
+      {
+        params: { path: { appIdentifier } },
+        body: {
+          userScopeEnabledDefault: true,
+          folderScopeEnabledDefault: false,
+        },
+      },
+    )
+    expect([200, 201]).toContain(res.response.status)
+    expect(res.data?.app).toBeDefined()
+  })
+
+  it('should persist access settings changes', async () => {
+    await testModule!.installLocalAppBundles([DUMMY_APP_SLUG])
+    appIdentifier = await testModule!.getAppIdentifierBySlug(DUMMY_APP_SLUG)
+
+    const {
+      session: { accessToken },
+    } = await createTestUser(testModule!, {
+      username: 'as_persist',
+      password: '123',
+      admin: true,
+    })
+
+    await apiClient(accessToken).PUT(
+      '/api/v1/server/apps/{appIdentifier}/enabled',
+      {
+        params: { path: { appIdentifier } },
+        body: { enabled: true },
+      },
+    )
+
+    await apiClient(accessToken).PUT(
+      '/api/v1/server/apps/{appIdentifier}/access-settings',
+      {
+        params: { path: { appIdentifier } },
+        body: {
+          userScopeEnabledDefault: false,
+          folderScopeEnabledDefault: true,
+        },
+      },
+    )
+
+    // Verify by getting the app
+    const getRes = await apiClient(accessToken).GET(
+      '/api/v1/server/apps/{appIdentifier}',
+      { params: { path: { appIdentifier } } },
+    )
+    expect(getRes.response.status).toBe(200)
+    expect(getRes.data?.app).toBeDefined()
+  })
+})

--- a/packages/api/src/app/tests/app-custom-settings.e2e-spec.ts
+++ b/packages/api/src/app/tests/app-custom-settings.e2e-spec.ts
@@ -15,7 +15,7 @@ describe('App Custom Settings', () => {
   beforeAll(async () => {
     testModule = await buildTestModule({
       testModuleKey: TEST_MODULE_KEY,
-      debug: true,
+      // debug: true,
     })
     apiClient = testModule.apiClient
 

--- a/packages/api/src/app/tests/app-uninstall.e2e-spec.ts
+++ b/packages/api/src/app/tests/app-uninstall.e2e-spec.ts
@@ -1,0 +1,104 @@
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'bun:test'
+import type { TestApiClient, TestModule } from 'src/test/test.types'
+import { buildTestModule, createTestUser } from 'src/test/test.util'
+import { DUMMY_APP_SLUG } from 'test/e2e.contants'
+
+const TEST_MODULE_KEY = 'app_uninstall'
+
+describe('App Uninstall', () => {
+  let testModule: TestModule | undefined
+  let apiClient: TestApiClient
+
+  beforeAll(async () => {
+    testModule = await buildTestModule({ testModuleKey: TEST_MODULE_KEY })
+    apiClient = testModule.apiClient
+  })
+
+  afterEach(async () => {
+    await testModule?.resetAppState()
+  })
+
+  afterAll(async () => {
+    await testModule?.shutdown()
+  })
+
+  it('should require authentication for uninstall', async () => {
+    const res = await apiClient().DELETE(
+      '/api/v1/server/apps/{appIdentifier}',
+      { params: { path: { appIdentifier: 'fake-app' } } },
+    )
+    expect(res.response.status).toBe(401)
+  })
+
+  it('should require admin for uninstall', async () => {
+    await testModule!.installLocalAppBundles([DUMMY_APP_SLUG])
+    const appIdentifier =
+      await testModule!.getAppIdentifierBySlug(DUMMY_APP_SLUG)
+
+    const {
+      session: { accessToken },
+    } = await createTestUser(testModule!, {
+      username: 'uninst_user',
+      password: '123',
+    })
+
+    const res = await apiClient(accessToken).DELETE(
+      '/api/v1/server/apps/{appIdentifier}',
+      { params: { path: { appIdentifier } } },
+    )
+    expect(res.response.status).toBe(401)
+  })
+
+  it('should return 404 for non-existent app', async () => {
+    const {
+      session: { accessToken },
+    } = await createTestUser(testModule!, {
+      username: 'uninst_404',
+      password: '123',
+      admin: true,
+    })
+
+    const res = await apiClient(accessToken).DELETE(
+      '/api/v1/server/apps/{appIdentifier}',
+      { params: { path: { appIdentifier: 'nonexistent-app-id' } } },
+    )
+    expect(res.response.status).toBe(404)
+  })
+
+  it('should uninstall an app as admin', async () => {
+    await testModule!.installLocalAppBundles([DUMMY_APP_SLUG])
+    const appIdentifier =
+      await testModule!.getAppIdentifierBySlug(DUMMY_APP_SLUG)
+
+    const {
+      session: { accessToken },
+    } = await createTestUser(testModule!, {
+      username: 'uninst_admin',
+      password: '123',
+      admin: true,
+    })
+
+    // Enable first
+    await apiClient(accessToken).PUT(
+      '/api/v1/server/apps/{appIdentifier}/enabled',
+      {
+        params: { path: { appIdentifier } },
+        body: { enabled: true },
+      },
+    )
+
+    // Uninstall
+    const res = await apiClient(accessToken).DELETE(
+      '/api/v1/server/apps/{appIdentifier}',
+      { params: { path: { appIdentifier } } },
+    )
+    expect([200, 204]).toContain(res.response.status)
+
+    // Verify app is gone
+    const getRes = await apiClient(accessToken).GET(
+      '/api/v1/server/apps/{appIdentifier}',
+      { params: { path: { appIdentifier } } },
+    )
+    expect(getRes.response.status).toBe(404)
+  })
+})

--- a/packages/api/src/app/tests/app-worker-env-vars.e2e-spec.ts
+++ b/packages/api/src/app/tests/app-worker-env-vars.e2e-spec.ts
@@ -1,0 +1,146 @@
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'bun:test'
+import type { TestApiClient, TestModule } from 'src/test/test.types'
+import { buildTestModule, createTestUser } from 'src/test/test.util'
+import { DUMMY_APP_SLUG } from 'test/e2e.contants'
+
+const TEST_MODULE_KEY = 'app_wkr_env'
+
+describe('App Worker Environment Variables', () => {
+  let testModule: TestModule | undefined
+  let apiClient: TestApiClient
+  let appIdentifier: string
+
+  beforeAll(async () => {
+    testModule = await buildTestModule({ testModuleKey: TEST_MODULE_KEY })
+    apiClient = testModule.apiClient
+  })
+
+  afterEach(async () => {
+    await testModule?.resetAppState()
+  })
+
+  afterAll(async () => {
+    await testModule?.shutdown()
+  })
+
+  async function setupApp(adminToken: string) {
+    await testModule!.installLocalAppBundles([DUMMY_APP_SLUG])
+    appIdentifier = await testModule!.getAppIdentifierBySlug(DUMMY_APP_SLUG)
+
+    await apiClient(adminToken).PUT(
+      '/api/v1/server/apps/{appIdentifier}/enabled',
+      {
+        params: { path: { appIdentifier } },
+        body: { enabled: true },
+      },
+    )
+
+    // Get the app to find a worker identifier
+    const appRes = await apiClient(adminToken).GET(
+      '/api/v1/server/apps/{appIdentifier}',
+      { params: { path: { appIdentifier } } },
+    )
+    return appRes.data!.app
+  }
+
+  it('should require authentication', async () => {
+    const res = await apiClient().PUT(
+      '/api/v1/server/apps/{appIdentifier}/workers/{workerIdentifier}/environment-variables',
+      {
+        params: {
+          path: {
+            appIdentifier: 'fake',
+            workerIdentifier: 'fake',
+          },
+        },
+        body: { environmentVariables: {} },
+      },
+    )
+    expect(res.response.status).toBe(401)
+  })
+
+  it('should require admin', async () => {
+    const {
+      session: { accessToken },
+    } = await createTestUser(testModule!, {
+      username: 'envnonadm',
+      password: '123',
+    })
+
+    const res = await apiClient(accessToken).PUT(
+      '/api/v1/server/apps/{appIdentifier}/workers/{workerIdentifier}/environment-variables',
+      {
+        params: {
+          path: {
+            appIdentifier: 'fake',
+            workerIdentifier: 'fake',
+          },
+        },
+        body: { environmentVariables: {} },
+      },
+    )
+    expect(res.response.status).toBe(401)
+  })
+
+  it('should set environment variables for a worker', async () => {
+    const {
+      session: { accessToken },
+    } = await createTestUser(testModule!, {
+      username: 'envadmin',
+      password: '123',
+      admin: true,
+    })
+
+    const app = await setupApp(accessToken)
+    const workerIds = Object.keys(app.runtimeWorkers?.definitions ?? {})
+
+    // Skip if dummy app has no workers
+    if (workerIds.length === 0) {
+      return
+    }
+
+    const workerIdentifier = workerIds[0]!
+
+    const res = await apiClient(accessToken).PUT(
+      '/api/v1/server/apps/{appIdentifier}/workers/{workerIdentifier}/environment-variables',
+      {
+        params: {
+          path: { appIdentifier, workerIdentifier },
+        },
+        body: {
+          environmentVariables: {
+            MY_VAR: 'hello',
+            ANOTHER_VAR: 'world',
+          },
+        },
+      },
+    )
+    expect([200, 201]).toContain(res.response.status)
+  })
+
+  it('should return error for non-existent worker', async () => {
+    const {
+      session: { accessToken },
+    } = await createTestUser(testModule!, {
+      username: 'envbadwkr',
+      password: '123',
+      admin: true,
+    })
+
+    await setupApp(accessToken)
+
+    const res = await apiClient(accessToken).PUT(
+      '/api/v1/server/apps/{appIdentifier}/workers/{workerIdentifier}/environment-variables',
+      {
+        params: {
+          path: {
+            appIdentifier,
+            workerIdentifier: 'nonexistent-worker',
+          },
+        },
+        body: { environmentVariables: { KEY: 'val' } },
+      },
+    )
+    expect([400, 404]).toContain(res.response.status)
+  })
+})

--- a/packages/api/src/auth/auth-edge-cases.e2e-spec.ts
+++ b/packages/api/src/auth/auth-edge-cases.e2e-spec.ts
@@ -1,0 +1,105 @@
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'bun:test'
+import type { TestApiClient, TestModule } from 'src/test/test.types'
+import { buildTestModule, createTestUser } from 'src/test/test.util'
+
+const TEST_MODULE_KEY = 'auth_edge'
+
+describe('Auth Edge Cases', () => {
+  let testModule: TestModule | undefined
+  let apiClient: TestApiClient
+
+  beforeAll(async () => {
+    testModule = await buildTestModule({ testModuleKey: TEST_MODULE_KEY })
+    apiClient = testModule.apiClient
+  })
+
+  afterEach(async () => {
+    await testModule?.resetAppState()
+  })
+
+  afterAll(async () => {
+    await testModule?.shutdown()
+  })
+
+  it('should reject login with wrong password', async () => {
+    await createTestUser(testModule!, {
+      username: 'wrongpw',
+      password: 'correct123',
+    })
+
+    const res = await apiClient().POST('/api/v1/auth/login', {
+      body: { login: 'wrongpw', password: 'incorrect' },
+    })
+    expect([400, 401]).toContain(res.response.status)
+  })
+
+  it('should reject login for non-existent user', async () => {
+    const res = await apiClient().POST('/api/v1/auth/login', {
+      body: { login: 'ghostuser', password: '123' },
+    })
+    expect([400, 401]).toContain(res.response.status)
+  })
+
+  it('should reject refresh with invalid token', async () => {
+    const res = await apiClient().POST('/api/v1/auth/{refreshToken}', {
+      params: { path: { refreshToken: 'invalid-token-string' } },
+    })
+    expect([400, 401]).toContain(res.response.status)
+  })
+
+  it('should reject signup with empty username', async () => {
+    const res = await apiClient().POST('/api/v1/auth/signup', {
+      body: { username: '', password: '123' },
+    })
+    expect([400, 422]).toContain(res.response.status)
+  })
+
+  it('should return valid tokens on successful login', async () => {
+    await createTestUser(testModule!, {
+      username: 'tokencheck',
+      password: 'pass123',
+    })
+
+    const res = await apiClient().POST('/api/v1/auth/login', {
+      body: { login: 'tokencheck', password: 'pass123' },
+    })
+    expect([200, 201]).toContain(res.response.status)
+    expect(res.data?.session.accessToken).toBeTruthy()
+    expect(res.data?.session.refreshToken).toBeTruthy()
+
+    // Verify the token works for authenticated requests
+    const viewerRes = await apiClient(res.data!.session.accessToken).GET(
+      '/api/v1/viewer',
+    )
+    expect(viewerRes.response.status).toBe(200)
+    expect(viewerRes.data?.user.username).toBe('tokencheck')
+  })
+
+  it('should successfully refresh a session', async () => {
+    const {
+      session: { refreshToken },
+    } = await createTestUser(testModule!, {
+      username: 'refreshtest',
+      password: '123',
+    })
+
+    const res = await apiClient().POST('/api/v1/auth/{refreshToken}', {
+      params: { path: { refreshToken } },
+    })
+    expect([200, 201]).toContain(res.response.status)
+    expect(res.data?.session.accessToken).toBeTruthy()
+    expect(res.data?.session.refreshToken).toBeTruthy()
+  })
+
+  it('should not allow duplicate username signup', async () => {
+    await createTestUser(testModule!, {
+      username: 'dupeuser',
+      password: '123',
+    })
+
+    const res = await apiClient().POST('/api/v1/auth/signup', {
+      body: { username: 'dupeuser', password: '456' },
+    })
+    expect([400, 409]).toContain(res.response.status)
+  })
+})

--- a/packages/api/src/auth/auth-sessions.e2e-spec.ts
+++ b/packages/api/src/auth/auth-sessions.e2e-spec.ts
@@ -1,0 +1,151 @@
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'bun:test'
+import type { TestApiClient, TestModule } from 'src/test/test.types'
+import { buildTestModule, createTestUser } from 'src/test/test.util'
+
+const TEST_MODULE_KEY = 'auth_sessions'
+
+describe('Auth Sessions', () => {
+  let testModule: TestModule | undefined
+  let apiClient: TestApiClient
+
+  beforeAll(async () => {
+    testModule = await buildTestModule({ testModuleKey: TEST_MODULE_KEY })
+    apiClient = testModule.apiClient
+  })
+
+  afterEach(async () => {
+    await testModule?.resetAppState()
+  })
+
+  afterAll(async () => {
+    await testModule?.shutdown()
+  })
+
+  it('should fail login with wrong password', async () => {
+    await createTestUser(testModule!, {
+      username: 'loginuser',
+      password: 'correctpass',
+    })
+
+    const response = await apiClient().POST('/api/v1/auth/login', {
+      body: { login: 'loginuser', password: 'wrongpass' },
+    })
+    expect(response.response.status).toEqual(401)
+  })
+
+  it('should fail login with non-existent user', async () => {
+    const response = await apiClient().POST('/api/v1/auth/login', {
+      body: { login: 'ghostuser', password: '123' },
+    })
+    expect(response.response.status).toEqual(401)
+  })
+
+  it('should login with email when provided', async () => {
+    await createTestUser(testModule!, {
+      username: 'emailuser',
+      password: '123',
+      email: 'emailuser@example.com',
+    })
+
+    const response = await apiClient().POST('/api/v1/auth/login', {
+      body: { login: 'emailuser@example.com', password: '123' },
+    })
+    expect(response.response.status).toEqual(201)
+    expect(response.data?.session.accessToken).toBeTruthy()
+  })
+
+  it('should get new tokens after refresh and old access token should still work until expiry', async () => {
+    const {
+      session: { accessToken: originalToken, refreshToken },
+    } = await createTestUser(testModule!, {
+      username: 'refreshuser',
+      password: '123',
+    })
+
+    // Verify original token works
+    const viewerBefore = await apiClient(originalToken).GET('/api/v1/viewer')
+    expect(viewerBefore.response.status).toEqual(200)
+
+    // Refresh
+    const refreshResponse = await apiClient().POST(
+      '/api/v1/auth/{refreshToken}',
+      { params: { path: { refreshToken } } },
+    )
+    expect(refreshResponse.response.status).toEqual(201)
+    expect(refreshResponse.data?.session.accessToken).toBeTruthy()
+    expect(refreshResponse.data?.session.refreshToken).toBeTruthy()
+
+    // New token should work
+    const newToken = refreshResponse.data!.session.accessToken
+    const viewerAfter = await apiClient(newToken).GET('/api/v1/viewer')
+    expect(viewerAfter.response.status).toEqual(200)
+    expect(viewerAfter.data?.user.username).toEqual('refreshuser')
+  })
+
+  it('should not reuse a refresh token after it has been consumed', async () => {
+    const {
+      session: { refreshToken },
+    } = await createTestUser(testModule!, {
+      username: 'reuse',
+      password: '123',
+    })
+
+    // First refresh succeeds
+    const first = await apiClient().POST('/api/v1/auth/{refreshToken}', {
+      params: { path: { refreshToken } },
+    })
+    expect(first.response.status).toEqual(201)
+
+    // Second refresh with same token should fail
+    const second = await apiClient().POST('/api/v1/auth/{refreshToken}', {
+      params: { path: { refreshToken } },
+    })
+    expect(second.response.status).toEqual(401)
+  })
+
+  it('should support multiple concurrent sessions for the same user', async () => {
+    // First login
+    const {
+      session: { accessToken: token1 },
+    } = await createTestUser(testModule!, {
+      username: 'multilogin',
+      password: '123',
+    })
+
+    // Second login (creates a new session)
+    const login2 = await apiClient().POST('/api/v1/auth/login', {
+      body: { login: 'multilogin', password: '123' },
+    })
+    expect(login2.response.status).toEqual(201)
+    const token2 = login2.data!.session.accessToken
+
+    // Both tokens should work
+    const viewer1 = await apiClient(token1).GET('/api/v1/viewer')
+    expect(viewer1.response.status).toEqual(200)
+
+    const viewer2 = await apiClient(token2).GET('/api/v1/viewer')
+    expect(viewer2.response.status).toEqual(200)
+
+    // Both see the same user
+    expect(viewer1.data?.user.username).toEqual('multilogin')
+    expect(viewer2.data?.user.username).toEqual('multilogin')
+  })
+
+  it('should reject expired or invalid access tokens', async () => {
+    const response = await apiClient('invalid.jwt.token').GET('/api/v1/viewer')
+    expect(response.response.status).toEqual(401)
+  })
+
+  it('should login case-insensitively by username', async () => {
+    await createTestUser(testModule!, {
+      username: 'CaseyUser',
+      password: 'mypass',
+    })
+
+    const response = await apiClient().POST('/api/v1/auth/login', {
+      body: { login: 'caseyuser', password: 'mypass' },
+    })
+    expect(response.response.status).toEqual(201)
+    expect(response.data?.session.accessToken).toBeTruthy()
+  })
+})

--- a/packages/api/src/comments/comment-threads.e2e-spec.ts
+++ b/packages/api/src/comments/comment-threads.e2e-spec.ts
@@ -1,0 +1,203 @@
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'bun:test'
+import { CoreTaskName } from 'src/task/task.constants'
+import type { TestApiClient, TestModule } from 'src/test/test.types'
+import {
+  buildTestModule,
+  createTestFolder,
+  createTestUser,
+  reindexTestFolder,
+} from 'src/test/test.util'
+
+const TEST_MODULE_KEY = 'comment_threads'
+
+describe('Comment Threads & Reactions', () => {
+  let testModule: TestModule | undefined
+  let apiClient: TestApiClient
+
+  beforeAll(async () => {
+    testModule = await buildTestModule({ testModuleKey: TEST_MODULE_KEY })
+    apiClient = testModule.apiClient
+  })
+
+  afterEach(async () => {
+    await testModule?.resetAppState()
+    testModule?.cleanupMinioTestBuckets()
+  })
+
+  afterAll(async () => {
+    await testModule?.shutdown()
+  })
+
+  async function setupFolderWithObject(accessToken: string) {
+    await testModule!.setServerStorageLocation()
+    const { folder } = await createTestFolder({
+      testModule: testModule!,
+      accessToken,
+      apiClient,
+      folderName: 'CommentTestFolder',
+      mockFiles: [{ objectKey: 'test-file.txt', content: 'hello' }],
+    })
+    await reindexTestFolder({ accessToken, apiClient, folderId: folder.id })
+    await testModule!.waitForTasks('completed', {
+      taskIdentifiers: [CoreTaskName.ReindexFolder],
+    })
+    const objectsRes = await apiClient(accessToken).GET(
+      '/api/v1/folders/{folderId}/objects',
+      { params: { path: { folderId: folder.id } } },
+    )
+    const folderObjectId = objectsRes.data!.result[0]!.id
+    return { folder, folderObjectId }
+  }
+
+  it('should get a comment thread', async () => {
+    const {
+      session: { accessToken },
+    } = await createTestUser(testModule!, {
+      username: 'threaduser',
+      password: '123',
+    })
+
+    const { folder, folderObjectId } = await setupFolderWithObject(accessToken)
+
+    // Create root comment with anchor (required for thread replies)
+    const rootRes = await apiClient(accessToken).POST(
+      '/api/v1/folders/{folderId}/objects/{folderObjectId}/comments',
+      {
+        params: { path: { folderId: folder.id, folderObjectId } },
+        body: {
+          content: 'Root comment',
+          anchor: { type: 'image_point', x: 0.5, y: 0.5 },
+        },
+      },
+    )
+    expect([200, 201]).toContain(rootRes.response.status)
+    const rootId = rootRes.data!.comment.id
+
+    // Create reply in thread
+    const replyRes = await apiClient(accessToken).POST(
+      '/api/v1/folders/{folderId}/objects/{folderObjectId}/comments',
+      {
+        params: { path: { folderId: folder.id, folderObjectId } },
+        body: { content: 'Reply comment', rootCommentId: rootId },
+      },
+    )
+    expect([200, 201]).toContain(replyRes.response.status)
+
+    // Get thread
+    const threadRes = await apiClient(accessToken).GET(
+      '/api/v1/folders/{folderId}/objects/{folderObjectId}/comments/{rootId}/thread',
+      {
+        params: {
+          path: { folderId: folder.id, folderObjectId, rootId },
+        },
+      },
+    )
+    expect(threadRes.response.status).toBe(200)
+    expect(threadRes.data!.comments.length).toBeGreaterThanOrEqual(2)
+  })
+
+  it('should delete own comment', async () => {
+    const {
+      session: { accessToken },
+    } = await createTestUser(testModule!, {
+      username: 'deluser',
+      password: '123',
+    })
+
+    const { folder, folderObjectId } = await setupFolderWithObject(accessToken)
+
+    const createRes = await apiClient(accessToken).POST(
+      '/api/v1/folders/{folderId}/objects/{folderObjectId}/comments',
+      {
+        params: { path: { folderId: folder.id, folderObjectId } },
+        body: { content: 'To be deleted' },
+      },
+    )
+    expect([200, 201]).toContain(createRes.response.status)
+    const commentId = createRes.data!.comment.id
+
+    const deleteRes = await apiClient(accessToken).DELETE(
+      '/api/v1/folders/{folderId}/objects/{folderObjectId}/comments/{commentId}',
+      {
+        params: {
+          path: { folderId: folder.id, folderObjectId, commentId },
+        },
+      },
+    )
+    expect(deleteRes.response.status).toBe(200)
+    expect(deleteRes.data?.success).toBe(true)
+  })
+
+  it('should add and remove a reaction', async () => {
+    const {
+      session: { accessToken },
+    } = await createTestUser(testModule!, {
+      username: 'reactuser',
+      password: '123',
+    })
+
+    const { folder, folderObjectId } = await setupFolderWithObject(accessToken)
+
+    const createRes = await apiClient(accessToken).POST(
+      '/api/v1/folders/{folderId}/objects/{folderObjectId}/comments',
+      {
+        params: { path: { folderId: folder.id, folderObjectId } },
+        body: { content: 'React to this' },
+      },
+    )
+    const commentId = createRes.data!.comment.id
+
+    // Add reaction
+    const addRes = await apiClient(accessToken).POST(
+      '/api/v1/folders/{folderId}/objects/{folderObjectId}/comments/{commentId}/reactions',
+      {
+        params: {
+          path: { folderId: folder.id, folderObjectId, commentId },
+        },
+        body: { emoji: '👍' },
+      },
+    )
+    expect([200, 201]).toContain(addRes.response.status)
+    expect(addRes.data?.success).toBe(true)
+
+    // Verify reaction appears in comment list
+    const listRes = await apiClient(accessToken).GET(
+      '/api/v1/folders/{folderId}/objects/{folderObjectId}/comments',
+      { params: { path: { folderId: folder.id, folderObjectId } } },
+    )
+    const comment = listRes.data!.comments.find((c) => c.id === commentId)
+    expect(comment?.reactions?.length).toBeGreaterThanOrEqual(1)
+
+    // Remove reaction
+    const removeRes = await apiClient(accessToken).DELETE(
+      '/api/v1/folders/{folderId}/objects/{folderObjectId}/comments/{commentId}/reactions/{emoji}',
+      {
+        params: {
+          path: {
+            folderId: folder.id,
+            folderObjectId,
+            commentId,
+            emoji: '👍',
+          },
+        },
+      },
+    )
+    expect(removeRes.response.status).toBe(200)
+  })
+
+  it('should require authentication for thread endpoint', async () => {
+    const res = await apiClient().GET(
+      '/api/v1/folders/{folderId}/objects/{folderObjectId}/comments/{rootId}/thread',
+      {
+        params: {
+          path: {
+            folderId: '00000000-0000-0000-0000-000000000000',
+            folderObjectId: '00000000-0000-0000-0000-000000000000',
+            rootId: '00000000-0000-0000-0000-000000000000',
+          },
+        },
+      },
+    )
+    expect(res.response.status).toBe(401)
+  })
+})

--- a/packages/api/src/event/folder-events.e2e-spec.ts
+++ b/packages/api/src/event/folder-events.e2e-spec.ts
@@ -1,0 +1,160 @@
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'bun:test'
+import { v4 as uuidV4 } from 'uuid'
+import type { TestApiClient, TestModule } from 'src/test/test.types'
+import {
+  buildTestModule,
+  createTestFolder,
+  createTestUser,
+} from 'src/test/test.util'
+import { eventsTable } from './entities/event.entity'
+
+const TEST_MODULE_KEY = 'folder_events'
+
+async function seedFolderEvent(
+  testModule: TestModule,
+  folderId: string,
+  overrides: Partial<typeof eventsTable.$inferInsert> = {},
+) {
+  const id = uuidV4()
+  const now = new Date()
+  await testModule.services.ormService.db.insert(eventsTable).values({
+    id,
+    eventIdentifier: 'object_added',
+    emitterIdentifier: 'core',
+    targetLocationFolderId: folderId,
+    createdAt: now,
+    ...overrides,
+  })
+  return { id }
+}
+
+describe('Folder Events', () => {
+  let testModule: TestModule | undefined
+  let apiClient: TestApiClient
+
+  beforeAll(async () => {
+    testModule = await buildTestModule({ testModuleKey: TEST_MODULE_KEY })
+    apiClient = testModule.apiClient
+  })
+
+  afterEach(async () => {
+    await testModule?.resetAppState()
+    testModule?.cleanupMinioTestBuckets()
+  })
+
+  afterAll(async () => {
+    await testModule?.shutdown()
+  })
+
+  it('should require authentication', async () => {
+    const response = await apiClient().GET('/api/v1/folders/{folderId}/events', {
+      params: { path: { folderId: uuidV4() } },
+    })
+    expect(response.response.status).toEqual(401)
+  })
+
+  it('should list events for a folder the user owns', async () => {
+    const {
+      session: { accessToken },
+    } = await createTestUser(testModule!, { username: 'evtuser', password: '123' })
+
+    await testModule!.setServerStorageLocation()
+    await testModule!.initMinioTestBucket()
+
+    const { folder } = await createTestFolder({
+      testModule: testModule!,
+      accessToken,
+      apiClient,
+      folderName: 'EventFolder',
+    })
+
+    await seedFolderEvent(testModule!, folder.id)
+    await seedFolderEvent(testModule!, folder.id)
+
+    const response = await apiClient(accessToken).GET(
+      '/api/v1/folders/{folderId}/events',
+      { params: { path: { folderId: folder.id } } },
+    )
+    expect(response.response.status).toEqual(200)
+    expect(response.data?.result).toBeArray()
+    expect(response.data?.result.length).toEqual(2)
+    expect(response.data?.meta.totalCount).toEqual(2)
+  })
+
+  it('should get a single folder event by ID', async () => {
+    const {
+      session: { accessToken },
+    } = await createTestUser(testModule!, { username: 'evtget', password: '123' })
+
+    await testModule!.setServerStorageLocation()
+    await testModule!.initMinioTestBucket()
+
+    const { folder } = await createTestFolder({
+      testModule: testModule!,
+      accessToken,
+      apiClient,
+      folderName: 'EventGetFolder',
+    })
+
+    const { id: eventId } = await seedFolderEvent(testModule!, folder.id, {
+      eventIdentifier: 'object_updated',
+    })
+
+    const response = await apiClient(accessToken).GET(
+      '/api/v1/folders/{folderId}/events/{eventId}',
+      { params: { path: { folderId: folder.id, eventId } } },
+    )
+    expect(response.response.status).toEqual(200)
+    expect(response.data?.event.eventIdentifier).toEqual('object_updated')
+  })
+
+  it('should not list events for a folder the user does not own', async () => {
+    const {
+      session: { accessToken: ownerToken },
+    } = await createTestUser(testModule!, { username: 'evtowner', password: '123' })
+
+    const {
+      session: { accessToken: otherToken },
+    } = await createTestUser(testModule!, { username: 'evtother', password: '123' })
+
+    await testModule!.setServerStorageLocation()
+    await testModule!.initMinioTestBucket()
+
+    const { folder } = await createTestFolder({
+      testModule: testModule!,
+      accessToken: ownerToken,
+      apiClient,
+      folderName: 'PrivateEventFolder',
+    })
+
+    await seedFolderEvent(testModule!, folder.id)
+
+    const response = await apiClient(otherToken).GET(
+      '/api/v1/folders/{folderId}/events',
+      { params: { path: { folderId: folder.id } } },
+    )
+    expect([403, 404]).toContain(response.response.status)
+  })
+
+  it('should return 404 for non-existent event in folder', async () => {
+    const {
+      session: { accessToken },
+    } = await createTestUser(testModule!, { username: 'evtmissing', password: '123' })
+
+    await testModule!.setServerStorageLocation()
+    await testModule!.initMinioTestBucket()
+
+    const { folder } = await createTestFolder({
+      testModule: testModule!,
+      accessToken,
+      apiClient,
+      folderName: 'MissingEventFolder',
+    })
+
+    const response = await apiClient(accessToken).GET(
+      '/api/v1/folders/{folderId}/events/{eventId}',
+      { params: { path: { folderId: folder.id, eventId: uuidV4() } } },
+    )
+    expect(response.response.status).toEqual(404)
+  })
+})

--- a/packages/api/src/event/server-events.e2e-spec.ts
+++ b/packages/api/src/event/server-events.e2e-spec.ts
@@ -1,0 +1,144 @@
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'bun:test'
+import { v4 as uuidV4 } from 'uuid'
+import type { TestApiClient, TestModule } from 'src/test/test.types'
+import { buildTestModule, createTestUser } from 'src/test/test.util'
+import { eventsTable } from './entities/event.entity'
+
+const TEST_MODULE_KEY = 'server_events'
+
+async function seedEvent(
+  testModule: TestModule,
+  overrides: Partial<typeof eventsTable.$inferInsert> = {},
+) {
+  const id = uuidV4()
+  await testModule.services.ormService.db.insert(eventsTable).values({
+    id,
+    eventIdentifier: 'object_added',
+    emitterIdentifier: 'core',
+    createdAt: new Date(),
+    ...overrides,
+  })
+  return { id }
+}
+
+describe('Server Events', () => {
+  let testModule: TestModule | undefined
+  let apiClient: TestApiClient
+
+  beforeAll(async () => {
+    testModule = await buildTestModule({ testModuleKey: TEST_MODULE_KEY })
+    apiClient = testModule.apiClient
+  })
+
+  afterEach(async () => {
+    await testModule?.resetAppState()
+  })
+
+  afterAll(async () => {
+    await testModule?.shutdown()
+  })
+
+  it('should require authentication', async () => {
+    const response = await apiClient().GET('/api/v1/server/events')
+    expect(response.response.status).toEqual(401)
+  })
+
+  it('should require admin role', async () => {
+    const {
+      session: { accessToken },
+    } = await createTestUser(testModule!, { username: 'nonadmin', password: '123' })
+
+    const response = await apiClient(accessToken).GET('/api/v1/server/events')
+    expect(response.response.status).toEqual(401)
+  })
+
+  it('should list events for admin', async () => {
+    const {
+      session: { accessToken },
+    } = await createTestUser(testModule!, {
+      username: 'evtadmin',
+      password: '123',
+      admin: true,
+    })
+
+    await seedEvent(testModule!, { eventIdentifier: 'event_a' })
+    await seedEvent(testModule!, { eventIdentifier: 'event_b' })
+    await seedEvent(testModule!, { eventIdentifier: 'event_c' })
+
+    const response = await apiClient(accessToken).GET('/api/v1/server/events')
+    expect(response.response.status).toEqual(200)
+    expect(response.data?.result).toBeArray()
+    // System events from user creation may also appear
+    expect(response.data!.result.length).toBeGreaterThanOrEqual(3)
+    expect(response.data!.meta.totalCount).toBeGreaterThanOrEqual(3)
+  })
+
+  it('should get a single event by ID', async () => {
+    const {
+      session: { accessToken },
+    } = await createTestUser(testModule!, {
+      username: 'evtgetadmin',
+      password: '123',
+      admin: true,
+    })
+
+    const { id: eventId } = await seedEvent(testModule!, {
+      eventIdentifier: 'specific_event',
+    })
+
+    const response = await apiClient(accessToken).GET(
+      '/api/v1/server/events/{eventId}',
+      { params: { path: { eventId } } },
+    )
+    expect(response.response.status).toEqual(200)
+    expect(response.data?.event.eventIdentifier).toEqual('specific_event')
+  })
+
+  it('should return 404 for non-existent event', async () => {
+    const {
+      session: { accessToken },
+    } = await createTestUser(testModule!, {
+      username: 'evtmissadmin',
+      password: '123',
+      admin: true,
+    })
+
+    const response = await apiClient(accessToken).GET(
+      '/api/v1/server/events/{eventId}',
+      { params: { path: { eventId: uuidV4() } } },
+    )
+    expect(response.response.status).toEqual(404)
+  })
+
+  it('should support pagination', async () => {
+    const {
+      session: { accessToken },
+    } = await createTestUser(testModule!, {
+      username: 'evtpageadmin',
+      password: '123',
+      admin: true,
+    })
+
+    for (let i = 0; i < 5; i++) {
+      await seedEvent(testModule!, {
+        createdAt: new Date(Date.now() + i * 1000),
+      })
+    }
+
+    const page1 = await apiClient(accessToken).GET('/api/v1/server/events', {
+      params: { query: { limit: 2, offset: 0 } },
+    })
+    expect(page1.data?.result.length).toEqual(2)
+    // Total may include system events from user creation
+    expect(page1.data!.meta.totalCount).toBeGreaterThanOrEqual(5)
+
+    const page2 = await apiClient(accessToken).GET('/api/v1/server/events', {
+      params: { query: { limit: 2, offset: 2 } },
+    })
+    expect(page2.data?.result.length).toEqual(2)
+
+    const ids1 = page1.data?.result.map((e) => e.id) ?? []
+    const ids2 = page2.data?.result.map((e) => e.id) ?? []
+    expect(ids1.filter((id) => ids2.includes(id)).length).toEqual(0)
+  })
+})

--- a/packages/api/src/folders/folder-app-settings.e2e-spec.ts
+++ b/packages/api/src/folders/folder-app-settings.e2e-spec.ts
@@ -1,0 +1,114 @@
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'bun:test'
+import { v4 as uuidV4 } from 'uuid'
+import type { TestApiClient, TestModule } from 'src/test/test.types'
+import {
+  buildTestModule,
+  createTestFolder,
+  createTestUser,
+} from 'src/test/test.util'
+
+const TEST_MODULE_KEY = 'folder_appsett'
+
+describe('Folder App Settings', () => {
+  let testModule: TestModule | undefined
+  let apiClient: TestApiClient
+
+  beforeAll(async () => {
+    testModule = await buildTestModule({ testModuleKey: TEST_MODULE_KEY })
+    apiClient = testModule.apiClient
+  })
+
+  afterEach(async () => {
+    await testModule?.resetAppState()
+    testModule?.cleanupMinioTestBuckets()
+  })
+
+  afterAll(async () => {
+    await testModule?.shutdown()
+  })
+
+  it('should require authentication for app-settings', async () => {
+    const res = await apiClient().GET(
+      '/api/v1/folders/{folderId}/app-settings',
+      {
+        params: {
+          path: { folderId: '00000000-0000-0000-0000-000000000000' },
+        },
+      },
+    )
+    expect(res.response.status).toBe(401)
+  })
+
+  it('should get app settings for owned folder', async () => {
+    const {
+      session: { accessToken },
+    } = await createTestUser(testModule!, {
+      username: 'appsettuser',
+      password: '123',
+    })
+
+    await testModule!.setServerStorageLocation()
+
+    const { folder } = await createTestFolder({
+      testModule: testModule!,
+      accessToken,
+      apiClient,
+      folderName: 'AppSettingsFolder',
+      mockFiles: [],
+    })
+
+    const res = await apiClient(accessToken).GET(
+      '/api/v1/folders/{folderId}/app-settings',
+      { params: { path: { folderId: folder.id } } },
+    )
+    expect(res.response.status).toBe(200)
+    expect(res.data?.settings).toBeDefined()
+  })
+
+  it('should not allow app settings for non-owned folder', async () => {
+    const {
+      session: { accessToken: ownerToken },
+    } = await createTestUser(testModule!, {
+      username: 'appsettowner',
+      password: '123',
+    })
+
+    const {
+      session: { accessToken: otherToken },
+    } = await createTestUser(testModule!, {
+      username: 'appsettother',
+      password: '123',
+    })
+
+    await testModule!.setServerStorageLocation()
+
+    const { folder } = await createTestFolder({
+      testModule: testModule!,
+      accessToken: ownerToken,
+      apiClient,
+      folderName: 'AppSettProtected',
+      mockFiles: [],
+    })
+
+    const res = await apiClient(otherToken).GET(
+      '/api/v1/folders/{folderId}/app-settings',
+      { params: { path: { folderId: folder.id } } },
+    )
+    expect([401, 403, 404]).toContain(res.response.status)
+  })
+
+  it('should return error for non-existent folder', async () => {
+    const {
+      session: { accessToken },
+    } = await createTestUser(testModule!, {
+      username: 'appsettmissing',
+      password: '123',
+    })
+
+    const res = await apiClient(accessToken).GET(
+      '/api/v1/folders/{folderId}/app-settings',
+      { params: { path: { folderId: uuidV4() } } },
+    )
+    expect([403, 404]).toContain(res.response.status)
+  })
+})

--- a/packages/api/src/folders/folder-check-access.e2e-spec.ts
+++ b/packages/api/src/folders/folder-check-access.e2e-spec.ts
@@ -1,0 +1,113 @@
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'bun:test'
+import { v4 as uuidV4 } from 'uuid'
+import type { TestApiClient, TestModule } from 'src/test/test.types'
+import {
+  buildTestModule,
+  createTestFolder,
+  createTestUser,
+} from 'src/test/test.util'
+
+const TEST_MODULE_KEY = 'folder_chk_acc'
+
+describe('Folder Check Access', () => {
+  let testModule: TestModule | undefined
+  let apiClient: TestApiClient
+
+  beforeAll(async () => {
+    testModule = await buildTestModule({ testModuleKey: TEST_MODULE_KEY })
+    apiClient = testModule.apiClient
+  })
+
+  afterEach(async () => {
+    await testModule?.resetAppState()
+    testModule?.cleanupMinioTestBuckets()
+  })
+
+  afterAll(async () => {
+    await testModule?.shutdown()
+  })
+
+  it('should require authentication', async () => {
+    const res = await apiClient().POST(
+      '/api/v1/folders/{folderId}/check-access',
+      {
+        params: {
+          path: { folderId: '00000000-0000-0000-0000-000000000000' },
+        },
+      },
+    )
+    expect(res.response.status).toBe(401)
+  })
+
+  it('should check access on owned folder', async () => {
+    const {
+      session: { accessToken },
+    } = await createTestUser(testModule!, {
+      username: 'chkacc',
+      password: '123',
+    })
+
+    await testModule!.setServerStorageLocation()
+
+    const { folder } = await createTestFolder({
+      testModule: testModule!,
+      accessToken,
+      apiClient,
+      folderName: 'CheckAccessFolder',
+      mockFiles: [],
+    })
+
+    const res = await apiClient(accessToken).POST(
+      '/api/v1/folders/{folderId}/check-access',
+      { params: { path: { folderId: folder.id } } },
+    )
+    expect([200, 201]).toContain(res.response.status)
+  })
+
+  it('should deny access on non-owned folder', async () => {
+    const {
+      session: { accessToken: ownerToken },
+    } = await createTestUser(testModule!, {
+      username: 'chkowner',
+      password: '123',
+    })
+
+    const {
+      session: { accessToken: otherToken },
+    } = await createTestUser(testModule!, {
+      username: 'chkother',
+      password: '123',
+    })
+
+    await testModule!.setServerStorageLocation()
+
+    const { folder } = await createTestFolder({
+      testModule: testModule!,
+      accessToken: ownerToken,
+      apiClient,
+      folderName: 'ProtectedCheck',
+      mockFiles: [],
+    })
+
+    const res = await apiClient(otherToken).POST(
+      '/api/v1/folders/{folderId}/check-access',
+      { params: { path: { folderId: folder.id } } },
+    )
+    expect([401, 403, 404]).toContain(res.response.status)
+  })
+
+  it('should return error for non-existent folder', async () => {
+    const {
+      session: { accessToken },
+    } = await createTestUser(testModule!, {
+      username: 'chk404',
+      password: '123',
+    })
+
+    const res = await apiClient(accessToken).POST(
+      '/api/v1/folders/{folderId}/check-access',
+      { params: { path: { folderId: uuidV4() } } },
+    )
+    expect([404, 400, 401, 403]).toContain(res.response.status)
+  })
+})

--- a/packages/api/src/folders/folder-delete.e2e-spec.ts
+++ b/packages/api/src/folders/folder-delete.e2e-spec.ts
@@ -1,0 +1,117 @@
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'bun:test'
+import { v4 as uuidV4 } from 'uuid'
+import type { TestApiClient, TestModule } from 'src/test/test.types'
+import {
+  buildTestModule,
+  createTestFolder,
+  createTestUser,
+} from 'src/test/test.util'
+
+const TEST_MODULE_KEY = 'folder_delete'
+
+describe('Folder Delete', () => {
+  let testModule: TestModule | undefined
+  let apiClient: TestApiClient
+
+  beforeAll(async () => {
+    testModule = await buildTestModule({ testModuleKey: TEST_MODULE_KEY })
+    apiClient = testModule.apiClient
+  })
+
+  afterEach(async () => {
+    await testModule?.resetAppState()
+    testModule?.cleanupMinioTestBuckets()
+  })
+
+  afterAll(async () => {
+    await testModule?.shutdown()
+  })
+
+  it('should require authentication', async () => {
+    const res = await apiClient().DELETE('/api/v1/folders/{folderId}', {
+      params: {
+        path: { folderId: '00000000-0000-0000-0000-000000000000' },
+      },
+    })
+    expect(res.response.status).toBe(401)
+  })
+
+  it('should delete an owned folder', async () => {
+    const {
+      session: { accessToken },
+    } = await createTestUser(testModule!, {
+      username: 'delowner',
+      password: '123',
+    })
+
+    await testModule!.setServerStorageLocation()
+
+    const { folder } = await createTestFolder({
+      testModule: testModule!,
+      accessToken,
+      apiClient,
+      folderName: 'ToDelete',
+      mockFiles: [],
+    })
+
+    const res = await apiClient(accessToken).DELETE(
+      '/api/v1/folders/{folderId}',
+      { params: { path: { folderId: folder.id } } },
+    )
+    expect([200, 204]).toContain(res.response.status)
+
+    // Verify it's gone
+    const getRes = await apiClient(accessToken).GET(
+      '/api/v1/folders/{folderId}',
+      { params: { path: { folderId: folder.id } } },
+    )
+    expect([404, 401, 403]).toContain(getRes.response.status)
+  })
+
+  it('should not allow non-owner to delete', async () => {
+    const {
+      session: { accessToken: ownerToken },
+    } = await createTestUser(testModule!, {
+      username: 'delown2',
+      password: '123',
+    })
+
+    const {
+      session: { accessToken: otherToken },
+    } = await createTestUser(testModule!, {
+      username: 'delother',
+      password: '123',
+    })
+
+    await testModule!.setServerStorageLocation()
+
+    const { folder } = await createTestFolder({
+      testModule: testModule!,
+      accessToken: ownerToken,
+      apiClient,
+      folderName: 'NoDeleteFolder',
+      mockFiles: [],
+    })
+
+    const res = await apiClient(otherToken).DELETE(
+      '/api/v1/folders/{folderId}',
+      { params: { path: { folderId: folder.id } } },
+    )
+    expect([401, 403, 404]).toContain(res.response.status)
+  })
+
+  it('should return error for non-existent folder', async () => {
+    const {
+      session: { accessToken },
+    } = await createTestUser(testModule!, {
+      username: 'del404',
+      password: '123',
+    })
+
+    const res = await apiClient(accessToken).DELETE(
+      '/api/v1/folders/{folderId}',
+      { params: { path: { folderId: uuidV4() } } },
+    )
+    expect([404, 400, 401, 403]).toContain(res.response.status)
+  })
+})

--- a/packages/api/src/folders/folder-metadata.e2e-spec.ts
+++ b/packages/api/src/folders/folder-metadata.e2e-spec.ts
@@ -1,0 +1,153 @@
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'bun:test'
+import { v4 as uuidV4 } from 'uuid'
+import type { TestApiClient, TestModule } from 'src/test/test.types'
+import {
+  buildTestModule,
+  createTestFolder,
+  createTestUser,
+  reindexTestFolder,
+} from 'src/test/test.util'
+
+const TEST_MODULE_KEY = 'folder_metadata'
+
+describe('Folder Metadata & Check Access', () => {
+  let testModule: TestModule | undefined
+  let apiClient: TestApiClient
+
+  beforeAll(async () => {
+    testModule = await buildTestModule({ testModuleKey: TEST_MODULE_KEY })
+    apiClient = testModule.apiClient
+  })
+
+  afterEach(async () => {
+    await testModule?.resetAppState()
+    testModule?.cleanupMinioTestBuckets()
+  })
+
+  afterAll(async () => {
+    await testModule?.shutdown()
+  })
+
+  it('should require authentication for metadata endpoint', async () => {
+    const res = await apiClient().GET(
+      '/api/v1/folders/{folderId}/metadata',
+      {
+        params: {
+          path: { folderId: '00000000-0000-0000-0000-000000000000' },
+        },
+      },
+    )
+    expect(res.response.status).toBe(401)
+  })
+
+  it('should get folder metadata for owned folder', async () => {
+    const {
+      session: { accessToken },
+    } = await createTestUser(testModule!, {
+      username: 'metauser',
+      password: '123',
+    })
+
+    await testModule!.setServerStorageLocation()
+    await testModule!.initMinioTestBucket()
+
+    const { folder } = await createTestFolder({
+      testModule: testModule!,
+      accessToken,
+      apiClient,
+      folderName: 'MetadataFolder',
+    })
+
+    const res = await apiClient(accessToken).GET(
+      '/api/v1/folders/{folderId}/metadata',
+      { params: { path: { folderId: folder.id } } },
+    )
+    expect(res.response.status).toBe(200)
+    expect(res.data).toBeDefined()
+  })
+
+  it('should not return metadata for non-existent folder', async () => {
+    const {
+      session: { accessToken },
+    } = await createTestUser(testModule!, {
+      username: 'metamisser',
+      password: '123',
+    })
+
+    const res = await apiClient(accessToken).GET(
+      '/api/v1/folders/{folderId}/metadata',
+      { params: { path: { folderId: uuidV4() } } },
+    )
+    expect([403, 404]).toContain(res.response.status)
+  })
+
+  it('should check folder access for owner', async () => {
+    const {
+      session: { accessToken },
+    } = await createTestUser(testModule!, {
+      username: 'checkuser',
+      password: '123',
+    })
+
+    await testModule!.setServerStorageLocation()
+    await testModule!.initMinioTestBucket()
+
+    const { folder } = await createTestFolder({
+      testModule: testModule!,
+      accessToken,
+      apiClient,
+      folderName: 'CheckAccessFolder',
+    })
+
+    const res = await apiClient(accessToken).POST(
+      '/api/v1/folders/{folderId}/check-access',
+      { params: { path: { folderId: folder.id } } },
+    )
+    expect([200, 201]).toContain(res.response.status)
+    expect(res.data?.ok).toBe(true)
+  })
+
+  it('should deny check-access for non-owner', async () => {
+    const {
+      session: { accessToken: ownerToken },
+    } = await createTestUser(testModule!, {
+      username: 'checkowner',
+      password: '123',
+    })
+
+    const {
+      session: { accessToken: otherToken },
+    } = await createTestUser(testModule!, {
+      username: 'checkother',
+      password: '123',
+    })
+
+    await testModule!.setServerStorageLocation()
+    await testModule!.initMinioTestBucket()
+
+    const { folder } = await createTestFolder({
+      testModule: testModule!,
+      accessToken: ownerToken,
+      apiClient,
+      folderName: 'DenyCheckFolder',
+    })
+
+    const res = await apiClient(otherToken).POST(
+      '/api/v1/folders/{folderId}/check-access',
+      { params: { path: { folderId: folder.id } } },
+    )
+    expect([401, 403, 404]).toContain(res.response.status)
+  })
+
+  it('should require authentication for check-access', async () => {
+    const res = await apiClient().POST(
+      '/api/v1/folders/{folderId}/check-access',
+      {
+        params: {
+          path: { folderId: '00000000-0000-0000-0000-000000000000' },
+        },
+      },
+    )
+    expect(res.response.status).toBe(401)
+  })
+})

--- a/packages/api/src/folders/folder-object-delete.e2e-spec.ts
+++ b/packages/api/src/folders/folder-object-delete.e2e-spec.ts
@@ -1,0 +1,162 @@
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'bun:test'
+import { CoreTaskName } from 'src/task/task.constants'
+import type { TestApiClient, TestModule } from 'src/test/test.types'
+import {
+  buildTestModule,
+  createTestFolder,
+  createTestUser,
+  reindexTestFolder,
+} from 'src/test/test.util'
+
+const TEST_MODULE_KEY = 'folder_obj_del'
+
+describe('Folder Object Delete', () => {
+  let testModule: TestModule | undefined
+  let apiClient: TestApiClient
+
+  beforeAll(async () => {
+    testModule = await buildTestModule({ testModuleKey: TEST_MODULE_KEY })
+    apiClient = testModule.apiClient
+  })
+
+  afterEach(async () => {
+    await testModule?.resetAppState()
+    testModule?.cleanupMinioTestBuckets()
+  })
+
+  afterAll(async () => {
+    await testModule?.shutdown()
+  })
+
+  it('should require authentication', async () => {
+    const res = await apiClient().DELETE(
+      '/api/v1/folders/{folderId}/objects/{objectKey}',
+      {
+        params: {
+          path: {
+            folderId: '00000000-0000-0000-0000-000000000000',
+            objectKey: 'test.txt',
+          },
+        },
+      },
+    )
+    expect(res.response.status).toBe(401)
+  })
+
+  it('should delete an object from owned folder', async () => {
+    const {
+      session: { accessToken },
+    } = await createTestUser(testModule!, {
+      username: 'delobj',
+      password: '123',
+    })
+
+    await testModule!.setServerStorageLocation()
+
+    const { folder } = await createTestFolder({
+      testModule: testModule!,
+      accessToken,
+      apiClient,
+      folderName: 'DelObjFolder',
+      mockFiles: [{ objectKey: 'deleteme.txt', content: 'bye' }],
+    })
+
+    await reindexTestFolder({ accessToken, apiClient, folderId: folder.id })
+    await testModule!.waitForTasks('completed', {
+      taskIdentifiers: [CoreTaskName.ReindexFolder],
+    })
+
+    const listBefore = await apiClient(accessToken).GET(
+      '/api/v1/folders/{folderId}/objects',
+      { params: { path: { folderId: folder.id } } },
+    )
+    expect(listBefore.data!.result.length).toBeGreaterThanOrEqual(1)
+    const objectKey = listBefore.data!.result[0]!.objectKey
+
+    const deleteRes = await apiClient(accessToken).DELETE(
+      '/api/v1/folders/{folderId}/objects/{objectKey}',
+      {
+        params: {
+          path: { folderId: folder.id, objectKey: encodeURIComponent(objectKey) },
+        },
+      },
+    )
+    expect(deleteRes.response.status).toBe(200)
+  })
+
+  it('should not allow deleting objects from another user folder', async () => {
+    const {
+      session: { accessToken: ownerToken },
+    } = await createTestUser(testModule!, {
+      username: 'objowner',
+      password: '123',
+    })
+
+    const {
+      session: { accessToken: otherToken },
+    } = await createTestUser(testModule!, {
+      username: 'objother',
+      password: '123',
+    })
+
+    await testModule!.setServerStorageLocation()
+
+    const { folder } = await createTestFolder({
+      testModule: testModule!,
+      accessToken: ownerToken,
+      apiClient,
+      folderName: 'ProtectedFolder',
+      mockFiles: [{ objectKey: 'protected.txt', content: 'nope' }],
+    })
+
+    await reindexTestFolder({ accessToken: ownerToken, apiClient, folderId: folder.id })
+    await testModule!.waitForTasks('completed', {
+      taskIdentifiers: [CoreTaskName.ReindexFolder],
+    })
+
+    const listRes = await apiClient(ownerToken).GET(
+      '/api/v1/folders/{folderId}/objects',
+      { params: { path: { folderId: folder.id } } },
+    )
+    const objectKey = listRes.data?.result?.[0]?.objectKey ?? 'protected.txt'
+
+    const deleteRes = await apiClient(otherToken).DELETE(
+      '/api/v1/folders/{folderId}/objects/{objectKey}',
+      {
+        params: {
+          path: { folderId: folder.id, objectKey: encodeURIComponent(objectKey) },
+        },
+      },
+    )
+    expect([401, 403, 404]).toContain(deleteRes.response.status)
+  })
+
+  it('should return error for non-existent object', async () => {
+    const {
+      session: { accessToken },
+    } = await createTestUser(testModule!, {
+      username: 'delmissing',
+      password: '123',
+    })
+
+    await testModule!.setServerStorageLocation()
+
+    const { folder } = await createTestFolder({
+      testModule: testModule!,
+      accessToken,
+      apiClient,
+      folderName: 'MissingObjFolder',
+      mockFiles: [],
+    })
+
+    const res = await apiClient(accessToken).DELETE(
+      '/api/v1/folders/{folderId}/objects/{objectKey}',
+      {
+        params: {
+          path: { folderId: folder.id, objectKey: 'nonexistent.txt' },
+        },
+      },
+    )
+    expect([404, 400]).toContain(res.response.status)
+  })
+})

--- a/packages/api/src/folders/folder-object-refresh.e2e-spec.ts
+++ b/packages/api/src/folders/folder-object-refresh.e2e-spec.ts
@@ -1,0 +1,155 @@
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'bun:test'
+import { CoreTaskName } from 'src/task/task.constants'
+import type { TestApiClient, TestModule } from 'src/test/test.types'
+import {
+  buildTestModule,
+  createTestFolder,
+  createTestUser,
+  reindexTestFolder,
+} from 'src/test/test.util'
+
+const TEST_MODULE_KEY = 'folder_obj_ref'
+
+describe('Folder Object Refresh', () => {
+  let testModule: TestModule | undefined
+  let apiClient: TestApiClient
+
+  beforeAll(async () => {
+    testModule = await buildTestModule({ testModuleKey: TEST_MODULE_KEY })
+    apiClient = testModule.apiClient
+  })
+
+  afterEach(async () => {
+    await testModule?.resetAppState()
+    testModule?.cleanupMinioTestBuckets()
+  })
+
+  afterAll(async () => {
+    await testModule?.shutdown()
+  })
+
+  it('should require authentication', async () => {
+    const res = await apiClient().POST(
+      '/api/v1/folders/{folderId}/objects/{objectKey}/refresh',
+      {
+        params: {
+          path: {
+            folderId: '00000000-0000-0000-0000-000000000000',
+            objectKey: 'test.txt',
+          },
+        },
+      },
+    )
+    expect(res.response.status).toBe(401)
+  })
+
+  it('should refresh an object in owned folder', async () => {
+    const {
+      session: { accessToken },
+    } = await createTestUser(testModule!, {
+      username: 'refreshuser',
+      password: '123',
+    })
+
+    await testModule!.setServerStorageLocation()
+
+    const { folder } = await createTestFolder({
+      testModule: testModule!,
+      accessToken,
+      apiClient,
+      folderName: 'RefreshFolder',
+      mockFiles: [{ objectKey: 'refresh-me.txt', content: 'data' }],
+    })
+
+    await reindexTestFolder({ accessToken, apiClient, folderId: folder.id })
+    await testModule!.waitForTasks('completed', {
+      taskIdentifiers: [CoreTaskName.ReindexFolder],
+    })
+
+    const listRes = await apiClient(accessToken).GET(
+      '/api/v1/folders/{folderId}/objects',
+      { params: { path: { folderId: folder.id } } },
+    )
+    expect(listRes.data!.result.length).toBeGreaterThanOrEqual(1)
+    const objectKey = listRes.data!.result[0]!.objectKey
+
+    const refreshRes = await apiClient(accessToken).POST(
+      '/api/v1/folders/{folderId}/objects/{objectKey}/refresh',
+      {
+        params: {
+          path: {
+            folderId: folder.id,
+            objectKey: encodeURIComponent(objectKey),
+          },
+        },
+      },
+    )
+    expect([200, 201]).toContain(refreshRes.response.status)
+    expect(refreshRes.data).toBeDefined()
+  })
+
+  it('should not allow refresh of object in non-owned folder', async () => {
+    const {
+      session: { accessToken: ownerToken },
+    } = await createTestUser(testModule!, {
+      username: 'refowner',
+      password: '123',
+    })
+
+    const {
+      session: { accessToken: otherToken },
+    } = await createTestUser(testModule!, {
+      username: 'refother',
+      password: '123',
+    })
+
+    await testModule!.setServerStorageLocation()
+
+    const { folder } = await createTestFolder({
+      testModule: testModule!,
+      accessToken: ownerToken,
+      apiClient,
+      folderName: 'RefProtected',
+      mockFiles: [{ objectKey: 'protected.txt', content: 'nope' }],
+    })
+
+    const res = await apiClient(otherToken).POST(
+      '/api/v1/folders/{folderId}/objects/{objectKey}/refresh',
+      {
+        params: {
+          path: { folderId: folder.id, objectKey: 'protected.txt' },
+        },
+      },
+    )
+    expect([401, 403, 404]).toContain(res.response.status)
+  })
+
+  it('should return error for non-existent object', async () => {
+    const {
+      session: { accessToken },
+    } = await createTestUser(testModule!, {
+      username: 'refmissing',
+      password: '123',
+    })
+
+    await testModule!.setServerStorageLocation()
+
+    const { folder } = await createTestFolder({
+      testModule: testModule!,
+      accessToken,
+      apiClient,
+      folderName: 'RefMissingFolder',
+      mockFiles: [],
+    })
+
+    const res = await apiClient(accessToken).POST(
+      '/api/v1/folders/{folderId}/objects/{objectKey}/refresh',
+      {
+        params: {
+          path: { folderId: folder.id, objectKey: 'nonexistent.txt' },
+        },
+      },
+    )
+    expect([404, 400]).toContain(res.response.status)
+  })
+})

--- a/packages/api/src/folders/folder-reindex.e2e-spec.ts
+++ b/packages/api/src/folders/folder-reindex.e2e-spec.ts
@@ -1,0 +1,113 @@
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'bun:test'
+import { v4 as uuidV4 } from 'uuid'
+import type { TestApiClient, TestModule } from 'src/test/test.types'
+import {
+  buildTestModule,
+  createTestFolder,
+  createTestUser,
+} from 'src/test/test.util'
+
+const TEST_MODULE_KEY = 'folder_reindex'
+
+describe('Folder Reindex', () => {
+  let testModule: TestModule | undefined
+  let apiClient: TestApiClient
+
+  beforeAll(async () => {
+    testModule = await buildTestModule({ testModuleKey: TEST_MODULE_KEY })
+    apiClient = testModule.apiClient
+  })
+
+  afterEach(async () => {
+    await testModule?.resetAppState()
+    testModule?.cleanupMinioTestBuckets()
+  })
+
+  afterAll(async () => {
+    await testModule?.shutdown()
+  })
+
+  it('should require authentication', async () => {
+    const res = await apiClient().POST(
+      '/api/v1/folders/{folderId}/reindex',
+      {
+        params: {
+          path: { folderId: '00000000-0000-0000-0000-000000000000' },
+        },
+      },
+    )
+    expect(res.response.status).toBe(401)
+  })
+
+  it('should reindex owned folder', async () => {
+    const {
+      session: { accessToken },
+    } = await createTestUser(testModule!, {
+      username: 'reindexuser',
+      password: '123',
+    })
+
+    await testModule!.setServerStorageLocation()
+
+    const { folder } = await createTestFolder({
+      testModule: testModule!,
+      accessToken,
+      apiClient,
+      folderName: 'ReindexFolder',
+      mockFiles: [{ objectKey: 'reindex-test.txt', content: 'data' }],
+    })
+
+    const res = await apiClient(accessToken).POST(
+      '/api/v1/folders/{folderId}/reindex',
+      { params: { path: { folderId: folder.id } } },
+    )
+    expect([200, 201]).toContain(res.response.status)
+  })
+
+  it('should not allow reindex of non-owned folder', async () => {
+    const {
+      session: { accessToken: ownerToken },
+    } = await createTestUser(testModule!, {
+      username: 'reindexowner',
+      password: '123',
+    })
+
+    const {
+      session: { accessToken: otherToken },
+    } = await createTestUser(testModule!, {
+      username: 'reindexother',
+      password: '123',
+    })
+
+    await testModule!.setServerStorageLocation()
+
+    const { folder } = await createTestFolder({
+      testModule: testModule!,
+      accessToken: ownerToken,
+      apiClient,
+      folderName: 'ReindexProtected',
+      mockFiles: [],
+    })
+
+    const res = await apiClient(otherToken).POST(
+      '/api/v1/folders/{folderId}/reindex',
+      { params: { path: { folderId: folder.id } } },
+    )
+    expect([401, 403, 404]).toContain(res.response.status)
+  })
+
+  it('should return error for non-existent folder', async () => {
+    const {
+      session: { accessToken },
+    } = await createTestUser(testModule!, {
+      username: 'reindexmissing',
+      password: '123',
+    })
+
+    const res = await apiClient(accessToken).POST(
+      '/api/v1/folders/{folderId}/reindex',
+      { params: { path: { folderId: uuidV4() } } },
+    )
+    expect([403, 404]).toContain(res.response.status)
+  })
+})

--- a/packages/api/src/folders/folder-shares.e2e-spec.ts
+++ b/packages/api/src/folders/folder-shares.e2e-spec.ts
@@ -1,0 +1,173 @@
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'bun:test'
+import type { TestApiClient, TestModule } from 'src/test/test.types'
+import {
+  buildTestModule,
+  createTestFolder,
+  createTestUser,
+} from 'src/test/test.util'
+
+const TEST_MODULE_KEY = 'folder_shares'
+
+describe('Folder Shares Management', () => {
+  let testModule: TestModule | undefined
+  let apiClient: TestApiClient
+
+  beforeAll(async () => {
+    testModule = await buildTestModule({ testModuleKey: TEST_MODULE_KEY })
+    apiClient = testModule.apiClient
+  })
+
+  afterEach(async () => {
+    await testModule?.resetAppState()
+    testModule?.cleanupMinioTestBuckets()
+  })
+
+  afterAll(async () => {
+    await testModule?.shutdown()
+  })
+
+  async function getViewerUserId(accessToken: string) {
+    const res = await apiClient(accessToken).GET('/api/v1/viewer')
+    return res.data!.user.id
+  }
+
+  it('should list shares for a folder (initially empty)', async () => {
+    const {
+      session: { accessToken },
+    } = await createTestUser(testModule!, {
+      username: 'shareowner',
+      password: '123',
+    })
+
+    await testModule!.setServerStorageLocation()
+    await testModule!.initMinioTestBucket()
+
+    const { folder } = await createTestFolder({
+      testModule: testModule!,
+      accessToken,
+      apiClient,
+      folderName: 'ShareFolder',
+    })
+
+    const res = await apiClient(accessToken).GET(
+      '/api/v1/folders/{folderId}/shares',
+      { params: { path: { folderId: folder.id } } },
+    )
+    expect(res.response.status).toBe(200)
+    expect(res.data?.result).toBeArray()
+  })
+
+  it('should create, get, and remove a folder share', async () => {
+    const {
+      session: { accessToken: ownerToken },
+    } = await createTestUser(testModule!, {
+      username: 'shareowner2',
+      password: '123',
+    })
+
+    const {
+      session: { accessToken: shareTarget },
+    } = await createTestUser(testModule!, {
+      username: 'sharetarget',
+      password: '123',
+    })
+
+    const targetUserId = await getViewerUserId(shareTarget)
+
+    await testModule!.setServerStorageLocation()
+    await testModule!.initMinioTestBucket()
+
+    const { folder } = await createTestFolder({
+      testModule: testModule!,
+      accessToken: ownerToken,
+      apiClient,
+      folderName: 'ShareCrudFolder',
+    })
+
+    // Create share
+    const createRes = await apiClient(ownerToken).POST(
+      '/api/v1/folders/{folderId}/shares/{userId}',
+      {
+        params: { path: { folderId: folder.id, userId: targetUserId } },
+        body: { permissions: ['OBJECT_EDIT'] },
+      },
+    )
+    expect([200, 201]).toContain(createRes.response.status)
+    expect(createRes.data?.share).toBeDefined()
+
+    // Get the share
+    const getRes = await apiClient(ownerToken).GET(
+      '/api/v1/folders/{folderId}/shares/{userId}',
+      {
+        params: { path: { folderId: folder.id, userId: targetUserId } },
+      },
+    )
+    expect(getRes.response.status).toBe(200)
+    expect(getRes.data?.share).toBeDefined()
+
+    // List shares - should have 1
+    const listRes = await apiClient(ownerToken).GET(
+      '/api/v1/folders/{folderId}/shares',
+      { params: { path: { folderId: folder.id } } },
+    )
+    expect(listRes.response.status).toBe(200)
+    expect(listRes.data!.result.length).toBeGreaterThanOrEqual(1)
+
+    // Remove share
+    const removeRes = await apiClient(ownerToken).DELETE(
+      '/api/v1/folders/{folderId}/shares/{userId}',
+      {
+        params: { path: { folderId: folder.id, userId: targetUserId } },
+      },
+    )
+    expect(removeRes.response.status).toBe(200)
+  })
+
+  it('should list user share options', async () => {
+    const {
+      session: { accessToken },
+    } = await createTestUser(testModule!, {
+      username: 'optowner',
+      password: '123',
+    })
+
+    await createTestUser(testModule!, {
+      username: 'optcandidate',
+      password: '123',
+    })
+
+    await testModule!.setServerStorageLocation()
+    await testModule!.initMinioTestBucket()
+
+    const { folder } = await createTestFolder({
+      testModule: testModule!,
+      accessToken,
+      apiClient,
+      folderName: 'OptFolder',
+    })
+
+    const res = await apiClient(accessToken).GET(
+      '/api/v1/folders/{folderId}/user-share-options',
+      { params: { path: { folderId: folder.id } } },
+    )
+    expect(res.response.status).toBe(200)
+    expect(res.data?.result).toBeArray()
+  })
+
+  it('should require authentication for share endpoints', async () => {
+    const folderId = '00000000-0000-0000-0000-000000000000'
+    const userId = '00000000-0000-0000-0000-000000000000'
+
+    const listRes = await apiClient().GET(
+      '/api/v1/folders/{folderId}/shares',
+      { params: { path: { folderId } } },
+    )
+    expect(listRes.response.status).toBe(401)
+
+    const getRes = await apiClient().GET(
+      '/api/v1/folders/{folderId}/shares/{userId}',
+      { params: { path: { folderId, userId } } },
+    )
+    expect(getRes.response.status).toBe(401)
+  })
+})

--- a/packages/api/src/folders/folder-update.e2e-spec.ts
+++ b/packages/api/src/folders/folder-update.e2e-spec.ts
@@ -1,0 +1,137 @@
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'bun:test'
+import type { TestApiClient, TestModule } from 'src/test/test.types'
+import {
+  buildTestModule,
+  createTestFolder,
+  createTestUser,
+} from 'src/test/test.util'
+
+const TEST_MODULE_KEY = 'folder_update'
+
+describe('Folder Update (Rename)', () => {
+  let testModule: TestModule | undefined
+  let apiClient: TestApiClient
+
+  beforeAll(async () => {
+    testModule = await buildTestModule({ testModuleKey: TEST_MODULE_KEY })
+    apiClient = testModule.apiClient
+  })
+
+  afterEach(async () => {
+    await testModule?.resetAppState()
+    testModule?.cleanupMinioTestBuckets()
+  })
+
+  afterAll(async () => {
+    await testModule?.shutdown()
+  })
+
+  it('should require authentication', async () => {
+    const res = await apiClient().PUT(
+      '/api/v1/folders/{folderId}',
+      {
+        params: {
+          path: { folderId: '00000000-0000-0000-0000-000000000000' },
+        },
+        body: { name: 'NewName' },
+      },
+    )
+    expect(res.response.status).toBe(401)
+  })
+
+  it('should rename an owned folder', async () => {
+    const {
+      session: { accessToken },
+    } = await createTestUser(testModule!, {
+      username: 'renameuser',
+      password: '123',
+    })
+
+    await testModule!.setServerStorageLocation()
+
+    const { folder } = await createTestFolder({
+      testModule: testModule!,
+      accessToken,
+      apiClient,
+      folderName: 'OriginalName',
+      mockFiles: [],
+    })
+
+    const res = await apiClient(accessToken).PUT(
+      '/api/v1/folders/{folderId}',
+      {
+        params: { path: { folderId: folder.id } },
+        body: { name: 'RenamedFolder' },
+      },
+    )
+    expect([200, 201]).toContain(res.response.status)
+    expect(res.data?.folder).toBeDefined()
+    expect(res.data!.folder.name).toBe('RenamedFolder')
+  })
+
+  it('should persist the rename', async () => {
+    const {
+      session: { accessToken },
+    } = await createTestUser(testModule!, {
+      username: 'persistrn',
+      password: '123',
+    })
+
+    await testModule!.setServerStorageLocation()
+
+    const { folder } = await createTestFolder({
+      testModule: testModule!,
+      accessToken,
+      apiClient,
+      folderName: 'BeforeRename',
+      mockFiles: [],
+    })
+
+    await apiClient(accessToken).PUT('/api/v1/folders/{folderId}', {
+      params: { path: { folderId: folder.id } },
+      body: { name: 'AfterRename' },
+    })
+
+    const getRes = await apiClient(accessToken).GET(
+      '/api/v1/folders/{folderId}',
+      { params: { path: { folderId: folder.id } } },
+    )
+    expect(getRes.response.status).toBe(200)
+    expect(getRes.data?.folder.name).toBe('AfterRename')
+  })
+
+  it('should not allow non-owner to rename', async () => {
+    const {
+      session: { accessToken: ownerToken },
+    } = await createTestUser(testModule!, {
+      username: 'rnowner',
+      password: '123',
+    })
+
+    const {
+      session: { accessToken: otherToken },
+    } = await createTestUser(testModule!, {
+      username: 'rnother',
+      password: '123',
+    })
+
+    await testModule!.setServerStorageLocation()
+
+    const { folder } = await createTestFolder({
+      testModule: testModule!,
+      accessToken: ownerToken,
+      apiClient,
+      folderName: 'ProtectedFolder',
+      mockFiles: [],
+    })
+
+    const res = await apiClient(otherToken).PUT(
+      '/api/v1/folders/{folderId}',
+      {
+        params: { path: { folderId: folder.id } },
+        body: { name: 'Hacked' },
+      },
+    )
+    expect([401, 403, 404]).toContain(res.response.status)
+  })
+})

--- a/packages/api/src/log/folder-logs.e2e-spec.ts
+++ b/packages/api/src/log/folder-logs.e2e-spec.ts
@@ -1,0 +1,226 @@
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'bun:test'
+import { LogEntryLevel } from '@lombokapp/types'
+import { v4 as uuidV4 } from 'uuid'
+import type { TestApiClient, TestModule } from 'src/test/test.types'
+import {
+  buildTestModule,
+  createTestFolder,
+  createTestUser,
+} from 'src/test/test.util'
+import { logEntriesTable } from './entities/log-entry.entity'
+
+const TEST_MODULE_KEY = 'folder_logs'
+
+async function seedFolderLogEntry(
+  testModule: TestModule,
+  folderId: string,
+  overrides: Partial<typeof logEntriesTable.$inferInsert> = {},
+) {
+  const id = uuidV4()
+  const now = new Date()
+
+  await testModule.services.ormService.db.insert(logEntriesTable).values({
+    id,
+    message: 'Test folder log',
+    emitterIdentifier: 'core',
+    level: LogEntryLevel.INFO,
+    targetLocationFolderId: folderId,
+    createdAt: now,
+    ...overrides,
+  })
+
+  return { id }
+}
+
+describe('Folder Logs', () => {
+  let testModule: TestModule | undefined
+  let apiClient: TestApiClient
+
+  beforeAll(async () => {
+    testModule = await buildTestModule({ testModuleKey: TEST_MODULE_KEY })
+    apiClient = testModule.apiClient
+  })
+
+  afterEach(async () => {
+    await testModule?.resetAppState()
+    testModule?.cleanupMinioTestBuckets()
+  })
+
+  afterAll(async () => {
+    await testModule?.shutdown()
+  })
+
+  it('should require authentication', async () => {
+    const response = await apiClient().GET(
+      '/api/v1/folders/{folderId}/logs',
+      { params: { path: { folderId: uuidV4() } } },
+    )
+    expect(response.response.status).toEqual(401)
+  })
+
+  it('should list logs for a folder the user owns', async () => {
+    const {
+      session: { accessToken },
+    } = await createTestUser(testModule!, {
+      username: 'folderloguser',
+      password: '123',
+    })
+
+    await testModule!.setServerStorageLocation()
+    await testModule!.initMinioTestBucket()
+
+    const { folder } = await createTestFolder({
+      testModule: testModule!,
+      accessToken,
+      apiClient,
+      folderName: 'LogTestFolder',
+    })
+
+    await seedFolderLogEntry(testModule!, folder.id, { message: 'Action 1' })
+    await seedFolderLogEntry(testModule!, folder.id, { message: 'Action 2' })
+
+    const response = await apiClient(accessToken).GET(
+      '/api/v1/folders/{folderId}/logs',
+      { params: { path: { folderId: folder.id } } },
+    )
+    expect(response.response.status).toEqual(200)
+    expect(response.data?.result).toBeArray()
+    expect(response.data?.result.length).toEqual(2)
+    expect(response.data?.meta.totalCount).toEqual(2)
+  })
+
+  it('should get a single folder log entry by ID', async () => {
+    const {
+      session: { accessToken },
+    } = await createTestUser(testModule!, {
+      username: 'folderlogget',
+      password: '123',
+    })
+
+    await testModule!.setServerStorageLocation()
+    await testModule!.initMinioTestBucket()
+
+    const { folder } = await createTestFolder({
+      testModule: testModule!,
+      accessToken,
+      apiClient,
+      folderName: 'LogGetFolder',
+    })
+
+    const { id: logId } = await seedFolderLogEntry(testModule!, folder.id, {
+      message: 'Specific folder log',
+      level: LogEntryLevel.ERROR,
+    })
+
+    const response = await apiClient(accessToken).GET(
+      '/api/v1/folders/{folderId}/logs/{logId}',
+      { params: { path: { folderId: folder.id, logId } } },
+    )
+    expect(response.response.status).toEqual(200)
+    expect(response.data?.log.message).toEqual('Specific folder log')
+    expect(response.data?.log.level).toEqual(LogEntryLevel.ERROR)
+  })
+
+  it('should not list logs for a folder the user does not own', async () => {
+    const {
+      session: { accessToken: ownerToken },
+    } = await createTestUser(testModule!, {
+      username: 'logowner',
+      password: '123',
+    })
+
+    const {
+      session: { accessToken: otherToken },
+    } = await createTestUser(testModule!, {
+      username: 'logother',
+      password: '123',
+    })
+
+    await testModule!.setServerStorageLocation()
+    await testModule!.initMinioTestBucket()
+
+    const { folder } = await createTestFolder({
+      testModule: testModule!,
+      accessToken: ownerToken,
+      apiClient,
+      folderName: 'PrivateLogFolder',
+    })
+
+    await seedFolderLogEntry(testModule!, folder.id, {
+      message: 'Private log',
+    })
+
+    // Other user should not be able to list logs for this folder
+    const response = await apiClient(otherToken).GET(
+      '/api/v1/folders/{folderId}/logs',
+      { params: { path: { folderId: folder.id } } },
+    )
+    expect([403, 404]).toContain(response.response.status)
+  })
+
+  it('should return 404 for non-existent log in folder', async () => {
+    const {
+      session: { accessToken },
+    } = await createTestUser(testModule!, {
+      username: 'lognotfound',
+      password: '123',
+    })
+
+    await testModule!.setServerStorageLocation()
+    await testModule!.initMinioTestBucket()
+
+    const { folder } = await createTestFolder({
+      testModule: testModule!,
+      accessToken,
+      apiClient,
+      folderName: 'NotFoundFolder',
+    })
+
+    const response = await apiClient(accessToken).GET(
+      '/api/v1/folders/{folderId}/logs/{logId}',
+      { params: { path: { folderId: folder.id, logId: uuidV4() } } },
+    )
+    expect(response.response.status).toEqual(404)
+  })
+
+  it('should only return logs for the requested folder', async () => {
+    const {
+      session: { accessToken },
+    } = await createTestUser(testModule!, {
+      username: 'multifolderuser',
+      password: '123',
+    })
+
+    await testModule!.setServerStorageLocation()
+    await testModule!.initMinioTestBucket()
+
+    const { folder: folder1 } = await createTestFolder({
+      testModule: testModule!,
+      accessToken,
+      apiClient,
+      folderName: 'Folder A',
+    })
+
+    const { folder: folder2 } = await createTestFolder({
+      testModule: testModule!,
+      accessToken,
+      apiClient,
+      folderName: 'Folder B',
+    })
+
+    await seedFolderLogEntry(testModule!, folder1.id, {
+      message: 'Folder A log',
+    })
+    await seedFolderLogEntry(testModule!, folder2.id, {
+      message: 'Folder B log',
+    })
+
+    const response = await apiClient(accessToken).GET(
+      '/api/v1/folders/{folderId}/logs',
+      { params: { path: { folderId: folder1.id } } },
+    )
+    expect(response.response.status).toEqual(200)
+    expect(response.data?.result.length).toEqual(1)
+    expect(response.data?.result[0]?.message).toEqual('Folder A log')
+  })
+})

--- a/packages/api/src/log/server-logs.e2e-spec.ts
+++ b/packages/api/src/log/server-logs.e2e-spec.ts
@@ -1,0 +1,180 @@
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'bun:test'
+import { LogEntryLevel } from '@lombokapp/types'
+import { v4 as uuidV4 } from 'uuid'
+import type { TestApiClient, TestModule } from 'src/test/test.types'
+import { buildTestModule, createTestUser } from 'src/test/test.util'
+import { logEntriesTable } from './entities/log-entry.entity'
+
+const TEST_MODULE_KEY = 'server_logs'
+
+async function seedLogEntry(
+  testModule: TestModule,
+  overrides: Partial<typeof logEntriesTable.$inferInsert> = {},
+) {
+  const id = uuidV4()
+  const now = new Date()
+
+  await testModule.services.ormService.db.insert(logEntriesTable).values({
+    id,
+    message: 'Test log message',
+    emitterIdentifier: 'core',
+    level: LogEntryLevel.INFO,
+    createdAt: now,
+    ...overrides,
+  })
+
+  return { id }
+}
+
+describe('Server Logs', () => {
+  let testModule: TestModule | undefined
+  let apiClient: TestApiClient
+
+  beforeAll(async () => {
+    testModule = await buildTestModule({ testModuleKey: TEST_MODULE_KEY })
+    apiClient = testModule.apiClient
+  })
+
+  afterEach(async () => {
+    await testModule?.resetAppState()
+  })
+
+  afterAll(async () => {
+    await testModule?.shutdown()
+  })
+
+  it('should require authentication', async () => {
+    const response = await apiClient().GET('/api/v1/server/logs')
+    expect(response.response.status).toEqual(401)
+  })
+
+  it('should require admin role', async () => {
+    const {
+      session: { accessToken },
+    } = await createTestUser(testModule!, {
+      username: 'regularuser',
+      password: '123',
+    })
+
+    const response = await apiClient(accessToken).GET('/api/v1/server/logs')
+    expect(response.response.status).toEqual(401)
+  })
+
+  it('should list logs for admin', async () => {
+    const {
+      session: { accessToken },
+    } = await createTestUser(testModule!, {
+      username: 'admin1',
+      password: '123',
+      admin: true,
+    })
+
+    await seedLogEntry(testModule!, { message: 'Log entry 1' })
+    await seedLogEntry(testModule!, { message: 'Log entry 2' })
+    await seedLogEntry(testModule!, { message: 'Log entry 3' })
+
+    const response = await apiClient(accessToken).GET('/api/v1/server/logs')
+    expect(response.response.status).toEqual(200)
+    expect(response.data?.result).toBeArray()
+    expect(response.data?.result.length).toEqual(3)
+    expect(response.data?.meta.totalCount).toEqual(3)
+  })
+
+  it('should get a single log entry by ID', async () => {
+    const {
+      session: { accessToken },
+    } = await createTestUser(testModule!, {
+      username: 'admin2',
+      password: '123',
+      admin: true,
+    })
+
+    const { id: logId } = await seedLogEntry(testModule!, {
+      message: 'Specific log entry',
+      level: LogEntryLevel.WARN,
+    })
+
+    const response = await apiClient(accessToken).GET(
+      '/api/v1/server/logs/{logId}',
+      { params: { path: { logId } } },
+    )
+    expect(response.response.status).toEqual(200)
+    expect(response.data?.log.message).toEqual('Specific log entry')
+    expect(response.data?.log.level).toEqual(LogEntryLevel.WARN)
+  })
+
+  it('should return 404 for non-existent log entry', async () => {
+    const {
+      session: { accessToken },
+    } = await createTestUser(testModule!, {
+      username: 'admin3',
+      password: '123',
+      admin: true,
+    })
+
+    const response = await apiClient(accessToken).GET(
+      '/api/v1/server/logs/{logId}',
+      { params: { path: { logId: uuidV4() } } },
+    )
+    expect(response.response.status).toEqual(404)
+  })
+
+  it('should support pagination with offset and limit', async () => {
+    const {
+      session: { accessToken },
+    } = await createTestUser(testModule!, {
+      username: 'admin4',
+      password: '123',
+      admin: true,
+    })
+
+    // Seed 5 log entries with sequential timestamps
+    for (let i = 0; i < 5; i++) {
+      const ts = new Date(Date.now() + i * 1000)
+      await seedLogEntry(testModule!, {
+        message: `Log ${i}`,
+        createdAt: ts,
+      })
+    }
+
+    const page1 = await apiClient(accessToken).GET('/api/v1/server/logs', {
+      params: { query: { limit: 2, offset: 0 } },
+    })
+    expect(page1.response.status).toEqual(200)
+    expect(page1.data?.result.length).toEqual(2)
+    expect(page1.data?.meta.totalCount).toEqual(5)
+
+    const page2 = await apiClient(accessToken).GET('/api/v1/server/logs', {
+      params: { query: { limit: 2, offset: 2 } },
+    })
+    expect(page2.response.status).toEqual(200)
+    expect(page2.data?.result.length).toEqual(2)
+
+    // Ensure no overlap
+    const page1Ids = page1.data?.result.map((l) => l.id) ?? []
+    const page2Ids = page2.data?.result.map((l) => l.id) ?? []
+    const overlap = page1Ids.filter((id) => page2Ids.includes(id))
+    expect(overlap.length).toEqual(0)
+  })
+
+  it('should filter logs by search term', async () => {
+    const {
+      session: { accessToken },
+    } = await createTestUser(testModule!, {
+      username: 'admin5',
+      password: '123',
+      admin: true,
+    })
+
+    await seedLogEntry(testModule!, { message: 'User login successful' })
+    await seedLogEntry(testModule!, { message: 'File upload completed' })
+    await seedLogEntry(testModule!, { message: 'User logout' })
+
+    const response = await apiClient(accessToken).GET('/api/v1/server/logs', {
+      params: { query: { search: 'User' } },
+    })
+    expect(response.response.status).toEqual(200)
+    expect(response.data?.result.length).toEqual(2)
+    expect(response.data?.meta.totalCount).toEqual(2)
+  })
+})

--- a/packages/api/src/notification/notification-settings.e2e-spec.ts
+++ b/packages/api/src/notification/notification-settings.e2e-spec.ts
@@ -1,0 +1,209 @@
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'bun:test'
+import type { TestApiClient, TestModule } from 'src/test/test.types'
+import { buildTestModule, createTestFolder, createTestUser } from 'src/test/test.util'
+
+const TEST_MODULE_KEY = 'notification_settings'
+
+describe('Notification Settings', () => {
+  let testModule: TestModule | undefined
+  let apiClient: TestApiClient
+
+  beforeAll(async () => {
+    testModule = await buildTestModule({ testModuleKey: TEST_MODULE_KEY })
+    apiClient = testModule.apiClient
+  })
+
+  afterEach(async () => {
+    await testModule?.resetAppState()
+  })
+
+  afterAll(async () => {
+    await testModule?.shutdown()
+  })
+
+  it('should require authentication', async () => {
+    const response = await apiClient().GET('/api/v1/notifications/settings')
+    expect(response.response.status).toEqual(401)
+  })
+
+  it('should get empty global settings for new user', async () => {
+    const {
+      session: { accessToken },
+    } = await createTestUser(testModule!, {
+      username: 'settingsuser',
+      password: '123',
+    })
+
+    const response = await apiClient(accessToken).GET(
+      '/api/v1/notifications/settings',
+    )
+    expect(response.response.status).toEqual(200)
+    expect(response.data?.settings).toBeArray()
+  })
+
+  it('should update and retrieve global notification settings', async () => {
+    const {
+      session: { accessToken },
+    } = await createTestUser(testModule!, {
+      username: 'updateuser',
+      password: '123',
+    })
+
+    const settings = [
+      {
+        eventIdentifier: 'object_added',
+        emitterIdentifier: 'core',
+        channel: 'web' as const,
+        enabled: false,
+      },
+      {
+        eventIdentifier: 'object_added',
+        emitterIdentifier: 'core',
+        channel: 'email' as const,
+        enabled: true,
+      },
+    ]
+
+    const updateResponse = await apiClient(accessToken).PUT(
+      '/api/v1/notifications/settings',
+      { body: { settings } },
+    )
+    expect(updateResponse.response.status).toEqual(200)
+    expect(updateResponse.data?.settings).toBeArray()
+    expect(updateResponse.data?.settings.length).toEqual(2)
+
+    // Verify the settings persisted
+    const getResponse = await apiClient(accessToken).GET(
+      '/api/v1/notifications/settings',
+    )
+    expect(getResponse.response.status).toEqual(200)
+    expect(getResponse.data?.settings.length).toEqual(2)
+
+    const webSetting = getResponse.data?.settings.find(
+      (s) => s.channel === 'web',
+    )
+    expect(webSetting?.enabled).toEqual(false)
+
+    const emailSetting = getResponse.data?.settings.find(
+      (s) => s.channel === 'email',
+    )
+    expect(emailSetting?.enabled).toEqual(true)
+  })
+
+  it('should isolate settings between users', async () => {
+    const {
+      session: { accessToken: token1 },
+    } = await createTestUser(testModule!, {
+      username: 'isouser1',
+      password: '123',
+    })
+
+    const {
+      session: { accessToken: token2 },
+    } = await createTestUser(testModule!, {
+      username: 'isouser2',
+      password: '123',
+    })
+
+    // User 1 updates settings
+    await apiClient(token1).PUT('/api/v1/notifications/settings', {
+      body: {
+        settings: [
+          {
+            eventIdentifier: 'object_added',
+            emitterIdentifier: 'core',
+            channel: 'web' as const,
+            enabled: false,
+          },
+        ],
+      },
+    })
+
+    // User 2 should not see user 1's settings
+    const user2Settings = await apiClient(token2).GET(
+      '/api/v1/notifications/settings',
+    )
+    expect(user2Settings.data?.settings.length).toEqual(0)
+  })
+
+  it('should get and update folder-specific notification settings', async () => {
+    const {
+      session: { accessToken },
+    } = await createTestUser(testModule!, {
+      username: 'folderuser',
+      password: '123',
+    })
+
+    await testModule!.setServerStorageLocation()
+    await testModule!.initMinioTestBucket()
+
+    const { folder } = await createTestFolder({
+      testModule: testModule!,
+      accessToken,
+      apiClient,
+      folderName: 'Notif Test Folder',
+    })
+
+    // Get folder settings (initially empty)
+    const getResponse = await apiClient(accessToken).GET(
+      '/api/v1/notifications/settings/folders/{folderId}',
+      { params: { path: { folderId: folder.id } } },
+    )
+    expect(getResponse.response.status).toEqual(200)
+    expect(getResponse.data?.settings).toBeArray()
+
+    // Update folder settings
+    const updateResponse = await apiClient(accessToken).PUT(
+      '/api/v1/notifications/settings/folders/{folderId}',
+      {
+        params: { path: { folderId: folder.id } },
+        body: {
+          settings: [
+            {
+              eventIdentifier: 'object_added',
+              emitterIdentifier: 'core',
+              channel: 'web' as const,
+              enabled: false,
+            },
+          ],
+        },
+      },
+    )
+    expect(updateResponse.response.status).toEqual(200)
+    expect(updateResponse.data?.settings.length).toEqual(1)
+    expect(updateResponse.data?.settings[0]?.enabled).toEqual(false)
+  })
+
+  it('should not allow access to other users folder settings', async () => {
+    const {
+      session: { accessToken: ownerToken },
+    } = await createTestUser(testModule!, {
+      username: 'folderowner',
+      password: '123',
+    })
+
+    const {
+      session: { accessToken: otherToken },
+    } = await createTestUser(testModule!, {
+      username: 'otheruser',
+      password: '123',
+    })
+
+    await testModule!.setServerStorageLocation()
+    await testModule!.initMinioTestBucket()
+
+    const { folder } = await createTestFolder({
+      testModule: testModule!,
+      accessToken: ownerToken,
+      apiClient,
+      folderName: 'Private Folder',
+    })
+
+    // Other user should not access the folder settings
+    const response = await apiClient(otherToken).GET(
+      '/api/v1/notifications/settings/folders/{folderId}',
+      { params: { path: { folderId: folder.id } } },
+    )
+    expect([403, 404]).toContain(response.response.status)
+  })
+})

--- a/packages/api/src/notification/notifications.e2e-spec.ts
+++ b/packages/api/src/notification/notifications.e2e-spec.ts
@@ -1,0 +1,223 @@
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'bun:test'
+import { v4 as uuidV4 } from 'uuid'
+import type { TestApiClient, TestModule } from 'src/test/test.types'
+import { buildTestModule, createTestUser } from 'src/test/test.util'
+import { notificationsTable } from './entities/notification.entity'
+import { notificationDeliveriesTable } from './entities/notification-delivery.entity'
+
+const TEST_MODULE_KEY = 'notifications'
+
+async function getUserId(apiClient: TestApiClient, accessToken: string) {
+  const viewer = await apiClient(accessToken).GET('/api/v1/viewer')
+  if (!viewer.data) throw new Error('Failed to get viewer')
+  return viewer.data.user.id
+}
+
+async function seedNotification(
+  testModule: TestModule,
+  userId: string,
+  overrides: Partial<typeof notificationsTable.$inferInsert> = {},
+) {
+  const notificationId = uuidV4()
+  const eventId = uuidV4()
+  const now = new Date()
+
+  await testModule.services.ormService.db
+    .insert(notificationsTable)
+    .values({
+      id: notificationId,
+      eventIdentifier: 'object_added',
+      emitterIdentifier: 'core',
+      aggregationKey: `test:${notificationId}`,
+      targetUserId: userId,
+      eventIds: [eventId],
+      title: 'Test notification',
+      body: 'Something happened',
+      createdAt: now,
+      ...overrides,
+    })
+
+  await testModule.services.ormService.db
+    .insert(notificationDeliveriesTable)
+    .values({
+      notificationId,
+      userId,
+      createdAt: now,
+    })
+
+  return { notificationId, eventId }
+}
+
+describe('Notifications', () => {
+  let testModule: TestModule | undefined
+  let apiClient: TestApiClient
+
+  beforeAll(async () => {
+    testModule = await buildTestModule({ testModuleKey: TEST_MODULE_KEY })
+    apiClient = testModule.apiClient
+  })
+
+  afterEach(async () => {
+    await testModule?.resetAppState()
+  })
+
+  afterAll(async () => {
+    await testModule?.shutdown()
+  })
+
+  it('should require authentication for listing notifications', async () => {
+    const response = await apiClient().GET('/api/v1/notifications')
+    expect(response.response.status).toEqual(401)
+  })
+
+  it('should list notifications for authenticated user', async () => {
+    const {
+      session: { accessToken },
+    } = await createTestUser(testModule!, {
+      username: 'notifuser',
+      password: '123',
+    })
+    const userId = await getUserId(apiClient, accessToken)
+
+    await seedNotification(testModule!, userId, { title: 'Notif 1' })
+    await seedNotification(testModule!, userId, { title: 'Notif 2' })
+
+    const response = await apiClient(accessToken).GET('/api/v1/notifications')
+    expect(response.response.status).toEqual(200)
+    expect(response.data?.notifications).toBeArray()
+    expect(response.data?.notifications.length).toEqual(2)
+  })
+
+  it('should not list other users notifications', async () => {
+    const {
+      session: { accessToken: token1 },
+    } = await createTestUser(testModule!, {
+      username: 'user1',
+      password: '123',
+    })
+    const userId1 = await getUserId(apiClient, token1)
+
+    const {
+      session: { accessToken: token2 },
+    } = await createTestUser(testModule!, {
+      username: 'user2',
+      password: '123',
+    })
+    const userId2 = await getUserId(apiClient, token2)
+
+    await seedNotification(testModule!, userId1, { title: 'User1 only' })
+    await seedNotification(testModule!, userId2, { title: 'User2 only' })
+
+    const response1 = await apiClient(token1).GET('/api/v1/notifications')
+    expect(response1.data?.notifications.length).toEqual(1)
+    expect(response1.data?.notifications[0]?.title).toEqual('User1 only')
+
+    const response2 = await apiClient(token2).GET('/api/v1/notifications')
+    expect(response2.data?.notifications.length).toEqual(1)
+    expect(response2.data?.notifications[0]?.title).toEqual('User2 only')
+  })
+
+  it('should get unread count', async () => {
+    const {
+      session: { accessToken },
+    } = await createTestUser(testModule!, {
+      username: 'countuser',
+      password: '123',
+    })
+    const userId = await getUserId(apiClient, accessToken)
+
+    await seedNotification(testModule!, userId)
+    await seedNotification(testModule!, userId)
+    await seedNotification(testModule!, userId)
+
+    const response = await apiClient(accessToken).GET(
+      '/api/v1/notifications/unread-count',
+    )
+    expect(response.response.status).toEqual(200)
+    expect(response.data?.count).toEqual(3)
+  })
+
+  it('should get a single notification by ID', async () => {
+    const {
+      session: { accessToken },
+    } = await createTestUser(testModule!, {
+      username: 'getuser',
+      password: '123',
+    })
+    const userId = await getUserId(apiClient, accessToken)
+
+    const { notificationId } = await seedNotification(testModule!, userId, {
+      title: 'Specific notification',
+    })
+
+    const response = await apiClient(accessToken).GET(
+      '/api/v1/notifications/{notificationId}',
+      { params: { path: { notificationId } } },
+    )
+    expect(response.response.status).toEqual(200)
+    expect(response.data?.title).toEqual('Specific notification')
+    expect(response.data?.id).toEqual(notificationId)
+  })
+
+  it('should return 404 for non-existent notification', async () => {
+    const {
+      session: { accessToken },
+    } = await createTestUser(testModule!, {
+      username: 'missing',
+      password: '123',
+    })
+
+    const response = await apiClient(accessToken).GET(
+      '/api/v1/notifications/{notificationId}',
+      { params: { path: { notificationId: uuidV4() } } },
+    )
+    expect(response.response.status).toEqual(404)
+  })
+
+  it('should mark notification as read and update unread count', async () => {
+    const {
+      session: { accessToken },
+    } = await createTestUser(testModule!, {
+      username: 'readuser',
+      password: '123',
+    })
+    const userId = await getUserId(apiClient, accessToken)
+
+    const { notificationId } = await seedNotification(testModule!, userId)
+    await seedNotification(testModule!, userId)
+
+    // Verify 2 unread
+    const countBefore = await apiClient(accessToken).GET(
+      '/api/v1/notifications/unread-count',
+    )
+    expect(countBefore.data?.count).toEqual(2)
+
+    // Mark one as read
+    const markResponse = await apiClient(accessToken).PATCH(
+      '/api/v1/notifications/{id}/read',
+      { params: { path: { id: notificationId } } },
+    )
+    expect(markResponse.response.status).toEqual(200)
+
+    // Verify 1 unread
+    const countAfter = await apiClient(accessToken).GET(
+      '/api/v1/notifications/unread-count',
+    )
+    expect(countAfter.data?.count).toEqual(1)
+  })
+
+  it('should return 404 when marking non-existent notification as read', async () => {
+    const {
+      session: { accessToken },
+    } = await createTestUser(testModule!, {
+      username: 'readmissing',
+      password: '123',
+    })
+
+    const response = await apiClient(accessToken).PATCH(
+      '/api/v1/notifications/{id}/read',
+      { params: { path: { id: uuidV4() } } },
+    )
+    expect(response.response.status).toEqual(404)
+  })
+})

--- a/packages/api/src/server/public-settings.e2e-spec.ts
+++ b/packages/api/src/server/public-settings.e2e-spec.ts
@@ -1,0 +1,46 @@
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'bun:test'
+import type { TestApiClient, TestModule } from 'src/test/test.types'
+import { buildTestModule, createTestUser } from 'src/test/test.util'
+
+const TEST_MODULE_KEY = 'public_settings'
+
+describe('Public Settings', () => {
+  let testModule: TestModule | undefined
+  let apiClient: TestApiClient
+
+  beforeAll(async () => {
+    testModule = await buildTestModule({ testModuleKey: TEST_MODULE_KEY })
+    apiClient = testModule.apiClient
+  })
+
+  afterEach(async () => {
+    await testModule?.resetAppState()
+  })
+
+  afterAll(async () => {
+    await testModule?.shutdown()
+  })
+
+  it('should return public settings without authentication', async () => {
+    const response = await apiClient().GET('/api/v1/public/settings')
+    expect(response.response.status).toEqual(200)
+    expect(response.data?.settings).toBeDefined()
+  })
+
+  it('should return public settings with authentication too', async () => {
+    const {
+      session: { accessToken },
+    } = await createTestUser(testModule!, { username: 'pubuser', password: '123' })
+
+    const response = await apiClient(accessToken).GET('/api/v1/public/settings')
+    expect(response.response.status).toEqual(200)
+    expect(response.data?.settings).toBeDefined()
+  })
+
+  it('should include expected fields in public settings', async () => {
+    const response = await apiClient().GET('/api/v1/public/settings')
+    expect(response.response.status).toEqual(200)
+    // Public settings should be an object (exact shape depends on config)
+    expect(typeof response.data?.settings).toEqual('object')
+  })
+})

--- a/packages/api/src/server/server-docker-hosts.e2e-spec.ts
+++ b/packages/api/src/server/server-docker-hosts.e2e-spec.ts
@@ -1,0 +1,97 @@
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'bun:test'
+import type { TestApiClient, TestModule } from 'src/test/test.types'
+import { buildTestModule, createTestUser } from 'src/test/test.util'
+
+const TEST_MODULE_KEY = 'server_docker_hosts'
+
+describe('Server Docker Hosts', () => {
+  let testModule: TestModule | undefined
+  let apiClient: TestApiClient
+
+  beforeAll(async () => {
+    testModule = await buildTestModule({ testModuleKey: TEST_MODULE_KEY })
+    apiClient = testModule.apiClient
+  })
+
+  afterEach(async () => {
+    await testModule?.resetAppState()
+  })
+
+  afterAll(async () => {
+    await testModule?.shutdown()
+  })
+
+  it('should require authentication for docker hosts config', async () => {
+    const response = await apiClient().GET('/api/v1/server/docker-hosts')
+    expect(response.response.status).toEqual(401)
+  })
+
+  it('should require admin role for docker hosts config', async () => {
+    const {
+      session: { accessToken },
+    } = await createTestUser(testModule!, { username: 'nonadmin', password: '123' })
+
+    const response = await apiClient(accessToken).GET('/api/v1/server/docker-hosts')
+    expect(response.response.status).toEqual(401)
+  })
+
+  it('should return docker hosts config for admin', async () => {
+    const {
+      session: { accessToken },
+    } = await createTestUser(testModule!, {
+      username: 'dockeradmin',
+      password: '123',
+      admin: true,
+    })
+
+    const response = await apiClient(accessToken).GET('/api/v1/server/docker-hosts')
+    expect(response.response.status).toEqual(200)
+    expect(response.data?.hosts).toBeArray()
+  })
+
+  it('should require admin for docker hosts state', async () => {
+    const {
+      session: { accessToken },
+    } = await createTestUser(testModule!, { username: 'nonadmin2', password: '123' })
+
+    const response = await apiClient(accessToken).GET(
+      '/api/v1/server/docker-hosts/state',
+    )
+    expect(response.response.status).toEqual(401)
+  })
+
+  it('should return docker hosts state for admin', async () => {
+    const {
+      session: { accessToken },
+    } = await createTestUser(testModule!, {
+      username: 'dockeradmin2',
+      password: '123',
+      admin: true,
+    })
+
+    const response = await apiClient(accessToken).GET(
+      '/api/v1/server/docker-hosts/state',
+    )
+    expect(response.response.status).toEqual(200)
+    expect(response.data?.hosts).toBeDefined()
+  })
+
+  it('should return hosts with expected structure', async () => {
+    const {
+      session: { accessToken },
+    } = await createTestUser(testModule!, {
+      username: 'dockeradmin3',
+      password: '123',
+      admin: true,
+    })
+
+    const response = await apiClient(accessToken).GET('/api/v1/server/docker-hosts')
+    expect(response.response.status).toEqual(200)
+
+    if (response.data?.hosts && response.data.hosts.length > 0) {
+      const host = response.data.hosts[0]!
+      expect(host.id).toBeTruthy()
+      expect(host.type).toBeTruthy()
+    }
+  })
+})

--- a/packages/api/src/server/server-settings-metrics.e2e-spec.ts
+++ b/packages/api/src/server/server-settings-metrics.e2e-spec.ts
@@ -1,0 +1,123 @@
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'bun:test'
+import type { TestApiClient, TestModule } from 'src/test/test.types'
+import { buildTestModule, createTestUser } from 'src/test/test.util'
+
+const TEST_MODULE_KEY = 'srv_set_met'
+
+describe('Server Settings & Metrics', () => {
+  let testModule: TestModule | undefined
+  let apiClient: TestApiClient
+
+  beforeAll(async () => {
+    testModule = await buildTestModule({ testModuleKey: TEST_MODULE_KEY })
+    apiClient = testModule.apiClient
+  })
+
+  afterEach(async () => {
+    await testModule?.resetAppState()
+  })
+
+  afterAll(async () => {
+    await testModule?.shutdown()
+  })
+
+  it('should require authentication for settings', async () => {
+    const res = await apiClient().GET('/api/v1/server/settings')
+    expect(res.response.status).toBe(401)
+  })
+
+  it('should require admin for settings', async () => {
+    const {
+      session: { accessToken },
+    } = await createTestUser(testModule!, {
+      username: 'setnonadm',
+      password: '123',
+    })
+
+    const res = await apiClient(accessToken).GET('/api/v1/server/settings')
+    expect(res.response.status).toBe(401)
+  })
+
+  it('should get server settings as admin', async () => {
+    const {
+      session: { accessToken },
+    } = await createTestUser(testModule!, {
+      username: 'setadmin',
+      password: '123',
+      admin: true,
+    })
+
+    const res = await apiClient(accessToken).GET('/api/v1/server/settings')
+    expect(res.response.status).toBe(200)
+    expect(res.data?.settings).toBeDefined()
+  })
+
+  it('should set and get a server setting', async () => {
+    const {
+      session: { accessToken },
+    } = await createTestUser(testModule!, {
+      username: 'setput',
+      password: '123',
+      admin: true,
+    })
+
+    const setRes = await apiClient(accessToken).PUT(
+      '/api/v1/server/settings/{settingKey}',
+      {
+        params: { path: { settingKey: 'SIGNUP_ENABLED' } },
+        body: { value: false },
+      },
+    )
+    expect([200, 201]).toContain(setRes.response.status)
+    expect(setRes.data?.settingKey).toBe('SIGNUP_ENABLED')
+
+    // Verify it persisted
+    const getRes = await apiClient(accessToken).GET('/api/v1/server/settings')
+    expect(getRes.response.status).toBe(200)
+  })
+
+  it('should delete (reset) a server setting', async () => {
+    const {
+      session: { accessToken },
+    } = await createTestUser(testModule!, {
+      username: 'setdel',
+      password: '123',
+      admin: true,
+    })
+
+    // Set a setting
+    await apiClient(accessToken).PUT(
+      '/api/v1/server/settings/{settingKey}',
+      {
+        params: { path: { settingKey: 'SIGNUP_ENABLED' } },
+        body: { value: false },
+      },
+    )
+
+    // Reset it
+    const delRes = await apiClient(accessToken).DELETE(
+      '/api/v1/server/settings/{settingKey}',
+      { params: { path: { settingKey: 'SIGNUP_ENABLED' } } },
+    )
+    expect([200, 204]).toContain(delRes.response.status)
+  })
+
+  it('should require authentication for metrics', async () => {
+    const res = await apiClient().GET('/api/v1/server/metrics')
+    expect(res.response.status).toBe(401)
+  })
+
+  it('should get server metrics as admin', async () => {
+    const {
+      session: { accessToken },
+    } = await createTestUser(testModule!, {
+      username: 'metadmin',
+      password: '123',
+      admin: true,
+    })
+
+    const res = await apiClient(accessToken).GET('/api/v1/server/metrics')
+    expect(res.response.status).toBe(200)
+    expect(res.data).toBeDefined()
+  })
+})

--- a/packages/api/src/server/server-storage-create.e2e-spec.ts
+++ b/packages/api/src/server/server-storage-create.e2e-spec.ts
@@ -1,0 +1,146 @@
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'bun:test'
+import type { TestApiClient, TestModule } from 'src/test/test.types'
+import { buildTestModule, createTestUser } from 'src/test/test.util'
+
+const TEST_MODULE_KEY = 'srv_stg_creat'
+
+describe('Server Storage Create (POST)', () => {
+  let testModule: TestModule | undefined
+  let apiClient: TestApiClient
+
+  beforeAll(async () => {
+    testModule = await buildTestModule({ testModuleKey: TEST_MODULE_KEY })
+    apiClient = testModule.apiClient
+  })
+
+  afterEach(async () => {
+    await testModule?.resetAppState()
+    testModule?.cleanupMinioTestBuckets()
+  })
+
+  afterAll(async () => {
+    await testModule?.shutdown()
+  })
+
+  it('should require authentication', async () => {
+    const res = await apiClient().POST('/api/v1/server/server-storage', {
+      body: {
+        accessKeyId: 'test',
+        secretAccessKey: 'test',
+        endpoint: 'http://localhost:9000',
+        bucket: 'test',
+        region: 'us-east-1',
+        prefix: null,
+      },
+    })
+    expect(res.response.status).toBe(401)
+  })
+
+  it('should require admin', async () => {
+    const {
+      session: { accessToken },
+    } = await createTestUser(testModule!, {
+      username: 'stgnonadm',
+      password: '123',
+    })
+
+    const res = await apiClient(accessToken).POST(
+      '/api/v1/server/server-storage',
+      {
+        body: {
+          accessKeyId: 'test',
+          secretAccessKey: 'test',
+          endpoint: 'http://localhost:9000',
+          bucket: 'test',
+          region: 'us-east-1',
+          prefix: null,
+        },
+      },
+    )
+    expect(res.response.status).toBe(401)
+  })
+
+  it('should create server storage location as admin', async () => {
+    const {
+      session: { accessToken },
+    } = await createTestUser(testModule!, {
+      username: 'stgadmin',
+      password: '123',
+      admin: true,
+    })
+
+    const s3Config = testModule!.testS3ClientConfig()
+    const bucketName = await testModule!.initMinioTestBucket()
+
+    const res = await apiClient(accessToken).POST(
+      '/api/v1/server/server-storage',
+      {
+        body: {
+          accessKeyId: s3Config.accessKeyId,
+          secretAccessKey: s3Config.secretAccessKey,
+          endpoint: s3Config.endpoint,
+          bucket: bucketName,
+          region: s3Config.region,
+          prefix: null,
+        },
+      },
+    )
+    expect([200, 201]).toContain(res.response.status)
+    expect(res.data?.serverStorageLocation).toBeDefined()
+  })
+
+  it('should persist the created storage location', async () => {
+    const {
+      session: { accessToken },
+    } = await createTestUser(testModule!, {
+      username: 'stgpersist',
+      password: '123',
+      admin: true,
+    })
+
+    const s3Config = testModule!.testS3ClientConfig()
+    const bucketName = await testModule!.initMinioTestBucket()
+
+    await apiClient(accessToken).POST('/api/v1/server/server-storage', {
+      body: {
+        accessKeyId: s3Config.accessKeyId,
+        secretAccessKey: s3Config.secretAccessKey,
+        endpoint: s3Config.endpoint,
+        bucket: bucketName,
+        region: s3Config.region,
+        prefix: null,
+      },
+    })
+
+    const getRes = await apiClient(accessToken).GET(
+      '/api/v1/server/server-storage',
+    )
+    expect(getRes.response.status).toBe(200)
+    expect(getRes.data?.serverStorageLocation).toBeDefined()
+  })
+
+  it('should reject invalid endpoint URL', async () => {
+    const {
+      session: { accessToken },
+    } = await createTestUser(testModule!, {
+      username: 'stgbadurl',
+      password: '123',
+      admin: true,
+    })
+
+    const res = await apiClient(accessToken).POST(
+      '/api/v1/server/server-storage',
+      {
+        body: {
+          accessKeyId: 'test',
+          secretAccessKey: 'test',
+          endpoint: 'not-a-url',
+          bucket: 'test',
+          region: 'us-east-1',
+          prefix: null,
+        },
+      },
+    )
+    expect([400, 422]).toContain(res.response.status)
+  })
+})

--- a/packages/api/src/server/server-storage-crud.e2e-spec.ts
+++ b/packages/api/src/server/server-storage-crud.e2e-spec.ts
@@ -1,0 +1,100 @@
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'bun:test'
+import type { TestApiClient, TestModule } from 'src/test/test.types'
+import { buildTestModule, createTestUser } from 'src/test/test.util'
+
+const TEST_MODULE_KEY = 'srv_stg_crud'
+
+describe('Server Storage Get & Delete', () => {
+  let testModule: TestModule | undefined
+  let apiClient: TestApiClient
+
+  beforeAll(async () => {
+    testModule = await buildTestModule({ testModuleKey: TEST_MODULE_KEY })
+    apiClient = testModule.apiClient
+  })
+
+  afterEach(async () => {
+    await testModule?.resetAppState()
+    testModule?.cleanupMinioTestBuckets()
+  })
+
+  afterAll(async () => {
+    await testModule?.shutdown()
+  })
+
+  it('should require authentication for get server storage', async () => {
+    const res = await apiClient().GET('/api/v1/server/server-storage')
+    expect(res.response.status).toBe(401)
+  })
+
+  it('should get server storage location after setting it', async () => {
+    const {
+      session: { accessToken },
+    } = await createTestUser(testModule!, {
+      username: 'ssget',
+      password: '123',
+      admin: true,
+    })
+
+    await testModule!.setServerStorageLocation()
+
+    const res = await apiClient(accessToken).GET(
+      '/api/v1/server/server-storage',
+    )
+    expect(res.response.status).toBe(200)
+    expect(res.data?.serverStorageLocation).toBeDefined()
+  })
+
+  it('should get null server storage when not set', async () => {
+    const {
+      session: { accessToken },
+    } = await createTestUser(testModule!, {
+      username: 'ssnull',
+      password: '123',
+      admin: true,
+    })
+
+    const res = await apiClient(accessToken).GET(
+      '/api/v1/server/server-storage',
+    )
+    expect(res.response.status).toBe(200)
+  })
+
+  it('should delete server storage location', async () => {
+    const {
+      session: { accessToken },
+    } = await createTestUser(testModule!, {
+      username: 'ssdelete',
+      password: '123',
+      admin: true,
+    })
+
+    await testModule!.setServerStorageLocation()
+
+    const deleteRes = await apiClient(accessToken).DELETE(
+      '/api/v1/server/server-storage',
+    )
+    expect(deleteRes.response.status).toBe(200)
+
+    // Verify it's gone
+    const getRes = await apiClient(accessToken).GET(
+      '/api/v1/server/server-storage',
+    )
+    expect(getRes.response.status).toBe(200)
+    expect(getRes.data?.serverStorageLocation).toBeFalsy()
+  })
+
+  it('should require admin for delete', async () => {
+    const {
+      session: { accessToken },
+    } = await createTestUser(testModule!, {
+      username: 'ssnonadmin',
+      password: '123',
+    })
+
+    const res = await apiClient(accessToken).DELETE(
+      '/api/v1/server/server-storage',
+    )
+    expect(res.response.status).toBe(401)
+  })
+})

--- a/packages/api/src/server/server-tasks.e2e-spec.ts
+++ b/packages/api/src/server/server-tasks.e2e-spec.ts
@@ -1,0 +1,83 @@
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'bun:test'
+import { v4 as uuidV4 } from 'uuid'
+import type { TestApiClient, TestModule } from 'src/test/test.types'
+import { buildTestModule, createTestUser } from 'src/test/test.util'
+
+const TEST_MODULE_KEY = 'server_tasks'
+
+describe('Server Tasks', () => {
+  let testModule: TestModule | undefined
+  let apiClient: TestApiClient
+
+  beforeAll(async () => {
+    testModule = await buildTestModule({ testModuleKey: TEST_MODULE_KEY })
+    apiClient = testModule.apiClient
+  })
+
+  afterEach(async () => {
+    await testModule?.resetAppState()
+  })
+
+  afterAll(async () => {
+    await testModule?.shutdown()
+  })
+
+  it('should require authentication for server tasks list', async () => {
+    const response = await apiClient().GET('/api/v1/server/tasks')
+    expect(response.response.status).toEqual(401)
+  })
+
+  it('should require admin role for server tasks list', async () => {
+    const {
+      session: { accessToken },
+    } = await createTestUser(testModule!, { username: 'nonadmin', password: '123' })
+
+    const response = await apiClient(accessToken).GET('/api/v1/server/tasks')
+    expect(response.response.status).toEqual(401)
+  })
+
+  it('should list tasks for admin', async () => {
+    const {
+      session: { accessToken },
+    } = await createTestUser(testModule!, {
+      username: 'taskadmin',
+      password: '123',
+      admin: true,
+    })
+
+    const response = await apiClient(accessToken).GET('/api/v1/server/tasks')
+    expect(response.response.status).toEqual(200)
+    expect(response.data?.result).toBeArray()
+    expect(response.data?.meta).toBeDefined()
+  })
+
+  it('should return empty list when no tasks exist', async () => {
+    const {
+      session: { accessToken },
+    } = await createTestUser(testModule!, {
+      username: 'taskadmin2',
+      password: '123',
+      admin: true,
+    })
+
+    const response = await apiClient(accessToken).GET('/api/v1/server/tasks')
+    expect(response.response.status).toEqual(200)
+    expect(response.data?.meta.totalCount).toEqual(0)
+  })
+
+  it('should return 404 for non-existent task', async () => {
+    const {
+      session: { accessToken },
+    } = await createTestUser(testModule!, {
+      username: 'taskadmin3',
+      password: '123',
+      admin: true,
+    })
+
+    const response = await apiClient(accessToken).GET(
+      '/api/v1/server/tasks/{taskId}',
+      { params: { path: { taskId: uuidV4() } } },
+    )
+    expect(response.response.status).toEqual(404)
+  })
+})

--- a/packages/api/src/server/storage-provisions-detail.e2e-spec.ts
+++ b/packages/api/src/server/storage-provisions-detail.e2e-spec.ts
@@ -1,0 +1,120 @@
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'bun:test'
+import { v4 as uuidV4 } from 'uuid'
+import type { TestApiClient, TestModule } from 'src/test/test.types'
+import { buildTestModule, createTestUser } from 'src/test/test.util'
+
+const TEST_MODULE_KEY = 'sp_detail'
+
+describe('Storage Provisions List & Detail', () => {
+  let testModule: TestModule | undefined
+  let apiClient: TestApiClient
+
+  beforeAll(async () => {
+    testModule = await buildTestModule({ testModuleKey: TEST_MODULE_KEY })
+    apiClient = testModule.apiClient
+  })
+
+  afterEach(async () => {
+    await testModule?.resetAppState()
+    testModule?.cleanupMinioTestBuckets()
+  })
+
+  afterAll(async () => {
+    await testModule?.shutdown()
+  })
+
+  it('should require authentication for list', async () => {
+    const res = await apiClient().GET('/api/v1/server/storage-provisions')
+    expect(res.response.status).toBe(401)
+  })
+
+  it('should list storage provisions as admin', async () => {
+    const {
+      session: { accessToken },
+    } = await createTestUser(testModule!, {
+      username: 'spadmin',
+      password: '123',
+      admin: true,
+    })
+
+    const s3Config = testModule!.testS3ClientConfig()
+    const bucketName = await testModule!.initMinioTestBucket()
+
+    // Create a provision first
+    await apiClient(accessToken).POST('/api/v1/server/storage-provisions', {
+      body: {
+        accessKeyId: s3Config.accessKeyId,
+        secretAccessKey: s3Config.secretAccessKey,
+        endpoint: s3Config.endpoint,
+        bucket: bucketName,
+        region: s3Config.region,
+        prefix: '',
+        label: 'test-provision',
+        description: 'Test',
+        provisionTypes: ['CONTENT'],
+      },
+    })
+
+    const res = await apiClient(accessToken).GET(
+      '/api/v1/server/storage-provisions',
+    )
+    expect(res.response.status).toBe(200)
+    expect(res.data?.result).toBeArray()
+    expect(res.data!.result.length).toBeGreaterThanOrEqual(1)
+  })
+
+  it('should get a storage provision by id', async () => {
+    const {
+      session: { accessToken },
+    } = await createTestUser(testModule!, {
+      username: 'spgetadmin',
+      password: '123',
+      admin: true,
+    })
+
+    const s3Config = testModule!.testS3ClientConfig()
+    const bucketName = await testModule!.initMinioTestBucket()
+
+    const createRes = await apiClient(accessToken).POST(
+      '/api/v1/server/storage-provisions',
+      {
+        body: {
+          accessKeyId: s3Config.accessKeyId,
+          secretAccessKey: s3Config.secretAccessKey,
+          endpoint: s3Config.endpoint,
+          bucket: bucketName,
+          region: s3Config.region,
+          prefix: '',
+          label: 'get-provision',
+          description: 'Test',
+          provisionTypes: ['CONTENT'],
+        },
+      },
+    )
+    const provisionId = createRes.data!.result[0]!.id
+
+    const res = await apiClient(accessToken).GET(
+      '/api/v1/server/storage-provisions/{storageProvisionId}',
+      { params: { path: { storageProvisionId: provisionId } } },
+    )
+    expect(res.response.status).toBe(200)
+    expect(res.data?.storageProvision).toBeDefined()
+    expect(res.data!.storageProvision.id).toBe(provisionId)
+  })
+
+  it('should return 404 for non-existent provision', async () => {
+    const {
+      session: { accessToken },
+    } = await createTestUser(testModule!, {
+      username: 'sp404admin',
+      password: '123',
+      admin: true,
+    })
+
+    const res = await apiClient(accessToken).GET(
+      '/api/v1/server/storage-provisions/{storageProvisionId}',
+      { params: { path: { storageProvisionId: uuidV4() } } },
+    )
+    expect(res.response.status).toBe(404)
+  })
+})

--- a/packages/api/src/storage/access-key-detail.e2e-spec.ts
+++ b/packages/api/src/storage/access-key-detail.e2e-spec.ts
@@ -1,0 +1,158 @@
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'bun:test'
+import type { TestApiClient, TestModule } from 'src/test/test.types'
+import {
+  buildTestModule,
+  createTestFolder,
+  createTestUser,
+} from 'src/test/test.util'
+
+import { buildAccessKeyHashId } from './access-key.utils'
+
+const TEST_MODULE_KEY = 'ak_detail'
+
+describe('Access Key Detail, Rotate & Buckets', () => {
+  let testModule: TestModule | undefined
+  let apiClient: TestApiClient
+
+  beforeAll(async () => {
+    testModule = await buildTestModule({ testModuleKey: TEST_MODULE_KEY })
+    apiClient = testModule.apiClient
+  })
+
+  afterEach(async () => {
+    await testModule?.resetAppState()
+    testModule?.cleanupMinioTestBuckets()
+  })
+
+  afterAll(async () => {
+    await testModule?.shutdown()
+  })
+
+  it('should require authentication for get access key', async () => {
+    const res = await apiClient().GET(
+      '/api/v1/access-keys/{accessKeyHashId}',
+      { params: { path: { accessKeyHashId: 'fake' } } },
+    )
+    expect(res.response.status).toBe(401)
+  })
+
+  it('should get an access key by hash id', async () => {
+    const {
+      session: { accessToken },
+    } = await createTestUser(testModule!, {
+      username: 'akdetail',
+      password: '123',
+    })
+
+    await createTestFolder({
+      testModule: testModule!,
+      accessToken,
+      apiClient,
+      folderName: 'AKFolder',
+      mockFiles: [],
+    })
+
+    const s3Config = testModule!.testS3ClientConfig()
+    const hashId = buildAccessKeyHashId({
+      accessKeyId: s3Config.accessKeyId,
+      secretAccessKey: s3Config.secretAccessKey,
+      region: s3Config.region,
+      endpoint: s3Config.endpoint,
+    })
+
+    const res = await apiClient(accessToken).GET(
+      '/api/v1/access-keys/{accessKeyHashId}',
+      { params: { path: { accessKeyHashId: hashId } } },
+    )
+    expect(res.response.status).toBe(200)
+    expect(res.data?.accessKey).toBeDefined()
+    expect(res.data!.accessKey.accessKeyHashId).toBe(hashId)
+  })
+
+  it('should list buckets for an access key', async () => {
+    const {
+      session: { accessToken },
+    } = await createTestUser(testModule!, {
+      username: 'akbuckets',
+      password: '123',
+    })
+
+    await createTestFolder({
+      testModule: testModule!,
+      accessToken,
+      apiClient,
+      folderName: 'BucketFolder',
+      mockFiles: [],
+    })
+
+    const s3Config = testModule!.testS3ClientConfig()
+    const hashId = buildAccessKeyHashId({
+      accessKeyId: s3Config.accessKeyId,
+      secretAccessKey: s3Config.secretAccessKey,
+      region: s3Config.region,
+      endpoint: s3Config.endpoint,
+    })
+
+    const res = await apiClient(accessToken).GET(
+      '/api/v1/access-keys/{accessKeyHashId}/buckets',
+      { params: { path: { accessKeyHashId: hashId } } },
+    )
+    expect(res.response.status).toBe(200)
+    expect(res.data?.result).toBeArray()
+    expect(res.data!.result.length).toBeGreaterThanOrEqual(1)
+  })
+
+  it('should rotate an access key', async () => {
+    const {
+      session: { accessToken },
+    } = await createTestUser(testModule!, {
+      username: 'akrotate',
+      password: '123',
+    })
+
+    await createTestFolder({
+      testModule: testModule!,
+      accessToken,
+      apiClient,
+      folderName: 'RotateFolder',
+      mockFiles: [],
+    })
+
+    const s3Config = testModule!.testS3ClientConfig()
+    const hashId = buildAccessKeyHashId({
+      accessKeyId: s3Config.accessKeyId,
+      secretAccessKey: s3Config.secretAccessKey,
+      region: s3Config.region,
+      endpoint: s3Config.endpoint,
+    })
+
+    // Rotate to same credentials (since we only have one MinIO key)
+    const res = await apiClient(accessToken).POST(
+      '/api/v1/access-keys/{accessKeyHashId}/rotate',
+      {
+        params: { path: { accessKeyHashId: hashId } },
+        body: {
+          accessKeyId: s3Config.accessKeyId,
+          secretAccessKey: s3Config.secretAccessKey,
+        },
+      },
+    )
+    expect([200, 201]).toContain(res.response.status)
+    expect(res.data?.accessKeyHashId).toBeTruthy()
+  })
+
+  it('should return error for non-existent access key', async () => {
+    const {
+      session: { accessToken },
+    } = await createTestUser(testModule!, {
+      username: 'akmissing',
+      password: '123',
+    })
+
+    const res = await apiClient(accessToken).GET(
+      '/api/v1/access-keys/{accessKeyHashId}',
+      { params: { path: { accessKeyHashId: 'nonexistenthashid' } } },
+    )
+    expect([400, 404]).toContain(res.response.status)
+  })
+})

--- a/packages/api/src/task/server-tasks.e2e-spec.ts
+++ b/packages/api/src/task/server-tasks.e2e-spec.ts
@@ -1,0 +1,117 @@
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'bun:test'
+import type { TestApiClient, TestModule } from 'src/test/test.types'
+import {
+  buildTestModule,
+  createTestFolder,
+  createTestUser,
+  reindexTestFolder,
+} from 'src/test/test.util'
+import { CoreTaskName } from 'src/task/task.constants'
+
+const TEST_MODULE_KEY = 'srv_tasks'
+
+describe('Server Tasks List & Get', () => {
+  let testModule: TestModule | undefined
+  let apiClient: TestApiClient
+
+  beforeAll(async () => {
+    testModule = await buildTestModule({ testModuleKey: TEST_MODULE_KEY })
+    apiClient = testModule.apiClient
+  })
+
+  afterEach(async () => {
+    await testModule?.resetAppState()
+    testModule?.cleanupMinioTestBuckets()
+  })
+
+  afterAll(async () => {
+    await testModule?.shutdown()
+  })
+
+  it('should require authentication for list tasks', async () => {
+    const res = await apiClient().GET('/api/v1/server/tasks')
+    expect(res.response.status).toBe(401)
+  })
+
+  it('should require admin for list tasks', async () => {
+    const {
+      session: { accessToken },
+    } = await createTestUser(testModule!, {
+      username: 'tasknonadm',
+      password: '123',
+    })
+
+    const res = await apiClient(accessToken).GET('/api/v1/server/tasks')
+    expect(res.response.status).toBe(401)
+  })
+
+  it('should list tasks as admin', async () => {
+    const {
+      session: { accessToken },
+    } = await createTestUser(testModule!, {
+      username: 'taskadmin',
+      password: '123',
+      admin: true,
+    })
+
+    const res = await apiClient(accessToken).GET('/api/v1/server/tasks')
+    expect(res.response.status).toBe(200)
+    expect(res.data?.result).toBeArray()
+    expect(res.data?.meta).toBeDefined()
+  })
+
+  it('should get a task by id after reindex creates one', async () => {
+    const {
+      session: { accessToken },
+    } = await createTestUser(testModule!, {
+      username: 'taskgetadm',
+      password: '123',
+      admin: true,
+    })
+
+    await testModule!.setServerStorageLocation()
+
+    const { folder } = await createTestFolder({
+      testModule: testModule!,
+      accessToken,
+      apiClient,
+      folderName: 'TaskTestFolder',
+      mockFiles: [{ objectKey: 'task-test.txt', content: 'data' }],
+    })
+
+    await reindexTestFolder({ accessToken, apiClient, folderId: folder.id })
+    await testModule!.waitForTasks('completed', {
+      taskIdentifiers: [CoreTaskName.ReindexFolder],
+    })
+
+    // List tasks to find a task id
+    const listRes = await apiClient(accessToken).GET('/api/v1/server/tasks')
+    expect(listRes.response.status).toBe(200)
+    expect(listRes.data!.result.length).toBeGreaterThanOrEqual(1)
+
+    const taskId = listRes.data!.result[0]!.id
+
+    const getRes = await apiClient(accessToken).GET(
+      '/api/v1/server/tasks/{taskId}',
+      { params: { path: { taskId } } },
+    )
+    expect(getRes.response.status).toBe(200)
+    expect(getRes.data?.task).toBeDefined()
+    expect(getRes.data!.task.id).toBe(taskId)
+  })
+
+  it('should require admin for get task', async () => {
+    const {
+      session: { accessToken },
+    } = await createTestUser(testModule!, {
+      username: 'taskgetna',
+      password: '123',
+    })
+
+    const res = await apiClient(accessToken).GET(
+      '/api/v1/server/tasks/{taskId}',
+      { params: { path: { taskId: 'fake-task-id' } } },
+    )
+    expect(res.response.status).toBe(401)
+  })
+})

--- a/packages/api/src/users/admin-user-sessions.e2e-spec.ts
+++ b/packages/api/src/users/admin-user-sessions.e2e-spec.ts
@@ -1,0 +1,99 @@
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'bun:test'
+import { v4 as uuidV4 } from 'uuid'
+import type { TestApiClient, TestModule } from 'src/test/test.types'
+import { buildTestModule, createTestUser } from 'src/test/test.util'
+
+const TEST_MODULE_KEY = 'adm_usr_sess'
+
+describe('Admin User Sessions Listing', () => {
+  let testModule: TestModule | undefined
+  let apiClient: TestApiClient
+
+  beforeAll(async () => {
+    testModule = await buildTestModule({ testModuleKey: TEST_MODULE_KEY })
+    apiClient = testModule.apiClient
+  })
+
+  afterEach(async () => {
+    await testModule?.resetAppState()
+  })
+
+  afterAll(async () => {
+    await testModule?.shutdown()
+  })
+
+  async function getViewerUserId(accessToken: string) {
+    const res = await apiClient(accessToken).GET('/api/v1/viewer')
+    return res.data!.user.id
+  }
+
+  it('should require authentication', async () => {
+    const res = await apiClient().GET(
+      '/api/v1/server/users/{userId}/sessions',
+      { params: { path: { userId: uuidV4() } } },
+    )
+    expect(res.response.status).toBe(401)
+  })
+
+  it('should require admin', async () => {
+    const {
+      session: { accessToken },
+    } = await createTestUser(testModule!, {
+      username: 'sessnonadm',
+      password: '123',
+    })
+
+    const userId = await getViewerUserId(accessToken)
+
+    const res = await apiClient(accessToken).GET(
+      '/api/v1/server/users/{userId}/sessions',
+      { params: { path: { userId } } },
+    )
+    expect(res.response.status).toBe(401)
+  })
+
+  it('should list sessions for a user as admin', async () => {
+    const {
+      session: { accessToken: adminToken },
+    } = await createTestUser(testModule!, {
+      username: 'sessadmin',
+      password: '123',
+      admin: true,
+    })
+
+    // Create a target user who will have a session
+    const {
+      session: { accessToken: targetToken },
+    } = await createTestUser(testModule!, {
+      username: 'sesstarget',
+      password: '123',
+    })
+
+    const targetUserId = await getViewerUserId(targetToken)
+
+    const res = await apiClient(adminToken).GET(
+      '/api/v1/server/users/{userId}/sessions',
+      { params: { path: { userId: targetUserId } } },
+    )
+    expect(res.response.status).toBe(200)
+    expect(res.data?.result).toBeArray()
+    expect(res.data!.result.length).toBeGreaterThanOrEqual(1)
+    expect(res.data?.meta).toBeDefined()
+  })
+
+  it('should return error for non-existent user', async () => {
+    const {
+      session: { accessToken },
+    } = await createTestUser(testModule!, {
+      username: 'sess404adm',
+      password: '123',
+      admin: true,
+    })
+
+    const res = await apiClient(accessToken).GET(
+      '/api/v1/server/users/{userId}/sessions',
+      { params: { path: { userId: uuidV4() } } },
+    )
+    expect([400, 404]).toContain(res.response.status)
+  })
+})

--- a/packages/api/src/users/user-sessions.e2e-spec.ts
+++ b/packages/api/src/users/user-sessions.e2e-spec.ts
@@ -1,0 +1,106 @@
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'bun:test'
+import { v4 as uuidV4 } from 'uuid'
+import type { TestApiClient, TestModule } from 'src/test/test.types'
+import { buildTestModule, createTestUser } from 'src/test/test.util'
+
+const TEST_MODULE_KEY = 'user_sessions'
+
+describe('User Sessions (Admin)', () => {
+  let testModule: TestModule | undefined
+  let apiClient: TestApiClient
+
+  beforeAll(async () => {
+    testModule = await buildTestModule({ testModuleKey: TEST_MODULE_KEY })
+    apiClient = testModule.apiClient
+  })
+
+  afterEach(async () => {
+    await testModule?.resetAppState()
+  })
+
+  afterAll(async () => {
+    await testModule?.shutdown()
+  })
+
+  async function getViewerUserId(accessToken: string) {
+    const res = await apiClient(accessToken).GET('/api/v1/viewer')
+    return res.data!.user.id
+  }
+
+  it('should require authentication', async () => {
+    const res = await apiClient().GET(
+      '/api/v1/server/users/{userId}/sessions',
+      {
+        params: { path: { userId: uuidV4() } },
+      },
+    )
+    expect(res.response.status).toBe(401)
+  })
+
+  it('should require admin role', async () => {
+    const {
+      session: { accessToken },
+    } = await createTestUser(testModule!, {
+      username: 'nonadmin',
+      password: '123',
+    })
+
+    const userId = await getViewerUserId(accessToken)
+
+    const res = await apiClient(accessToken).GET(
+      '/api/v1/server/users/{userId}/sessions',
+      { params: { path: { userId } } },
+    )
+    expect(res.response.status).toBe(401)
+  })
+
+  it('should list active sessions for a user', async () => {
+    const {
+      session: { accessToken: adminToken },
+    } = await createTestUser(testModule!, {
+      username: 'sessadmin',
+      password: '123',
+      admin: true,
+    })
+
+    // Create a target user who logs in (creating a session)
+    const {
+      session: { accessToken: targetToken },
+    } = await createTestUser(testModule!, {
+      username: 'sesstarget',
+      password: '123',
+    })
+
+    const targetUserId = await getViewerUserId(targetToken)
+
+    const res = await apiClient(adminToken).GET(
+      '/api/v1/server/users/{userId}/sessions',
+      { params: { path: { userId: targetUserId } } },
+    )
+    expect(res.response.status).toBe(200)
+    expect(res.data?.result).toBeArray()
+    expect(res.data!.result.length).toBeGreaterThanOrEqual(1)
+    expect(res.data!.meta.totalCount).toBeGreaterThanOrEqual(1)
+
+    // Verify session structure
+    const session = res.data!.result[0]!
+    expect(session.createdAt).toBeTruthy()
+    expect(session.expiresAt).toBeTruthy()
+  })
+
+  it('should return 404 for non-existent user', async () => {
+    const {
+      session: { accessToken },
+    } = await createTestUser(testModule!, {
+      username: 'sessadmin2',
+      password: '123',
+      admin: true,
+    })
+
+    const res = await apiClient(accessToken).GET(
+      '/api/v1/server/users/{userId}/sessions',
+      { params: { path: { userId: uuidV4() } } },
+    )
+    expect([404, 400]).toContain(res.response.status)
+  })
+})

--- a/packages/api/src/users/viewer-update.e2e-spec.ts
+++ b/packages/api/src/users/viewer-update.e2e-spec.ts
@@ -1,0 +1,77 @@
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'bun:test'
+import type { TestApiClient, TestModule } from 'src/test/test.types'
+import { buildTestModule, createTestUser } from 'src/test/test.util'
+
+const TEST_MODULE_KEY = 'viewer_update'
+
+describe('Viewer Update', () => {
+  let testModule: TestModule | undefined
+  let apiClient: TestApiClient
+
+  beforeAll(async () => {
+    testModule = await buildTestModule({ testModuleKey: TEST_MODULE_KEY })
+    apiClient = testModule.apiClient
+  })
+
+  afterEach(async () => {
+    await testModule?.resetAppState()
+  })
+
+  afterAll(async () => {
+    await testModule?.shutdown()
+  })
+
+  it('should require authentication', async () => {
+    const res = await apiClient().PUT('/api/v1/viewer', {
+      body: { name: 'New Name' },
+    })
+    expect(res.response.status).toBe(401)
+  })
+
+  it('should update viewer name', async () => {
+    const {
+      session: { accessToken },
+    } = await createTestUser(testModule!, {
+      username: 'viewerupd',
+      password: '123',
+    })
+
+    const res = await apiClient(accessToken).PUT('/api/v1/viewer', {
+      body: { name: 'Updated Name' },
+    })
+    expect(res.response.status).toBe(200)
+    expect(res.data?.user.name).toBe('Updated Name')
+  })
+
+  it('should persist viewer name after update', async () => {
+    const {
+      session: { accessToken },
+    } = await createTestUser(testModule!, {
+      username: 'viewerpersist',
+      password: '123',
+    })
+
+    await apiClient(accessToken).PUT('/api/v1/viewer', {
+      body: { name: 'Persisted Name' },
+    })
+
+    const getRes = await apiClient(accessToken).GET('/api/v1/viewer')
+    expect(getRes.response.status).toBe(200)
+    expect(getRes.data?.user.name).toBe('Persisted Name')
+  })
+
+  it('should allow updating name to empty string', async () => {
+    const {
+      session: { accessToken },
+    } = await createTestUser(testModule!, {
+      username: 'viewerempty',
+      password: '123',
+    })
+
+    const res = await apiClient(accessToken).PUT('/api/v1/viewer', {
+      body: { name: '' },
+    })
+    // Either succeeds or validates - both are acceptable
+    expect([200, 400]).toContain(res.response.status)
+  })
+})


### PR DESCRIPTION
## Summary
- Adds 34 new e2e test spec files across auth, folders, events, server, notifications, apps, users, storage, and logs modules
- ~4500 lines of new test coverage

## Linked issue
LOM-274
