### PR TITLE
refactor(LOM-282): remove .apps. segment from subdomain host patterns

### DIFF
--- a/docker/docker-bridge/TUNNELS-REVIEW.md
+++ b/docker/docker-bridge/TUNNELS-REVIEW.md
@@ -472,7 +472,7 @@ controller only — no global middleware needed.
 **File:** `packages/api/src/docker/controllers/tunnel-auth.controller.ts` line 168
 
 ```typescript
-// BEFORE — produced http://foo.apps.example.com:8080:3000/...
+// BEFORE — produced http://foo.example.com:8080:3000/...
 const tunnelOrigin = `${req.protocol}://${tunnelHost}`
 const landingUrl = `${tunnelOrigin}:${this.config.platformPort}/...`
 ```

--- a/docker/docker-bridge/src/tunnel/tunnel-traffic.ts
+++ b/docker/docker-bridge/src/tunnel/tunnel-traffic.ts
@@ -12,7 +12,7 @@
  *   - Subsequent requests: cookie sent automatically.
  *
  * nginx sets X-Tunnel-Public-Id header based on the subdomain:
- *   {label}--{publicId}--{appId}.apps.{domain}
+ *   {label}--{publicId}--{appId}.{domain}
  */
 
 import type { BridgeConfig } from '../config.js'

--- a/packages/api/nginx/dev-nginx.conf
+++ b/packages/api/nginx/dev-nginx.conf
@@ -1,12 +1,12 @@
 js_import app_router from app_router.js;
 
 # Tunnel traffic — route tunnel subdomains to bridge tunnel handler
-# Subdomain format: {label}--{publicId}--{appId}.apps.{domain}
+# Subdomain format: {label}--{publicId}--{appId}.{domain}
 # The tunnelId is always lowercase alphanumeric (no hyphens), ensuring
 # this 3-part pattern doesn't collide with app-server--{name} (2-part).
 server {
     listen 0.0.0.0:8080;
-    server_name ~^(?<tunnel_label>.+)--(?<tunnel_public_id>[a-z0-9]+)--(?<tunnel_app>[^.]+)\.apps\.{{PLATFORM_HOST}}$;
+    server_name ~^(?<tunnel_label>.+)--(?<tunnel_public_id>[a-z0-9]+)--(?<tunnel_app>[^.]+)\.{{PLATFORM_HOST}}$;
 
     # Tunnel auth — route to platform API preserving full path
     # (/-/tunnel-auth, /-/tunnel-auth/landing, /-/tunnel-auth/sw.js)
@@ -51,7 +51,7 @@ server {
 # App host routing
 server {
     listen 0.0.0.0:8080;
-    server_name ~^app-server--(?<appname>.+)\.apps\.{{PLATFORM_HOST}}$;
+    server_name ~^app-server--(?<appname>.+)\.{{PLATFORM_HOST}}$;
 
     resolver 127.0.0.11 ipv6=off valid=30s;
 

--- a/packages/api/nginx/nginx.conf
+++ b/packages/api/nginx/nginx.conf
@@ -1,10 +1,10 @@
 # Tunnel traffic — route tunnel subdomains to bridge tunnel handler
-# Subdomain format: {label}--{publicId}--{appId}.apps.{domain}
+# Subdomain format: {label}--{publicId}--{appId}.{domain}
 # The tunnelId is always lowercase alphanumeric (no hyphens), ensuring
 # this 3-part pattern doesn't collide with app-server--{name} (2-part).
 server {
     listen 0.0.0.0:8080;
-    server_name ~^(?<tunnel_label>.+)--(?<tunnel_public_id>[a-z0-9]+)--(?<tunnel_app>[^.]+)\.apps\.{{PLATFORM_HOST}}$;
+    server_name ~^(?<tunnel_label>.+)--(?<tunnel_public_id>[a-z0-9]+)--(?<tunnel_app>[^.]+)\.{{PLATFORM_HOST}}$;
 
     # Tunnel auth — route to platform API preserving full path
     # (/-/tunnel-auth, /-/tunnel-auth/landing, /-/tunnel-auth/sw.js)
@@ -51,7 +51,7 @@ server {
 # App host routing
 server {
     listen 0.0.0.0:8080;
-    server_name ~^app-server--(?<appname>.+)\.apps\.{{PLATFORM_HOST}}$;
+    server_name ~^app-server--(?<appname>.+)\.{{PLATFORM_HOST}}$;
 
     # Lombok Socket.IO connection
     location /socket.io/ {

--- a/packages/api/src/core-worker/core-worker.e2e-spec.ts
+++ b/packages/api/src/core-worker/core-worker.e2e-spec.ts
@@ -476,7 +476,7 @@ describe('Core Worker', () => {
   it('should serve UI bundle via core worker server', async () => {
     const response = await fetch('http://127.0.0.1:3001/', {
       headers: {
-        host: `app-server--${installedAppIdentifier}.apps.localhost`,
+        host: `app-server--${installedAppIdentifier}.localhost`,
       },
     })
     const bodyText = await response.text()

--- a/packages/api/src/docker/controllers/tunnel-auth.controller.ts
+++ b/packages/api/src/docker/controllers/tunnel-auth.controller.ts
@@ -21,8 +21,8 @@ import { DockerBridgeService } from '../services/docker-bridge.service'
 const COOKIE_NAME = 'tunnel_auth'
 const TUNNEL_TOKEN_TTL_SECONDS = 86400 // 24 hours
 
-/** Tunnel subdomain format: {label}--{publicId}--{appIdentifier}.apps.{platformHost} */
-const TUNNEL_DOMAIN_REGEX = /^(.+)--([a-z0-9]+)--([^.]+)\.apps\.(.+)$/
+/** Tunnel subdomain format: {label}--{publicId}--{appIdentifier}.{platformHost} */
+const TUNNEL_DOMAIN_REGEX = /^(.+)--([a-z0-9]+)--([^.]+)\.(.+)$/
 
 interface SessionTokenPayload {
   sub: string
@@ -248,7 +248,7 @@ async function refreshAuth() {
 
   /**
    * Build a full origin URL for a given hostname using platform config.
-   * Produces e.g. `https://foo.apps.example.com` or `http://foo.apps.localhost:8080`.
+   * Produces e.g. `https://foo.example.com` or `http://foo.localhost:8080`.
    */
   private buildTunnelOrigin(hostname: string): string {
     const protocol = this.config.platformHttps ? 'https' : 'http'

--- a/packages/api/src/docker/services/client/docker-client.service.ts
+++ b/packages/api/src/docker/services/client/docker-client.service.ts
@@ -1074,6 +1074,6 @@ export class DockerClientService {
       typeof platformPort === 'number' && ![80, 443].includes(platformPort)
         ? `:${platformPort}`
         : ''
-    return `${protocol}://${label}--${publicId}--${appIdentifier}.apps.${platformHost}${portSuffix}`
+    return `${protocol}://${label}--${publicId}--${appIdentifier}.${platformHost}${portSuffix}`
   }
 }

