### PR TITLE
feat(lombok): add container security options and caller sub-path routing

### DIFF
--- a/docker/docker-bridge/src/docker/adapter.ts
+++ b/docker/docker-bridge/src/docker/adapter.ts
@@ -31,6 +31,8 @@ export interface CreateContainerOptions {
   volumes?: string[]
   networkMode?: string
   gpus?: { driver: string; deviceIds: string[] }
+  capAdd?: string[]
+  securityOpt?: string[]
 }
 
 export interface BridgeContainerInfo {

--- a/docker/docker-bridge/src/docker/dockerode-adapter.ts
+++ b/docker/docker-bridge/src/docker/dockerode-adapter.ts
@@ -267,6 +267,8 @@ export class DockerodeAdapter implements DockerAdapter {
         ExtraHosts: options.extraHosts,
         Binds: options.volumes,
         NetworkMode: options.networkMode,
+        CapAdd: options.capAdd,
+        SecurityOpt: options.securityOpt,
       },
     }
 

--- a/packages/api/src/core/config/core.config.ts
+++ b/packages/api/src/core/config/core.config.ts
@@ -57,6 +57,8 @@ export const dockerHostConfigSchema = z
             env: z
               .record(z.string(), z.record(z.string(), z.string()))
               .optional(), // the environment variables assigned to app container profiles. e.g. {'app:content_indexing': { 'PRIVATE_KEY': '___' }}
+            capAdd: z.record(z.string(), z.string().array()).optional(), // Linux capabilities to add per profile. e.g. {'coder:lombok_codicle_agent': ['SYS_ADMIN']}
+            securityOpt: z.record(z.string(), z.string().array()).optional(), // Docker security options per profile. e.g. {'coder:lombok_codicle_agent': ['apparmor=unconfined']}
           })
           .strict(),
       )

--- a/packages/api/src/docker/dto/docker-route-app-container-request.dto.ts
+++ b/packages/api/src/docker/dto/docker-route-app-container-request.dto.ts
@@ -3,6 +3,10 @@ import { z } from 'zod'
 
 export const dockerRouteAppContainerRequestSchema = z.object({
   requestId: z.string().regex(/^[a-zA-Z0-9_-]+$/),
+  callerSubPath: z
+    .string()
+    .regex(/^[a-zA-Z0-9_-]+$/)
+    .optional(),
 })
 
 export class DockerRouteAppContainerRequestDTO extends createZodDto(

--- a/packages/api/src/docker/services/client/docker-client.service.ts
+++ b/packages/api/src/docker/services/client/docker-client.service.ts
@@ -192,6 +192,8 @@ export class DockerClientService {
         volumes: options.volumes,
         networkMode: options.networkMode,
         gpus: options.gpus,
+        capAdd: options.capAdd,
+        securityOpt: options.securityOpt,
       },
     )
     return toBridgeContainerInfo(result)

--- a/packages/api/src/docker/services/client/docker-client.types.ts
+++ b/packages/api/src/docker/services/client/docker-client.types.ts
@@ -18,6 +18,8 @@ export interface FindOrCreateContainerOptions {
   volumes?: string[]
   networkMode?: 'host' | 'bridge' | `container:${string}`
   gpus?: { driver: string; deviceIds: string[] }
+  capAdd?: string[]
+  securityOpt?: string[]
   startIfNotRunning?: boolean
 }
 

--- a/packages/api/src/docker/services/docker-jobs.service.ts
+++ b/packages/api/src/docker/services/docker-jobs.service.ts
@@ -259,6 +259,8 @@ export class DockerJobsService {
     gpus: { driver: string; deviceIds: string[] } | undefined
     extraHosts: string[] | undefined
     networkMode: 'host' | 'bridge' | `container:${string}` | undefined
+    capAdd: string[] | undefined
+    securityOpt: string[] | undefined
   } {
     const profileKeyParts = profileKey.split(':')
     const appSlugProfileKey = `${profileKeyParts[0]?.split('_')[0]}:${profileKeyParts[1]}`
@@ -308,6 +310,18 @@ export class DockerJobsService {
         | 'bridge'
         | `container:${string}`
         | undefined,
+      capAdd:
+        this._coreConfig.dockerHostConfig.hosts?.[resolvedHostId]?.capAdd?.[
+          profileKey
+        ] ??
+        this._coreConfig.dockerHostConfig.hosts?.[resolvedHostId]?.capAdd?.[
+          appSlugProfileKey
+        ],
+      securityOpt:
+        this._coreConfig.dockerHostConfig.hosts?.[resolvedHostId]
+          ?.securityOpt?.[profileKey] ??
+        this._coreConfig.dockerHostConfig.hosts?.[resolvedHostId]
+          ?.securityOpt?.[appSlugProfileKey],
     }
   }
 

--- a/packages/api/src/docker/services/docker-worker-hook.service.ts
+++ b/packages/api/src/docker/services/docker-worker-hook.service.ts
@@ -628,10 +628,14 @@ export class DockerWorkerHookService {
       const { appIdentifier, hostId, containerId, userId } = claims
 
       // 1. Exec into container to read the request context
+      // When callerSubPath is provided, read from a caller-specific subdirectory
+      const relayDir = body.callerSubPath
+        ? `/tmp/lombok-relay-requests/${body.callerSubPath}`
+        : '/tmp/lombok-relay-requests'
       const loadRequestContext = await this.dockerClientService.execInContainer(
         hostId,
         containerId,
-        ['cat', `/tmp/lombok-relay-requests/${body.requestId}.json`],
+        ['cat', `${relayDir}/${body.requestId}.json`],
       )
       if (loadRequestContext.exitCode !== 0) {
         throw new NotFoundException(

--- a/packages/api/src/openapi.json
+++ b/packages/api/src/openapi.json
@@ -34713,6 +34713,10 @@
           "requestId": {
             "type": "string",
             "pattern": "^[a-zA-Z0-9_-]+$"
+          },
+          "callerSubPath": {
+            "type": "string",
+            "pattern": "^[a-zA-Z0-9_-]+$"
           }
         },
         "required": [

--- a/packages/types/src/api-paths.d.ts
+++ b/packages/types/src/api-paths.d.ts
@@ -7956,6 +7956,7 @@ export interface components {
         };
         DockerRouteAppContainerRequestDTO: {
             requestId: string;
+            callerSubPath?: string;
         };
         DockerRouteAppContainerResponseDTO: {
             status: number;


### PR DESCRIPTION
## Summary
- Add `capAdd` and `securityOpt` per-profile config for Docker containers (Linux capabilities and AppArmor control)
- Add `callerSubPath` optional field to relay request routing for caller-specific subdirectories
- Thread new options through bridge adapter, client types, jobs service, and worker hook service

Resolves LOM-279

## Test plan
- [x] tsc passes
- [x] prettier passes
- [x] API e2e tests pass (505 tests)