### PR TITLE
feat(LOM-285): support template vars in app container profile volume configs

### DIFF
--- a/packages/api/src/docker/services/docker-jobs.service.ts
+++ b/packages/api/src/docker/services/docker-jobs.service.ts
@@ -323,6 +323,11 @@ export class DockerJobsService {
       profileKey: string
       userId?: string
     },
+    templateContext?: {
+      userId?: string
+      isolationKey?: string
+      appIdentifier?: string
+    },
   ): Promise<{ containerId: string; hostId: string }> {
     if ('containerId' in attributes) {
       const { hostId, containerId: refContainerId } = attributes
@@ -358,10 +363,21 @@ export class DockerJobsService {
       attributes.profileKey,
     )
 
+    // Resolve {{ }} template expressions in volumes with runtime context
+    let resolvedVolumes = config.volumes
+    if (config.volumes?.length && templateContext) {
+      const resolved = await dataFromTemplate(
+        { volumes: config.volumes },
+        { objects: templateContext },
+      )
+      resolvedVolumes = resolved.volumes as string[]
+    }
+
     const container = await this.dockerClientService.findOrCreateContainer(
       hostId,
       {
         ...config,
+        volumes: resolvedVolumes,
         image,
         labels: { ...config.labels, ...labels },
         start: true,
@@ -564,6 +580,7 @@ export class DockerJobsService {
             profileKey,
             userId: effectiveUserId,
           },
+          { userId: effectiveUserId, isolationKey, appIdentifier },
         )
       } else {
         // No containerTarget — shared container per profile (backward-compatible default)
@@ -583,6 +600,7 @@ export class DockerJobsService {
             env: { LOMBOK_PROVISION_SECRET: provisionSecret },
           },
           { provisionSecret, appIdentifier, profileKey, userId },
+          { userId, appIdentifier },
         )
       }
 

--- a/packages/api/src/docker/tests/docker.e2e-spec.ts
+++ b/packages/api/src/docker/tests/docker.e2e-spec.ts
@@ -36,6 +36,7 @@ import {
   TEST_DOCKER_HOST_ID,
 } from 'src/test/test.util'
 
+import { dockerProfileResourceAssignmentsTable } from '../entities/docker-profile-resource-assignment.entity'
 import { DockerClientService } from '../services/client/docker-client.service'
 import { buildMockDockerClientService } from './docker.e2e-mocks'
 
@@ -466,6 +467,47 @@ describe('Docker Jobs', () => {
       jobInterface: { kind: 'exec_per_job' },
       jobData: {},
     })
+  })
+
+  it('should resolve {{ }} template expressions in volume configuration', async () => {
+    // Override the profile assignment to use template volumes
+    await testModule!.services.ormService.db
+      .update(dockerProfileResourceAssignmentsTable)
+      .set({
+        config: {
+          volumes: [
+            '/data/{{appIdentifier}}:/mnt/appdata',
+            '/static:/mnt/static',
+          ],
+        },
+      })
+      .where(
+        eq(dockerProfileResourceAssignmentsTable.appIdentifier, TEST_APP_SLUG),
+      )
+
+    execSpy.mockImplementation((_hostId, _containerId, command, _options?) => {
+      return Promise.resolve({
+        exitCode: 0,
+        stdout:
+          command[1] === 'job-state'
+            ? `{"job_id": "${command.at(-1)}", "job_class": "test_job", "status": "complete", "success": true, "started_at": "${new Date().toISOString()}"}`
+            : '',
+        stderr: '',
+      })
+    })
+
+    await testModule?.services.appService.executeAppDockerJob({
+      appIdentifier: TEST_APP_SLUG,
+      profileIdentifier: 'dummy_profile',
+      jobIdentifier: 'test_job',
+      jobData: {},
+    })
+
+    const findOrCreateContainerCall = findOrCreateContainerSpy.mock.calls[0]!
+    expect(findOrCreateContainerCall[1].volumes).toEqual([
+      `/data/${TEST_APP_SLUG}:/mnt/appdata`,
+      '/static:/mnt/static',
+    ])
   })
 
   it('should call exec with waitForCompletion=true when no asyncTaskId is provided', async () => {


### PR DESCRIPTION
## Summary
- Add support for template variables in app container profile volume configurations
- Volume mount paths in `containerProfiles` can now use dynamic template variables that get resolved at runtime
- Adds E2E tests for the new functionality

Closes LOM-285

## Test plan
- [ ] Verify template variables resolve correctly in volume mount paths at runtime
- [ ] Run docker E2E tests: `./dx e2e api` (docker specs)