### PR TITLE
fix(lombok): disable time limit for runtime workers

### DIFF
--- a/packages/core-worker/src/worker-scripts/run-worker.ts
+++ b/packages/core-worker/src/worker-scripts/run-worker.ts
@@ -1351,6 +1351,7 @@ async function createWorkerProcess(
       '--disable_clone_newuser',
       '--disable_clone_newcgroup',
       '--disable_rlimits',
+      '--time_limit=0',
       '--disable_proc',
       '--tmpfsmount=/',
       '--user=1000',


### PR DESCRIPTION
## Summary
- Add `--time_limit=0` to nsjail arguments for sandboxed runtime workers to prevent long-running processes from being killed by the default timeout

Resolves LOM-281

## Test plan
- [ ] tsc passes
- [ ] API e2e tests pass