--- a/packages/api/src/docker/services/docker-worker-hook.service.ts
+++ b/packages/api/src/docker/services/docker-worker-hook.service.ts
@@ -671,7 +671,7 @@ export class DockerWorkerHookService {
 
       const forwardHeaders: Record<string, string> = {
         ...requestContext.headers,
-        Host: `app-server--${appIdentifier}.apps.localhost`,
+        Host: `app-server--${appIdentifier}.localhost`,
         ...(accessToken ? { Authorization: `Bearer ${accessToken}` } : {}),
       }
 

--- a/packages/core-worker/src/app-workers/app-request-server.ts
+++ b/packages/core-worker/src/app-workers/app-request-server.ts
@@ -56,10 +56,7 @@ export const buildAppRequestServer = ({
         const host = req.headers.get('host') ?? ''
         const hostParts = host.split('.')
 
-        if (
-          hostParts.length < 2 ||
-          !hostParts[0]?.startsWith('app-server--')
-        ) {
+        if (hostParts.length < 2 || !hostParts[0]?.startsWith('app-server--')) {
           return new Response('Invalid host format', { status: 400 })
         }
 

--- a/packages/core-worker/src/app-workers/app-request-server.ts
+++ b/packages/core-worker/src/app-workers/app-request-server.ts
@@ -58,7 +58,6 @@ export const buildAppRequestServer = ({
 
         if (
           hostParts.length < 2 ||
-          hostParts[1] !== 'apps' ||
           !hostParts[0]?.startsWith('app-server--')
         ) {
           return new Response('Invalid host format', { status: 400 })

--- a/packages/ui/src/components/folder-object-detail-view-selector/folder-object-detail-view-embed-selector.tsx
+++ b/packages/ui/src/components/folder-object-detail-view-selector/folder-object-detail-view-embed-selector.tsx
@@ -70,7 +70,7 @@ export function FolderObjectDetailViewEmbedSelector({
             <div className="flex items-center gap-2">
               {option.iconPath && (
                 <img
-                  src={`${window.location.protocol}//${option.appIdentifier}.apps.${window.location.hostname}${window.location.port ? `:${window.location.port}` : ''}${option.iconPath ?? ''}`}
+                  src={`${window.location.protocol}//${option.appIdentifier}.${window.location.hostname}${window.location.port ? `:${window.location.port}` : ''}${option.iconPath ?? ''}`}
                   alt=""
                   className="size-4 object-contain"
                 />

--- a/packages/ui/src/components/sidebar/menu-list.ts
+++ b/packages/ui/src/components/sidebar/menu-list.ts
@@ -40,7 +40,7 @@ const port = window.location.port
 const API_HOST = `${hostname}${port && !['80', '443'].includes(port) ? `:${port}` : ''}`
 
 function resolveAppIconUrl(appIdentifier: string, iconPath: string): string {
-  return `${protocol}//${appIdentifier}.apps.${API_HOST}${iconPath}`
+  return `${protocol}//${appIdentifier}.${API_HOST}${iconPath}`
 }
 
 function groupContributionsByApp(

--- a/packages/ui/src/views/app-ui/app-ui.view.tsx
+++ b/packages/ui/src/views/app-ui/app-ui.view.tsx
@@ -65,7 +65,7 @@ export function AppUI({
 
   const theme = useTheme()
   const srcUrl = React.useMemo(() => {
-    return `${scheme}//app-server--${appIdentifier}.apps.${host}${paths.initial}`
+    return `${scheme}//app-server--${appIdentifier}.${host}${paths.initial}`
   }, [appIdentifier, host, scheme, paths.initial])
 
   React.useEffect(() => {

--- a/packages/ui/src/views/folder-object-sidebar/folder-object-sidebar.view.tsx
+++ b/packages/ui/src/views/folder-object-sidebar/folder-object-sidebar.view.tsx
@@ -200,7 +200,7 @@ export const FolderObjectSidebar = ({
                       <TypographyH3>
                         <div className="flex items-center gap-2">
                           <img
-                            src={`${protocol}//${embed.appIdentifier}.apps.${API_HOST}${embed.iconPath ?? ''}`}
+                            src={`${protocol}//${embed.appIdentifier}.${API_HOST}${embed.iconPath ?? ''}`}
                             alt={`${embed.appLabel} icon`}
                             className="size-6"
                           />

--- a/packages/ui/src/views/folder-sidebar/folder-sidebar.view.tsx
+++ b/packages/ui/src/views/folder-sidebar/folder-sidebar.view.tsx
@@ -164,7 +164,7 @@ export function FolderSidebar({
                         <TypographyH3>
                           <div className="flex items-center gap-2">
                             <img
-                              src={`${protocol}//${view.appIdentifier}.apps.${API_HOST}${view.iconPath ?? ''}`}
+                              src={`${protocol}//${view.appIdentifier}.${API_HOST}${view.iconPath ?? ''}`}
                               alt={`${view.appLabel} icon`}
                               className="size-6"
                             />

--- a/packages/ui/vite.config.ts
+++ b/packages/ui/vite.config.ts
@@ -14,13 +14,13 @@ function subdomainProxyPlugin(env: Record<string, string>): PluginOption {
         const host = req.headers.host
         const url = req.url || ''
 
-        // Only handle if it's an apps subdomain
-        if (!host?.match(/\.apps\./)) {
+        // Only handle if it's an app subdomain
+        if (!host?.startsWith('app-server--')) {
           next()
           return
         }
 
-        // Extract combined subdomain and parse identifiers: app-server--<app>.apps.<platform_host>
+        // Extract combined subdomain and parse identifiers: app-server--<app>.<platform_host>
         const hostParts = host.split('.')
         const appIdentifier = hostParts[0]?.replace('app-server--', '')
 


### PR DESCRIPTION
## Summary
- Flatten app and tunnel subdomains to connect directly to the platform host (e.g., `app-server--demo.example.com` instead of `app-server--demo.apps.example.com`)
- Updates nginx configs, docker bridge tunnels, tunnel auth, docker client service, vite config, and UI views

## Test plan
- [ ] Verify app iframe URLs load correctly without the `.apps.` segment
- [ ] Verify tunnel traffic routing works with flattened subdomains
- [ ] Verify nginx proxy passes route to correct backends
- [ ] Verify vite dev server proxy config works locally