### PR TITLE
fix(lombok): don't send job token for non-task docker jobs

### DIFF
--- a/packages/api/src/docker/services/docker-jobs.service.ts
+++ b/packages/api/src/docker/services/docker-jobs.service.ts
@@ -633,7 +633,10 @@ export class DockerJobsService {
         job_id: jobId,
         job_class: jobIdentifier,
         job_input: jobData,
-        job_token: jobToken,
+        // Only include job_token + platform_url when there's a platform-side
+        // task to track. Without a task, there's nothing to send lifecycle
+        // signals to and no reason to issue presigned URLs.
+        job_token: params.asyncTaskId ? jobToken : undefined,
         worker_command: jobDefinition.command,
         interface:
           jobDefinition.kind === 'http'
@@ -644,9 +647,9 @@ export class DockerJobsService {
             : {
                 kind: 'exec_per_job',
               },
-        platform_url: !jobToken
-          ? undefined
-          : buildPlatformOrigin(this._coreConfig),
+        platform_url: params.asyncTaskId
+          ? buildPlatformOrigin(this._coreConfig)
+          : undefined,
         output_location: params.storageAccessPolicy?.outputLocation
           ? {
               folder_id: params.storageAccessPolicy.outputLocation.folderId,

--- a/packages/api/src/docker/tests/docker.e2e-spec.ts
+++ b/packages/api/src/docker/tests/docker.e2e-spec.ts
@@ -53,8 +53,6 @@ const parseJobPayload = (payload: string) => {
       | undefined
   }
 
-  expect(parsedPaylod.job_token?.length).toBeGreaterThan(0)
-  expect(parsedPaylod.platform_url?.length).toBeGreaterThan(0)
   expect(parsedPaylod.job_id?.length).toBeGreaterThan(0)
   expect(parsedPaylod.job_class?.length).toBeGreaterThan(0)
   expect(parsedPaylod.interface?.kind).toBeDefined()
@@ -402,10 +400,8 @@ describe('Docker Jobs', () => {
 
     expect(payload).toEqual({
       jobId: expect.any(String),
-      jobToken: expect.any(String),
       jobIdentifier: 'test_job',
       jobInterface: { kind: 'exec_per_job' },
-      platformURL: 'http://localhost:3000',
       jobData: {},
     })
 
@@ -456,8 +452,6 @@ describe('Docker Jobs', () => {
       jobIdentifier: 'test_job_other',
       jobInterface: { kind: 'exec_per_job' },
       jobData: {},
-      jobToken: expect.any(String),
-      platformURL: 'http://localhost:3000',
     })
   })
 
@@ -526,8 +520,6 @@ describe('Docker Jobs', () => {
       jobIdentifier: 'test_job',
       jobInterface: { kind: 'exec_per_job' },
       jobData: { foo: 'bar' },
-      jobToken: expect.any(String),
-      platformURL: 'http://localhost:3000',
     })
 
     const findOrCreateContainerCall = findOrCreateContainerSpy.mock.calls[0]!


### PR DESCRIPTION
## Summary
- Only include `job_token` and `platform_url` in docker job payloads when there's an async task (`asyncTaskId`) to track
- Without a task, there's nothing to send lifecycle signals to and no reason to issue presigned URLs

Resolves LOM-280

## Test plan
- [ ] tsc passes
- [ ] prettier passes
- [ ] API e2e tests pass (505 tests)