### PR TITLE
fix(LOM-286): fix platform host resolution in app browser sdk

### DIFF
--- a/packages/app-browser-sdk/src/app-browser-sdk.ts
+++ b/packages/app-browser-sdk/src/app-browser-sdk.ts
@@ -58,7 +58,7 @@ export class AppBrowserSdk implements AppBrowserSdkInstance {
   public readonly lombokApiBasePath: string = (() => {
     const potocol = window.location.protocol
     const port = window.location.port
-    const hostname = window.location.hostname.split('.').slice(2).join('.')
+    const hostname = window.location.hostname.split('.').slice(1).join('.')
     return `${potocol}//${hostname}${port ? `:${port}` : ''}`
   })()
 


### PR DESCRIPTION
## Summary
- Fix incorrect platform host resolution in the app browser SDK

Closes LOM-286

## Test plan
- [ ] Verify app browser SDK resolves the platform host correctly in iframe context