### PR TITLE
chore(LOM-293): add version field to @lombokapp/types package.json

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -293,6 +293,7 @@
     },
     "packages/types": {
       "name": "@lombokapp/types",
+      "version": "0.0.1",
       "dependencies": {
         "jexpr": "catalog:",
         "zod": "catalog:",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@lombokapp/types",
+  "version": "0.0.1",
   "private": true,
   "exports": {
     ".": {


### PR DESCRIPTION
## Summary

Trivial change — adds `"version"` to `packages/types/package.json` and the matching `bun.lock` entry so the package is publishable and the lockfile can pin it consistently.

> **Stacked PR** — depends on #224 (LOM-292). Targets `mekpans/lom-292-move-app-worker-api-routing-from-path-prefix-to-hostname`; will retarget to `main` once #224 lands.

Closes [LOM-293](https://linear.app/lombokapp/issue/LOM-293/add-version-field-to-lombokapptypes-packagejson)