### PR TITLE
fix(LOM-294): fail early in docker worker test harness when image build fails

### DIFF
--- a/docker/worker-test/src/docker.ts
+++ b/docker/worker-test/src/docker.ts
@@ -89,6 +89,8 @@ export class DockerClient {
             return
           }
 
+          let buildError: string | null = null
+
           // Collect build output
           stream.on('data', (chunk: Buffer) => {
             const text = chunk.toString('utf-8')
@@ -101,6 +103,9 @@ export class DockerClient {
                   process.stdout.write(json.stream)
                 } else if (json.error) {
                   process.stderr.write(`Error: ${json.error}\n`)
+                  buildError = buildError
+                    ? `${buildError}\n${json.error}`
+                    : json.error
                 } else if (json.status) {
                   process.stdout.write(`${json.status}\n`)
                 }
@@ -111,7 +116,11 @@ export class DockerClient {
           })
 
           stream.on('end', () => {
-            resolve()
+            if (buildError) {
+              reject(new Error(`Docker image build failed: ${buildError}`))
+            } else {
+              resolve()
+            }
           })
 
           stream.on('error', (error) => {


### PR DESCRIPTION
## Summary

The docker worker test harness used to swallow the docker build step's exit code, so a broken Dockerfile would surface much later as a confusing "container failed to start" error rather than the underlying build error. Check the build exit and abort with the build's stderr when it fails.

> **Stacked PR** — depends on #225 (LOM-293). Targets `mekpans/lom-293-...`; will retarget to `main` once upstream lands.

Closes [LOM-294](https://linear.app/lombokapp/issue/LOM-294/fail-early-in-docker-worker-test-harness-when-image-build-fails)