### PR TITLE
feat(lombok): improve app custom settings schema logic

### DIFF
--- a/packages/api/src/app/utils/json-schema-to-zod.util.ts
+++ b/packages/api/src/app/utils/json-schema-to-zod.util.ts
@@ -56,13 +56,59 @@ function primitivePropertyToZod(
   }
 }
 
+function nestedObjectToZod(prop: {
+  type: 'object'
+  properties?: Record<string, unknown>
+  additionalProperties?: unknown
+  required?: string[]
+}): z.ZodType {
+  // additionalProperties: validate all values against a schema (dynamic keys)
+  if (prop.additionalProperties) {
+    // eslint-disable-next-line @typescript-eslint/no-use-before-define, no-use-before-define
+    const valueSchema = objectItemPropertyToZod(
+      prop.additionalProperties as JsonSchema07ObjectItemProperty,
+    )
+    return z.record(z.string(), valueSchema)
+  }
+
+  const properties = prop.properties ?? {}
+  const shape: Record<string, z.ZodType> = {}
+  const requiredKeys = new Set(prop.required ?? [])
+  for (const [key, nestedProp] of Object.entries(properties)) {
+    // eslint-disable-next-line @typescript-eslint/no-use-before-define, no-use-before-define
+    let fieldSchema = objectItemPropertyToZod(
+      nestedProp as JsonSchema07ObjectItemProperty,
+    )
+    if (!requiredKeys.has(key)) {
+      fieldSchema = fieldSchema.optional()
+    }
+    shape[key] = fieldSchema
+  }
+  if (Object.keys(shape).length === 0) {
+    return z.record(z.string(), z.unknown())
+  }
+  return z.object(shape).strict()
+}
+
 function objectItemPropertyToZod(
   prop: JsonSchema07ObjectItemProperty,
 ): z.ZodType {
   if (prop.type === 'array') {
-    const itemZod = primitivePropertyToZod({
-      type: prop.items.type,
-    } as JsonSchema07PrimitiveProperty)
+    let itemZod: z.ZodType
+    if (prop.items.type === 'object') {
+      itemZod = nestedObjectToZod(
+        prop.items as {
+          type: 'object'
+          properties?: Record<string, unknown>
+          additionalProperties?: unknown
+          required?: string[]
+        },
+      )
+    } else {
+      itemZod = primitivePropertyToZod({
+        type: prop.items.type,
+      } as JsonSchema07PrimitiveProperty)
+    }
     let schema = z.array(itemZod)
     if (prop.minItems !== undefined) {
       schema = schema.min(prop.minItems)
@@ -71,6 +117,9 @@ function objectItemPropertyToZod(
       schema = schema.max(prop.maxItems)
     }
     return schema
+  }
+  if (prop.type === 'object') {
+    return nestedObjectToZod(prop)
   }
   return primitivePropertyToZod(prop)
 }
@@ -107,6 +156,10 @@ function discriminatedObjectItemToZod(
 }
 
 function propertyToZod(prop: JsonSchema07Property): z.ZodType {
+  if (prop.type === 'object') {
+    return nestedObjectToZod(prop)
+  }
+
   if (prop.type !== 'array') {
     return primitivePropertyToZod(prop)
   }

--- a/packages/api/src/app/utils/json-schema-to-zod.util.unit-spec.ts
+++ b/packages/api/src/app/utils/json-schema-to-zod.util.unit-spec.ts
@@ -331,6 +331,223 @@ describe('jsonSchemaToZod', () => {
     ).toBe(false)
   })
 
+  it('should convert top-level object property with known keys', () => {
+    const schema: JsonSchema07Object = {
+      type: 'object',
+      properties: {
+        DEFAULTS: {
+          type: 'object',
+          properties: {
+            default: { type: 'string' },
+            code_small: { type: 'string' },
+            reasoning: { type: 'string' },
+          },
+        },
+      },
+    }
+    const zod = jsonSchemaToZod(schema)
+    expect(
+      zod.safeParse({
+        DEFAULTS: {
+          default: 'anthropic/claude-sonnet-4-6',
+          code_small: 'openai/gpt-4.1-mini',
+        },
+      }).success,
+    ).toBe(true)
+    expect(zod.safeParse({ DEFAULTS: { default: 123 } }).success).toBe(false)
+    // Strict: rejects unknown keys
+    expect(
+      zod.safeParse({ DEFAULTS: { default: 'x', unknown_role: 'y' } }).success,
+    ).toBe(false)
+  })
+
+  it('should convert top-level object property with empty properties as passthrough', () => {
+    const schema: JsonSchema07Object = {
+      type: 'object',
+      properties: {
+        META: {
+          type: 'object',
+        },
+      },
+    }
+    const zod = jsonSchemaToZod(schema)
+    expect(zod.safeParse({ META: { anything: 'goes' } }).success).toBe(true)
+    expect(zod.safeParse({ META: {} }).success).toBe(true)
+    expect(zod.safeParse({ META: 'string' }).success).toBe(false)
+  })
+
+  it('should convert object with additionalProperties to validate values', () => {
+    const schema: JsonSchema07Object = {
+      type: 'object',
+      properties: {
+        MODELS: {
+          type: 'object',
+          additionalProperties: {
+            type: 'object',
+            properties: {
+              name: { type: 'string' },
+              reasoning: { type: 'boolean' },
+            },
+            required: ['name', 'reasoning'],
+          },
+        },
+      },
+    }
+    const zod = jsonSchemaToZod(schema)
+    // Valid: values match schema
+    expect(
+      zod.safeParse({
+        MODELS: {
+          'anthropic/claude-sonnet-4-6': {
+            name: 'Claude Sonnet 4.6',
+            reasoning: true,
+          },
+          'openai/gpt-5.4': { name: 'GPT 5.4', reasoning: true },
+        },
+      }).success,
+    ).toBe(true)
+    expect(zod.safeParse({ MODELS: {} }).success).toBe(true)
+    // Invalid: missing required field
+    expect(
+      zod.safeParse({
+        MODELS: { 'openai/gpt-5.4': { name: 'GPT 5.4' } },
+      }).success,
+    ).toBe(false)
+    // Invalid: wrong type
+    expect(
+      zod.safeParse({
+        MODELS: { 'openai/gpt-5.4': { name: 123, reasoning: true } },
+      }).success,
+    ).toBe(false)
+    // Invalid: not an object
+    expect(zod.safeParse({ MODELS: 'string' }).success).toBe(false)
+  })
+
+  it('should convert object property with required fields', () => {
+    const schema: JsonSchema07Object = {
+      type: 'object',
+      properties: {
+        config: {
+          type: 'object',
+          properties: {
+            name: { type: 'string' },
+            port: { type: 'integer' },
+          },
+          required: ['name'],
+        },
+      },
+    }
+    const zod = jsonSchemaToZod(schema)
+    expect(zod.safeParse({ config: { name: 'test' } }).success).toBe(true)
+    expect(
+      zod.safeParse({ config: { name: 'test', port: 8080 } }).success,
+    ).toBe(true)
+    // Missing required 'name'
+    expect(zod.safeParse({ config: { port: 8080 } }).success).toBe(false)
+  })
+
+  it('should convert nested object within object item in array', () => {
+    const schema: JsonSchema07Object = {
+      type: 'object',
+      properties: {
+        providers: {
+          type: 'array',
+          items: {
+            type: 'object',
+            properties: {
+              TYPE: { type: 'string' },
+              DEFAULTS: {
+                type: 'object',
+                properties: {
+                  default: { type: 'string' },
+                  code_large: { type: 'string' },
+                },
+              },
+            },
+            required: ['TYPE'],
+          },
+        },
+      },
+    }
+    const zod = jsonSchemaToZod(schema)
+    expect(
+      zod.safeParse({
+        providers: [
+          {
+            TYPE: 'openai',
+            DEFAULTS: { default: 'gpt-5.4', code_large: 'gpt-5.3-codex' },
+          },
+        ],
+      }).success,
+    ).toBe(true)
+    expect(
+      zod.safeParse({
+        providers: [{ TYPE: 'openai' }],
+      }).success,
+    ).toBe(true)
+    // Wrong type for nested field
+    expect(
+      zod.safeParse({
+        providers: [{ TYPE: 'openai', DEFAULTS: { default: 123 } }],
+      }).success,
+    ).toBe(false)
+  })
+
+  it('should convert object with additionalProperties within array item', () => {
+    const schema: JsonSchema07Object = {
+      type: 'object',
+      properties: {
+        providers: {
+          type: 'array',
+          items: {
+            type: 'object',
+            properties: {
+              TYPE: { type: 'string' },
+              MODELS: {
+                type: 'object',
+                additionalProperties: {
+                  type: 'object',
+                  properties: {
+                    name: { type: 'string' },
+                    reasoning: { type: 'boolean' },
+                  },
+                  required: ['name'],
+                },
+              },
+            },
+            required: ['TYPE'],
+          },
+        },
+      },
+    }
+    const zod = jsonSchemaToZod(schema)
+    // Valid
+    expect(
+      zod.safeParse({
+        providers: [
+          {
+            TYPE: 'openai_compatible',
+            MODELS: {
+              'anthropic/claude-sonnet-4-6': { name: 'Claude Sonnet' },
+              'openai/gpt-5.4': { name: 'GPT 5.4', reasoning: true },
+            },
+          },
+        ],
+      }).success,
+    ).toBe(true)
+    // Missing required 'name' in value
+    expect(
+      zod.safeParse({
+        providers: [
+          {
+            TYPE: 'openai_compatible',
+            MODELS: { 'openai/gpt-5.4': { reasoning: true } },
+          },
+        ],
+      }).success,
+    ).toBe(false)
+  })
+
   it('should validate mixed discriminated union items in same array', () => {
     const schema: JsonSchema07Object = {
       type: 'object',
@@ -411,6 +628,32 @@ describe('jsonSchemaToPartialZod', () => {
     expect(zod.safeParse({ ANTHROPIC_API_KEY_1234: 'sk-abc' }).success).toBe(
       true,
     )
+  })
+
+  it('should make object properties optional and nullable in partial mode', () => {
+    const schema: JsonSchema07Object = {
+      type: 'object',
+      properties: {
+        DEFAULTS: {
+          type: 'object',
+          properties: {
+            default: { type: 'string' },
+          },
+        },
+        MODELS: {
+          type: 'object',
+          properties: {},
+        },
+      },
+    }
+    const zod = jsonSchemaToPartialZod(schema)
+    expect(zod.safeParse({}).success).toBe(true)
+    expect(zod.safeParse({ DEFAULTS: null }).success).toBe(true)
+    expect(zod.safeParse({ MODELS: null }).success).toBe(true)
+    expect(
+      zod.safeParse({ DEFAULTS: { default: 'anthropic/claude-sonnet-4-6' } })
+        .success,
+    ).toBe(true)
   })
 
   it('should reject unknown keys even in partial mode', () => {

--- a/packages/types/src/apps.types.ts
+++ b/packages/types/src/apps.types.ts
@@ -315,26 +315,80 @@ export type JsonSchema07PrimitiveProperty = z.infer<
 >
 
 /**
- * Property schema for object items — primitives plus primitive-typed arrays.
- * Allows e.g. `MODELS: { type: 'array', items: { type: 'string' } }` inside object items.
+ * Property schema for object items — primitives, primitive-typed arrays,
+ * and nested objects (with primitive/primitive-array properties).
+ * Allows e.g. `THINGS: { type: 'array', items: { type: 'string' } }` inside object items.
  */
-export const jsonSchema07ObjectItemPropertySchema = z.union([
-  jsonSchema07PrimitivePropertySchema,
-  z.object({
-    type: z.literal('array'),
-    description: z.string().optional(),
-    default: z.array(z.unknown()).optional(),
-    items: z.object({
-      type: z.enum(['string', 'number', 'integer', 'boolean']),
-    }),
-    minItems: z.number().int().min(0).optional(),
-    maxItems: z.number().int().min(0).optional(),
-  }),
-])
+export type JsonSchema07ObjectItemProperty =
+  | z.infer<typeof jsonSchema07PrimitivePropertySchema>
+  | {
+      type: 'array'
+      description?: string
+      default?: unknown[]
+      items:
+        | { type: 'string' | 'number' | 'integer' | 'boolean' }
+        | {
+            type: 'object'
+            properties?: Record<string, JsonSchema07ObjectItemProperty>
+            additionalProperties?: JsonSchema07ObjectItemProperty
+            required?: string[]
+          }
+      minItems?: number
+      maxItems?: number
+    }
+  | {
+      type: 'object'
+      description?: string
+      default?: Record<string, unknown>
+      properties?: Record<string, JsonSchema07ObjectItemProperty>
+      additionalProperties?: JsonSchema07ObjectItemProperty
+      required?: string[]
+    }
 
-export type JsonSchema07ObjectItemProperty = z.infer<
-  typeof jsonSchema07ObjectItemPropertySchema
->
+export const jsonSchema07ObjectItemPropertySchema: z.ZodType<JsonSchema07ObjectItemProperty> =
+  z.union([
+    jsonSchema07PrimitivePropertySchema,
+    z.object({
+      type: z.literal('array'),
+      description: z.string().optional(),
+      default: z.array(z.unknown()).optional(),
+      items: z.union([
+        z.object({
+          type: z.enum(['string', 'number', 'integer', 'boolean']),
+        }),
+        z.object({
+          type: z.literal('object'),
+          properties: z
+            .record(
+              z.string(),
+              z.lazy(() => jsonSchema07ObjectItemPropertySchema),
+            )
+            .optional(),
+          additionalProperties: z
+            .lazy(() => jsonSchema07ObjectItemPropertySchema)
+            .optional(),
+          required: z.array(z.string()).optional(),
+        }),
+      ]),
+      minItems: z.number().int().min(0).optional(),
+      maxItems: z.number().int().min(0).optional(),
+    }),
+    z.object({
+      type: z.literal('object'),
+      description: z.string().optional(),
+      default: z.record(z.string(), z.unknown()).optional(),
+      properties: z
+        .record(
+          z.string(),
+          z.lazy(() => jsonSchema07ObjectItemPropertySchema),
+        )
+        .optional(),
+      additionalProperties: z
+        .lazy(() => jsonSchema07ObjectItemPropertySchema)
+        .optional(),
+      required: z.array(z.string()).optional(),
+    }),
+  ])
 
 /**
  * Schema for object items within arrays.
@@ -382,6 +436,16 @@ export const jsonSchema07PropertySchema = z.union([
     ]),
     minItems: z.number().int().min(0).optional(),
     maxItems: z.number().int().min(0).optional(),
+  }),
+  z.object({
+    type: z.literal('object'),
+    description: z.string().optional(),
+    default: z.record(z.string(), z.unknown()).optional(),
+    properties: z
+      .record(z.string(), jsonSchema07ObjectItemPropertySchema)
+      .optional(),
+    additionalProperties: jsonSchema07ObjectItemPropertySchema.optional(),
+    required: z.array(z.string()).optional(),
   }),
 ])
 

--- a/packages/ui/src/components/custom-settings-form/custom-settings-form.tsx
+++ b/packages/ui/src/components/custom-settings-form/custom-settings-form.tsx
@@ -265,6 +265,10 @@ function ObjectItemPropertyInput({
       />
     )
   }
+  if (property.type === 'object') {
+    // Nested object settings are not yet supported in the UI
+    return null
+  }
   return (
     <PrimitiveFieldInput
       id={id}


### PR DESCRIPTION
## Summary
- Extend JSON Schema to Zod converter to support nested objects, `additionalProperties` (dynamic keys), and recursive object structures in app custom settings schemas
- Add `nestedObjectToZod` function and update type definitions to be recursive
- Add comprehensive unit tests for all new nested object scenarios

Resolves LOM-278

## Test plan
- [ ] Existing json-schema-to-zod unit tests pass
- [ ] New nested object tests pass (top-level objects, additionalProperties, required fields, nested in arrays)