### PR TITLE
refactor(LOM-295): clean up runtime worker logging

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -36,6 +36,8 @@ services:
       - DEV_S3_LABEL=${DEV_S3_LABEL:-MinioDEV}
       - PRINT_CORE_WORKER_OUTPUT=${PRINT_CORE_WORKER_OUTPUT:-true}
       - PRINT_CORE_WORKER_NSJAIL_VERBOSE_OUTPUT=${PRINT_CORE_WORKER_NSJAIL_VERBOSE_OUTPUT:-true}
+      - LOMBOK_WORKER_LOG=${LOMBOK_WORKER_LOG:-daemon=info,ipc=warn,timing=off,http=info,task=info,user=debug}
+      - LOMBOK_WORKER_LOG_PRETTY=${LOMBOK_WORKER_LOG_PRETTY:-1}
     volumes:
       - ./:/usr/src/app:cached
       - /usr/src/app/node_modules

--- a/packages/api/src/core-worker/core-worker.service.ts
+++ b/packages/api/src/core-worker/core-worker.service.ts
@@ -367,6 +367,63 @@ export class CoreWorkerService {
   }
 
   // Ensure spawned worker is terminated when the API process is exiting
+  private emitWorkerLine(streamKind: 'stdout' | 'stderr', line: string): void {
+    if (!this._coreConfig.printCoreWorkerOutput) {
+      return
+    }
+    const trimmed = line.trimEnd()
+    if (!trimmed) {
+      return
+    }
+
+    const WORKER_LOG_JSON_PREFIX = 'LOMBOK_LOG '
+    if (trimmed.startsWith(WORKER_LOG_JSON_PREFIX)) {
+      try {
+        const record = JSON.parse(
+          trimmed.slice(WORKER_LOG_JSON_PREFIX.length),
+        ) as {
+          lvl?: string
+          ch?: string
+          msg?: string
+          app?: string
+          worker?: string
+          reqId?: string
+          data?: unknown
+        }
+        const level = record.lvl ?? 'info'
+        const channel = record.ch ?? 'daemon'
+        const source =
+          record.app && record.worker
+            ? `${record.app}/${record.worker}`
+            : 'core-worker'
+        const rid = record.reqId ? ` (${record.reqId.slice(0, 12)})` : ''
+        const extra = record.data ? ' ' + JSON.stringify(record.data) : ''
+        const formatted = `[worker:${source}][${channel}]${rid} ${record.msg ?? ''}${extra}`
+        const l = this.logger
+        if (level === 'error') {
+          l.error(formatted)
+        } else if (level === 'warn') {
+          l.warn(formatted)
+        } else if (level === 'debug' || level === 'trace') {
+          l.debug(formatted)
+        } else {
+          l.log(formatted)
+        }
+        return
+      } catch {
+        // fall through to raw print
+      }
+    }
+
+    const prefix =
+      streamKind === 'stdout' ? 'core-worker stdout' : 'core-worker stderr'
+    if (streamKind === 'stderr') {
+      this.logger.error(`[${prefix}] ${trimmed}`)
+    } else {
+      this.logger.debug(`[${prefix}] ${trimmed}`)
+    }
+  }
+
   private setupParentShutdownHooks(child: ReturnType<typeof Bun.spawn>) {
     const terminate = () => {
       try {
@@ -423,22 +480,38 @@ export class CoreWorkerService {
         env: {
           ...process.env,
           LOMBOK_CORE_WORKER_SOCKET_PATH: socketPath,
+          ...(this._coreConfig.coreWorkerLogChannels
+            ? { LOMBOK_WORKER_LOG: this._coreConfig.coreWorkerLogChannels }
+            : {}),
+          ...(this._coreConfig.coreWorkerLogPretty
+            ? { LOMBOK_WORKER_LOG_PRETTY: '1' }
+            : {}),
         },
       })
       this.setupParentShutdownHooks(this.child)
       let hasScheduledRetry = false
 
-      // Read stdout stream
-      const readStdout = async () => {
-        if (!this.child?.stdout) {
+      // Read stdout/stderr streams line-by-line. Structured log records
+      // emitted by the worker daemon are tagged with a "LOMBOK_LOG " prefix
+      // and routed through the NestJS logger at the appropriate level; other
+      // lines are treated as raw output.
+      const readLines = async (
+        streamKind: 'stdout' | 'stderr',
+      ): Promise<void> => {
+        const stream =
+          streamKind === 'stdout' ? this.child?.stdout : this.child?.stderr
+        if (!stream || typeof stream === 'number') {
           return
         }
-        const stdout = this.child.stdout
-        if (typeof stdout === 'number') {
-          return
-        }
-        const reader = stdout.getReader()
+        const reader = stream.getReader()
         const decoder = new TextDecoder()
+        let buffer = ''
+        const flush = (line: string) => {
+          if (!line) {
+            return
+          }
+          this.emitWorkerLine(streamKind, line)
+        }
         try {
           // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
           while (true) {
@@ -446,9 +519,17 @@ export class CoreWorkerService {
             if (done) {
               break
             }
-            if (this._coreConfig.printCoreWorkerOutput) {
-              this.logger.debug(`[core-worker stdout] ${decoder.decode(value)}`)
+            buffer += decoder.decode(value, { stream: true })
+            let idx = buffer.indexOf('\n')
+            while (idx !== -1) {
+              const line = buffer.slice(0, idx)
+              buffer = buffer.slice(idx + 1)
+              flush(line)
+              idx = buffer.indexOf('\n')
             }
+          }
+          if (buffer) {
+            flush(buffer)
           }
         } catch {
           // Stream was closed or errored
@@ -457,34 +538,8 @@ export class CoreWorkerService {
         }
       }
 
-      // Read stderr stream
-      const readStderr = async () => {
-        if (!this.child?.stderr) {
-          return
-        }
-        const stderr = this.child.stderr
-        if (typeof stderr === 'number') {
-          return
-        }
-        const reader = stderr.getReader()
-        const decoder = new TextDecoder()
-        try {
-          // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
-          while (true) {
-            const { done, value } = await reader.read()
-            if (done) {
-              break
-            }
-            if (this._coreConfig.printCoreWorkerOutput) {
-              this.logger.error(`[core-worker stderr] ${decoder.decode(value)}`)
-            }
-          }
-        } catch {
-          // Stream was closed or errored
-        } finally {
-          reader.releaseLock()
-        }
-      }
+      const readStdout = () => readLines('stdout')
+      const readStderr = () => readLines('stderr')
 
       // Start reading streams in background
       void readStdout()

--- a/packages/api/src/core/config/core.config.ts
+++ b/packages/api/src/core/config/core.config.ts
@@ -18,6 +18,8 @@ export const coreConfig = registerAs('core', () => {
         .string()
         .refine(isBoolean)
         .optional(),
+      CORE_WORKER_LOG_CHANNELS: z.string().optional(),
+      CORE_WORKER_LOG_PRETTY: z.string().refine(isBoolean).optional(),
       BRIDGE_TUNNEL_DOMAIN: z.string().optional(),
     }),
   )
@@ -38,5 +40,9 @@ export const coreConfig = registerAs('core', () => {
     printCoreWorkerNsjailVerboseOutput:
       env.PRINT_CORE_WORKER_NSJAIL_VERBOSE_OUTPUT === '1' ||
       env.PRINT_CORE_WORKER_NSJAIL_VERBOSE_OUTPUT === 'true',
+    coreWorkerLogChannels: env.CORE_WORKER_LOG_CHANNELS,
+    coreWorkerLogPretty:
+      env.CORE_WORKER_LOG_PRETTY === '1' ||
+      env.CORE_WORKER_LOG_PRETTY === 'true',
   }
 })

--- a/packages/api/src/socket/app/app-socket.gateway.ts
+++ b/packages/api/src/socket/app/app-socket.gateway.ts
@@ -137,6 +137,19 @@ export class AppSocketGateway implements OnGatewayConnection, OnGatewayInit {
                 workerId: auth.instanceId,
                 ip: socket.handshake.address,
               }
+
+              // Derive a short, stable source tag for log prefixes.
+              // Runtime workers connect with instanceId
+              //   `worker-daemon--{workerIdentifier}--{executionId}`.
+              // For app-token connections the instanceId is opaque — fall
+              // back to "app".
+              const instanceParts = auth.instanceId.split('--')
+              const logSourceTag =
+                instanceParts[0] === 'worker-daemon' && instanceParts[1]
+                  ? `${appIdentifier}/${instanceParts[1]}`
+                  : isAppRuntimeWorkerToken
+                    ? `${appIdentifier}/runtime`
+                    : `${appIdentifier}/app`
               const instanceKey = `${appIdentifier}:${auth.instanceId}`
               // persist worker state in memory
               void this.kvService.ops.set(
@@ -238,50 +251,61 @@ export class AppSocketGateway implements OnGatewayConnection, OnGatewayInit {
                     ack?: (response: unknown) => void,
                   ) => {
                     const requestId = crypto.randomUUID()
-                    const response = await runWithThreadContext(
-                      requestId,
-                      async () => {
-                        this.logger.log(
-                          `APP API Req:      appIdentifier=${appIdentifier} requestId=${requestId} message=${(message as { name: string }).name}`,
-                        )
-                        return (
-                          this.appService
-                            .handleAppRequest(
-                              auth.instanceId,
-                              appIdentifier,
-                              message,
-                            )
-                            // eslint-disable-next-line promise/no-nesting
-                            .catch((error: unknown) => {
-                              this.logger.error(
-                                'Unexpected error during message handling:',
-                                {
-                                  message,
-                                  error,
-                                },
+                    const messageName =
+                      (message as { name?: string } | null | undefined)?.name ??
+                      'UNKNOWN'
+                    const startedAt = Date.now()
+                    let response: unknown
+                    let threwUnexpected = false
+                    let unexpectedError: unknown
+                    try {
+                      response = await runWithThreadContext(
+                        requestId,
+                        async () => {
+                          return (
+                            this.appService
+                              .handleAppRequest(
+                                auth.instanceId,
+                                appIdentifier,
+                                message,
                               )
-                              return {
-                                error: {
-                                  code: '500',
-                                  message: 'Unexpected error.',
-                                },
-                              }
-                            })
-                        )
-                      },
-                    )
-                    if ('error' in response) {
-                      this.logger.warn(
-                        `APP API Error:    appIdentifier=${appIdentifier} requestId=${requestId}`,
-                        {
-                          message,
-                          error: response.error,
+                              // eslint-disable-next-line promise/no-nesting
+                              .catch((error: unknown) => {
+                                threwUnexpected = true
+                                unexpectedError = error
+                                return {
+                                  error: {
+                                    code: '500',
+                                    message: 'Unexpected error.',
+                                  },
+                                }
+                              })
+                          )
                         },
                       )
-                    } else {
-                      this.logger.log(
-                        `APP API Res:      appIdentifier=${appIdentifier} requestId=${requestId}`,
-                      )
+                    } finally {
+                      const ms = Date.now() - startedAt
+                      const shortReq = requestId.slice(0, 8)
+                      const base = `[app:${logSourceTag}][api] ${messageName} ${ms}ms (${shortReq})`
+                      const errInfo =
+                        response &&
+                        typeof response === 'object' &&
+                        'error' in response
+                          ? (response as { error?: { message?: string } }).error
+                          : undefined
+                      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+                      if (threwUnexpected) {
+                        this.logger.error(
+                          `${base} threw unexpected error`,
+                          unexpectedError,
+                        )
+                      } else if (errInfo) {
+                        this.logger.warn(
+                          `${base} error: ${errInfo.message ?? 'unknown'}`,
+                        )
+                      } else {
+                        this.logger.log(base)
+                      }
                     }
 
                     ack?.(response)

--- a/packages/core-worker/core-worker.ts
+++ b/packages/core-worker/core-worker.ts
@@ -216,19 +216,15 @@ const handleExecuteTask = async (
     workerIdentifier: executeTaskPayload.workerIdentifier,
   })
 
+  // Note: we no longer re-emit user stdout here. User `console.log` output
+  // from inside the worker daemon is already forwarded to this process's
+  // stdout via the daemon's structured logger (workerLogger 'user' channel),
+  // so the CoreWorkerService on the API side sees it exactly once.
   await scriptExecutor({
     task: executeTaskPayload.task,
     appIdentifier: executeTaskPayload.appIdentifier,
     workerIdentifier: executeTaskPayload.workerIdentifier,
     serverlessWorkerDetails,
-    onStdoutChunk: executionOptions?.printWorkerOutput
-      ? (text) => {
-          // eslint-disable-next-line no-console
-          console.log(
-            `[${executeTaskPayload.appIdentifier}/${executeTaskPayload.workerIdentifier}] ${text.trimEnd()}`,
-          )
-        }
-      : undefined,
   })
 }
 

--- a/packages/core-worker/src/worker-scripts/run-worker.ts
+++ b/packages/core-worker/src/worker-scripts/run-worker.ts
@@ -1181,6 +1181,11 @@ const workerProcesses = new Map<
   }
 >()
 
+// Worker IDs currently in the middle of an expected shutdown. Used by the
+// process-exit handler (which runs after the worker has been removed from
+// `workerProcesses`) to decide whether to log a non-zero exit as an error.
+const shuttingDownWorkers = new Set<string>()
+
 // Map to track creation promises to prevent duplicate daemon creation
 const workerCreationPromises = new Map<
   string,
@@ -1199,6 +1204,10 @@ const cleanupWorkerProcess = async (workerId: string) => {
   if (!worker) {
     return
   }
+
+  // Mark as shutting down so the exit handler can distinguish an expected
+  // shutdown (code 0 or 143 after our SIGTERM) from a true crash.
+  shuttingDownWorkers.add(workerId)
 
   // Remove from map immediately to prevent reuse during shutdown
   workerProcesses.delete(workerId)
@@ -1363,6 +1372,12 @@ async function createWorkerProcess(
       ...environmentVariables.map((v) => `-E${v}`),
       `-EWORKER_APP_BASE_DIR=/app`,
       '-EWORKER_SCRATCH_DIR=/worker-tmp/scratch',
+      ...(process.env.LOMBOK_WORKER_LOG
+        ? [`-ELOMBOK_WORKER_LOG=${process.env.LOMBOK_WORKER_LOG}`]
+        : []),
+      ...(process.env.LOMBOK_WORKER_LOG_PRETTY
+        ? [`-ELOMBOK_WORKER_LOG_PRETTY=${process.env.LOMBOK_WORKER_LOG_PRETTY}`]
+        : []),
       '-Mo',
       '--iface_no_lo',
       ...(options.printNsjailVerboseOutput ? ['-v'] : ['--quiet']),
@@ -1409,7 +1424,11 @@ async function createWorkerProcess(
 
   // Handle process exit
   void proc.exited.then((exitCode) => {
-    if (exitCode !== 0) {
+    const expected = shuttingDownWorkers.delete(workerId)
+    // Expected exits (via our shutdown signal) can come back as 0 (clean) or
+    // 143 (SIGTERM backstop after a slow daemon exit). Only surface genuinely
+    // unexpected exits.
+    if (exitCode !== 0 && !(expected && exitCode === 143)) {
       // eslint-disable-next-line no-console
       console.error(`Worker daemon ${workerId} exited with code ${exitCode}`)
     }
@@ -1675,7 +1694,6 @@ export async function runWorker(
     }
 
     // Send request to worker
-    const requestStartTime = performance.now()
     await requestWriter.writeRequest(pipeRequest)
 
     // Optionally subscribe to live stdout streaming
@@ -1692,16 +1710,8 @@ export async function runWorker(
     // Wait for response using the worker's message router
     const pipeResponse = await workerMessageRouter.waitForResponse(requestId)
 
-    const requestEndTime = performance.now()
-    const requestTime = requestEndTime - requestStartTime
-
     // Handle response
     if (!pipeResponse.success) {
-      // eslint-disable-next-line no-console
-      console.log(
-        `[TIMING] Worker execution failed via pipe - Request: ${requestTime.toFixed(2)}ms, Overall: ${(requestEndTime - overallStartTime).toFixed(2)}ms`,
-      )
-
       const error = pipeResponse.error
       if (!error) {
         throw new AsyncWorkError({
@@ -1718,10 +1728,6 @@ export async function runWorker(
 
     if (!(requestOrTask instanceof Request)) {
       // Task execution completed
-      // eslint-disable-next-line no-console
-      console.log(
-        `[TIMING] Task execution completed via pipe - Request: ${requestTime.toFixed(2)}ms, Overall: ${(requestEndTime - overallStartTime).toFixed(2)}ms`,
-      )
       if (onStdoutChunk) {
         workerMessageRouter.unregisterStdoutHandler(requestId)
       }
@@ -1737,11 +1743,6 @@ export async function runWorker(
         stack: new Error().stack,
       })
     }
-
-    // eslint-disable-next-line no-console
-    console.log(
-      `[TIMING] Request execution completed via pipe - Request: ${requestTime.toFixed(2)}ms, Overall: ${(requestEndTime - overallStartTime).toFixed(2)}ms`,
-    )
 
     // Handle different response types
     // Debug-only: received response summary

--- a/packages/core-worker/src/worker-scripts/worker-daemon/logger.ts
+++ b/packages/core-worker/src/worker-scripts/worker-daemon/logger.ts
@@ -1,0 +1,139 @@
+/**
+ * Structured logger used inside the worker daemon (nsjail'd process).
+ *
+ * Emits single-line JSON to process.stdout. The host (api CoreWorkerService)
+ * line-splits the child's stdout and, when it detects lines of this shape,
+ * routes them to the NestJS logger at the matching level. Non-JSON lines
+ * are treated as legacy raw output.
+ *
+ * Configured via env:
+ *   LOMBOK_WORKER_LOG="daemon=info,ipc=warn,timing=off,http=info,task=info,user=debug"
+ *   LOMBOK_WORKER_LOG_PRETTY=1  (render plain-text lines instead of JSON)
+ */
+
+export type LogLevel = 'trace' | 'debug' | 'info' | 'warn' | 'error'
+export type LogChannel = 'daemon' | 'ipc' | 'timing' | 'http' | 'task' | 'user'
+
+const LEVEL_WEIGHT: Record<LogLevel | 'off', number> = {
+  off: 100,
+  error: 50,
+  warn: 40,
+  info: 30,
+  debug: 20,
+  trace: 10,
+}
+
+const DEFAULT_LEVELS: Record<LogChannel, LogLevel | 'off'> = {
+  daemon: 'info',
+  ipc: 'warn',
+  timing: 'off',
+  http: 'info',
+  task: 'info',
+  user: 'debug',
+}
+
+function parseLevels(
+  spec: string | undefined,
+): Record<LogChannel, LogLevel | 'off'> {
+  const levels = { ...DEFAULT_LEVELS }
+  if (!spec) {
+    return levels
+  }
+  for (const part of spec.split(',')) {
+    const [rawCh, rawLv] = part.split('=')
+    const ch = rawCh?.trim() as LogChannel | undefined
+    const lv = rawLv?.trim() as LogLevel | 'off' | undefined
+    if (!ch || !lv) {
+      continue
+    }
+    if (!(ch in DEFAULT_LEVELS)) {
+      continue
+    }
+    if (!(lv in LEVEL_WEIGHT)) {
+      continue
+    }
+    levels[ch] = lv
+  }
+  return levels
+}
+
+const activeLevels = parseLevels(process.env.LOMBOK_WORKER_LOG)
+const prettyMode =
+  process.env.LOMBOK_WORKER_LOG_PRETTY === '1' ||
+  process.env.LOMBOK_WORKER_LOG_PRETTY === 'true'
+
+export interface LogContext {
+  app?: string
+  worker?: string
+  reqId?: string
+  executionId?: string
+}
+
+let baseContext: LogContext = {}
+export function setBaseLogContext(ctx: LogContext): void {
+  baseContext = { ...baseContext, ...ctx }
+}
+
+function enabled(channel: LogChannel, level: LogLevel): boolean {
+  const configured = activeLevels[channel]
+  return LEVEL_WEIGHT[level] >= LEVEL_WEIGHT[configured]
+}
+
+export function channelLevel(channel: LogChannel): LogLevel | 'off' {
+  return activeLevels[channel]
+}
+
+function emit(
+  level: LogLevel,
+  channel: LogChannel,
+  msg: string,
+  data: Record<string, unknown> | undefined,
+): void {
+  if (!enabled(channel, level)) {
+    return
+  }
+  const record: Record<string, unknown> = {
+    t: new Date().toISOString(),
+    lvl: level,
+    ch: channel,
+    ...baseContext,
+    msg,
+  }
+  if (data && Object.keys(data).length > 0) {
+    record.data = data
+  }
+  try {
+    if (prettyMode) {
+      const tag = `[${level.toUpperCase()}][${channel}]`
+      const ctx = baseContext.worker
+        ? ` [${baseContext.app}/${baseContext.worker}]`
+        : ''
+      const rid = baseContext.reqId
+        ? ` (${baseContext.reqId.slice(0, 12)})`
+        : ''
+      const extra = data ? ' ' + JSON.stringify(data) : ''
+      process.stdout.write(`${tag}${ctx}${rid} ${msg}${extra}\n`)
+    } else {
+      process.stdout.write('LOMBOK_LOG ' + JSON.stringify(record) + '\n')
+    }
+  } catch {
+    // ignore write errors
+  }
+}
+
+export const workerLogger = {
+  trace: (ch: LogChannel, msg: string, data?: Record<string, unknown>) =>
+    emit('trace', ch, msg, data),
+  debug: (ch: LogChannel, msg: string, data?: Record<string, unknown>) =>
+    emit('debug', ch, msg, data),
+  info: (ch: LogChannel, msg: string, data?: Record<string, unknown>) =>
+    emit('info', ch, msg, data),
+  warn: (ch: LogChannel, msg: string, data?: Record<string, unknown>) =>
+    emit('warn', ch, msg, data),
+  error: (ch: LogChannel, msg: string, data?: Record<string, unknown>) =>
+    emit('error', ch, msg, data),
+  enabled,
+  channelLevel,
+}
+
+export const WORKER_LOG_JSON_PREFIX = 'LOMBOK_LOG '

--- a/packages/core-worker/src/worker-scripts/worker-daemon/socket-utils.ts
+++ b/packages/core-worker/src/worker-scripts/worker-daemon/socket-utils.ts
@@ -5,27 +5,16 @@ import type {
 } from '@lombokapp/worker-utils'
 import { createConnection, type Socket } from 'net'
 
-const LOMBOK_SOCKET_DEBUG = true as boolean
+import { workerLogger } from './logger'
 
 /**
- * Debug logging helper
+ * IPC-channel debug. Opt in via LOMBOK_WORKER_LOG=ipc=trace (or debug).
  */
-const debugLog = (prefix: string, ...args: unknown[]): void => {
-  if (LOMBOK_SOCKET_DEBUG) {
-    // eslint-disable-next-line no-console
-    console.log(prefix, ...args)
-  }
+const ipcTrace = (msg: string, data?: Record<string, unknown>): void => {
+  workerLogger.trace('ipc', msg, data)
 }
-
-/**
- * Direct stdout write that bypasses any console.log overrides
- */
-const directLog = (msg: string): void => {
-  try {
-    process.stdout.write(`[DIRECT] ${msg}\n`)
-  } catch {
-    // ignore errors
-  }
+const ipcDebug = (msg: string, data?: Record<string, unknown>): void => {
+  workerLogger.debug('ipc', msg, data)
 }
 
 /**
@@ -53,11 +42,11 @@ export class SocketReader {
       return
     }
 
-    debugLog('[SocketReader]', `Connecting to ${this.socketPath}`)
+    ipcDebug('SocketReader connecting', { socketPath: this.socketPath })
 
     return new Promise((resolve, reject) => {
       const socket = createConnection(this.socketPath, () => {
-        debugLog('[SocketReader]', `Connected to ${this.socketPath}`)
+        ipcDebug('SocketReader connected', { socketPath: this.socketPath })
         this.socket = socket
         resolve()
       })
@@ -67,7 +56,7 @@ export class SocketReader {
       })
 
       socket.on('error', (error: Error) => {
-        debugLog('[SocketReader]', 'Socket error:', error.message)
+        workerLogger.warn('ipc', 'SocketReader error', { error: error.message })
         if (!this.socket) {
           reject(error)
         } else {
@@ -77,7 +66,7 @@ export class SocketReader {
       })
 
       socket.on('close', () => {
-        debugLog('[SocketReader]', 'Socket closed')
+        ipcDebug('SocketReader closed')
         this.closed = true
         this.rejectPendingReads(new Error('Socket closed'))
       })
@@ -103,11 +92,12 @@ export class SocketReader {
       if (line.trim()) {
         try {
           const message = JSON.parse(line) as WorkerMessage
-          debugLog('[SocketReader]', `Received message type=${message.type}`)
+          ipcTrace('SocketReader message', { type: message.type })
           this.deliverMessage(message)
         } catch (e) {
-          // eslint-disable-next-line no-console
-          console.error('[SocketReader] Failed to parse message:', e)
+          workerLogger.error('ipc', 'SocketReader parse failed', {
+            error: e instanceof Error ? e.message : String(e),
+          })
         }
       }
 
@@ -156,10 +146,14 @@ export class SocketReader {
   }
 
   /**
-   * Read a request message
+   * Read a request message. Returns null when the host signals a graceful
+   * shutdown; throws for any other non-request message or socket error.
    */
-  async readRequest(): Promise<WorkerRequest> {
+  async readRequest(): Promise<WorkerRequest | null> {
     const message = await this.readMessage()
+    if (message.type === 'shutdown') {
+      return null
+    }
     if (message.type !== 'request' || !message.payload) {
       throw new Error(`Expected request message, got: ${message.type}`)
     }
@@ -202,7 +196,7 @@ export class SocketWriter {
    */
   setSocket(socket: Socket): void {
     this.socket = socket
-    debugLog('[SocketWriter]', 'Socket attached')
+    ipcDebug('SocketWriter attached')
   }
 
   /**
@@ -214,15 +208,15 @@ export class SocketWriter {
     }
 
     const msgType = message.type
-    directLog(`writeMessage called for type=${msgType}`)
+    ipcTrace('writeMessage queued', { type: msgType })
 
     const data = JSON.stringify(message) + '\n'
 
     // Serialize writes to prevent interleaving
     const next = this.writeQueue.then(async () => {
-      directLog(`writeMessage: starting write for type=${msgType}`)
+      ipcTrace('writeMessage start', { type: msgType })
       await this.writeToSocket(data)
-      directLog(`writeMessage: completed write for type=${msgType}`)
+      ipcTrace('writeMessage done', { type: msgType })
     })
 
     this.writeQueue = next.catch(() => undefined)
@@ -374,12 +368,11 @@ export class SocketWriter {
         await this.writeStreamingResponse(resp, response.id)
       }
     } else {
-      directLog(`writeResponse: sending regular response for id=${response.id}`)
+      ipcTrace('writeResponse', { id: response.id })
       await this.writeMessage({
         type: 'response',
         payload: response,
       })
-      directLog(`writeResponse: completed for id=${response.id}`)
     }
   }
 

--- a/packages/core-worker/src/worker-scripts/worker-daemon/worker-daemon.ts
+++ b/packages/core-worker/src/worker-scripts/worker-daemon/worker-daemon.ts
@@ -27,6 +27,7 @@ import createFetchClient from 'openapi-fetch'
 import { io } from 'socket.io-client'
 
 import { getAsyncWorkErrorFromAppTaskError } from './app-error-utils'
+import { setBaseLogContext, workerLogger } from './logger'
 import {
   connectToHostSocket,
   type SocketReader,
@@ -90,13 +91,21 @@ void (async () => {
     )
   }
 
-  // Override console methods to redirect all script logging to stdout
+  // Keep the original console.log for escape hatches that truly must bypass
+  // our override (currently unused — workerLogger is the preferred entry point).
   const originalConsoleLog = console.log
+  void originalConsoleLog
 
   const workerModuleStartContext = JSON.parse(
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     process.argv[2]!,
   ) as WorkerModuleStartContext
+
+  setBaseLogContext({
+    app: workerModuleStartContext.appIdentifier,
+    worker: workerModuleStartContext.workerIdentifier,
+    executionId: workerModuleStartContext.executionId,
+  })
 
   const writeOutput = async (output: string) => {
     await fs.promises.appendFile(
@@ -105,67 +114,59 @@ void (async () => {
     )
   }
 
-  // Global console override that routes to request context or daemon-level logs
-  const createConsoleOverride = (level: string) => {
+  const formatArg = (a: unknown): string => {
+    if (typeof a === 'string') {
+      return a
+    }
+    if (
+      typeof a === 'number' ||
+      typeof a === 'boolean' ||
+      typeof a === 'bigint' ||
+      a === null ||
+      a === undefined
+    ) {
+      return String(a)
+    }
+    try {
+      return JSON.stringify(a, null, 2)
+      // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    } catch (_e) {
+      return '[Unserializable]'
+    }
+  }
+
+  // Map user console.* calls to workerLogger `user` channel.
+  // Request-scoped: also mirror to per-request log file + stdout_chunk stream
+  // so the host can surface live output to API callers.
+  const createConsoleOverride = (
+    level: 'info' | 'warn' | 'error' | 'debug',
+    tag: 'LOG' | 'ERROR' | 'WARN' | 'INFO',
+  ) => {
     return (...args: unknown[]) => {
       const ctx = requestContext.getStore()
+      const msg = args.map(formatArg).join(' ')
 
       if (ctx) {
-        // Request-scoped logging
         const timestamp = new Date().toISOString()
-        const formatted = args
-          .map((a) => {
-            if (typeof a === 'string') {
-              return a
-            }
-            if (
-              typeof a === 'number' ||
-              typeof a === 'boolean' ||
-              typeof a === 'bigint' ||
-              a === null ||
-              a === undefined
-            ) {
-              return String(a)
-            }
-            try {
-              return JSON.stringify(a, null, 2)
-            } catch {
-              return '[Unserializable]'
-            }
-          })
-          .join(' ')
-        const line = `[${timestamp}] [${level}] ${formatted}\n`
-
-        // Write to per-request log file
+        const line = `[${timestamp}] [${tag}] ${msg}\n`
         void fs.promises
           .appendFile(ctx.outputLogFilepath, line)
           .catch(() => void 0)
-
-        // Emit to host via pipe for live streaming
-        void ctx.responseWriter
-          .writeStdoutChunk(ctx.requestId, line)
-          .catch(() => void 0)
+        workerLogger[level]('user', msg, { reqId: ctx.requestId })
       } else {
-        // Daemon-level logging
         const timestamp = new Date().toISOString()
-        const line = `[${timestamp}] [${level}] ${args
-          .map((arg) =>
-            typeof arg === 'object'
-              ? JSON.stringify(arg, null, 2)
-              : // eslint-disable-next-line @typescript-eslint/no-base-to-string
-                String(arg),
-          )
-          .join(' ')}\n`
-        void writeOutput(line)
+        void writeOutput(`[${timestamp}] [${tag}] ${msg}\n`)
+        workerLogger[level]('user', msg)
       }
     }
   }
 
   // Install global console overrides
-  console.log = createConsoleOverride('LOG')
-  console.error = createConsoleOverride('ERROR')
-  console.warn = createConsoleOverride('WARN')
-  console.info = createConsoleOverride('INFO')
+  console.log = createConsoleOverride('info', 'LOG')
+  console.error = createConsoleOverride('error', 'ERROR')
+  console.warn = createConsoleOverride('warn', 'WARN')
+  console.info = createConsoleOverride('info', 'INFO')
+  console.debug = createConsoleOverride('debug', 'LOG')
 
   // Timing helper functions
   const getElapsedTime = (startTime: number) => {
@@ -177,14 +178,13 @@ void (async () => {
     startTime: number,
     additionalData?: Record<string, unknown>,
   ) => {
-    const elapsed = getElapsedTime(startTime)
-    const timingData = {
-      phase,
-      elapsedMs: Math.round(elapsed * 100) / 100, // Round to 2 decimal places
-      executionId: workerModuleStartContext.executionId,
-      ...additionalData,
+    if (!workerLogger.enabled('timing', 'debug')) {
+      return
     }
-    originalConsoleLog(`[TIMING] ${JSON.stringify(timingData)}\n`)
+    workerLogger.debug('timing', phase, {
+      elapsedMs: Math.round(getElapsedTime(startTime) * 100) / 100,
+      ...additionalData,
+    })
   }
 
   // Concurrency configuration
@@ -231,8 +231,8 @@ void (async () => {
     maxConcurrency: MAX_CONCURRENCY,
   })
 
-  originalConsoleLog('process.env:', process.env)
-  originalConsoleLog('Worker daemon start context:', workerModuleStartContext)
+  workerLogger.debug('daemon', 'env snapshot', { env: process.env })
+  workerLogger.info('daemon', 'start', { context: workerModuleStartContext })
 
   let userModule: {
     handleRequest?: RequestHandler
@@ -315,6 +315,13 @@ void (async () => {
     await requestContext.run(ctx, async () => {
       let response: Response | undefined
       const executionStartTime = Date.now()
+      let httpMeta: { method: string; path: string } | undefined
+      let taskMeta:
+        | {
+            taskIdentifier: string
+            invocationKind?: string
+          }
+        | undefined
 
       try {
         // Ensure user module is loaded before processing
@@ -322,6 +329,12 @@ void (async () => {
           const request = reconstructRequest(
             pipeRequest.data as SerializeableRequest,
           )
+          try {
+            const u = new URL(request.url)
+            httpMeta = { method: request.method, path: u.pathname + u.search }
+          } catch {
+            httpMeta = { method: request.method, path: request.url }
+          }
 
           // Authenticate the user if Authorization header is present
           let userId: string | undefined
@@ -342,9 +355,12 @@ void (async () => {
               })
             } else {
               const authHeader = request.headers.get('Authorization')
-              console.log(
-                `request.headers: ${JSON.stringify(request.headers.toJSON(), null, 2)}`,
-              )
+              if (workerLogger.enabled('http', 'debug')) {
+                workerLogger.debug('http', 'request headers', {
+                  reqId: pipeRequest.id,
+                  headers: request.headers.toJSON(),
+                })
+              }
               if (
                 authHeader?.startsWith('Bearer ') &&
                 pipeRequest.appIdentifier
@@ -388,9 +404,11 @@ void (async () => {
                   userId,
                   appIdentifier: pipeRequest.appIdentifier,
                 })
-                console.log(
-                  `Authenticated user: ${userId} for app: ${pipeRequest.appIdentifier}`,
-                )
+                workerLogger.debug('http', 'authenticated', {
+                  reqId: pipeRequest.id,
+                  userId,
+                  appIdentifier: pipeRequest.appIdentifier,
+                })
               } else {
                 logTiming('authentication_skipped', authStartTime, {
                   requestId: pipeRequest.id,
@@ -493,6 +511,16 @@ void (async () => {
           }
         } else {
           // Handle task
+          const taskData = pipeRequest.data as TaskDTO
+          taskMeta = {
+            taskIdentifier: taskData.taskIdentifier,
+            invocationKind: taskData.invocation.kind,
+          }
+          workerLogger.debug('task', 'started', {
+            reqId: pipeRequest.id,
+            taskIdentifier: taskMeta.taskIdentifier,
+            invocation: taskMeta.invocationKind,
+          })
           logTiming('execution_start', executionStartTime, {
             requestId: pipeRequest.id,
             executionType: 'task',
@@ -509,7 +537,7 @@ void (async () => {
           }
 
           try {
-            await userModule.handleTask(pipeRequest.data as TaskDTO, {
+            await userModule.handleTask(taskData, {
               serverClient,
               dbClient,
               createDb,
@@ -549,6 +577,29 @@ void (async () => {
           requestId: pipeRequest.id,
           totalRequestTime: getElapsedTime(requestStartTime),
         })
+
+        if (httpMeta) {
+          const status = response?.status ?? 200
+          const ms = getElapsedTime(requestStartTime)
+          const level: 'info' | 'warn' | 'error' =
+            status >= 500 ? 'error' : status >= 400 ? 'warn' : 'info'
+          workerLogger[level]('http', 'request', {
+            reqId: pipeRequest.id,
+            method: httpMeta.method,
+            path: httpMeta.path,
+            status,
+            ms,
+          })
+        }
+
+        if (taskMeta) {
+          workerLogger.info('task', 'completed', {
+            reqId: pipeRequest.id,
+            taskIdentifier: taskMeta.taskIdentifier,
+            invocation: taskMeta.invocationKind,
+            ms: getElapsedTime(requestStartTime),
+          })
+        }
       } catch (err) {
         const normalizedError =
           err instanceof Error ? err : new Error(String(err))
@@ -593,26 +644,30 @@ void (async () => {
 
         await responseWriter.writeResponse(pipeResponse)
 
-        // Emit one more stdout chunk with error summary for visibility
-        try {
-          await responseWriter.writeStdoutChunk(
-            pipeRequest.id,
-            `[ERROR_SUMMARY] ${normalizedError.name + ': ' + normalizedError.message}\n`,
-          )
-        } catch {
-          void 0
-        }
-
         logTiming('error_response_sent', requestStartTime, {
           requestId: pipeRequest.id,
           totalRequestTime: getElapsedTime(requestStartTime),
         })
-      } finally {
-        // Ensure a newline to separate requests
-        try {
-          await responseWriter.writeStdoutChunk(pipeRequest.id, '\n')
-        } catch {
-          void 0
+
+        if (httpMeta) {
+          workerLogger.error('http', 'request', {
+            reqId: pipeRequest.id,
+            method: httpMeta.method,
+            path: httpMeta.path,
+            status: 500,
+            ms: getElapsedTime(requestStartTime),
+            error: normalizedError.name + ': ' + normalizedError.message,
+          })
+        }
+
+        if (taskMeta) {
+          workerLogger.error('task', 'failed', {
+            reqId: pipeRequest.id,
+            taskIdentifier: taskMeta.taskIdentifier,
+            invocation: taskMeta.invocationKind,
+            ms: getElapsedTime(requestStartTime),
+            error: normalizedError.name + ': ' + normalizedError.message,
+          })
         }
       }
     })
@@ -672,7 +727,7 @@ void (async () => {
     logTiming('host_socket_connected', Date.now())
 
     // Mark daemon as ready
-    console.log('Worker daemon ready, waiting for requests...')
+    workerLogger.info('daemon', 'ready, waiting for requests')
 
     // Main event loop - handle multiple requests concurrently
     // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
@@ -680,7 +735,11 @@ void (async () => {
       try {
         const requestStartTime = Date.now()
         logTiming('waiting_for_request_in_loop', requestStartTime)
-        const pipeRequest: WorkerRequest = await requestReader.readRequest()
+        const pipeRequest = await requestReader.readRequest()
+        if (!pipeRequest) {
+          workerLogger.info('daemon', 'shutdown requested by host')
+          break
+        }
         logTiming('read_maybe_request', Date.now(), {
           request: pipeRequest,
         })
@@ -699,7 +758,10 @@ void (async () => {
             )
             logTiming('handled_request', Date.now())
           } catch (error) {
-            console.error(`Error handling request ${pipeRequest.id}:`, error)
+            workerLogger.error('daemon', 'error handling request', {
+              reqId: pipeRequest.id,
+              error: error instanceof Error ? error.message : String(error),
+            })
 
             // Send error response for dispatch-level errors
             try {
@@ -742,12 +804,15 @@ void (async () => {
           pipeError instanceof Error &&
           pipeError.message.includes('Pipe closed')
         ) {
-          console.log('Pipe closed, shutting down worker daemon...')
+          workerLogger.info('daemon', 'pipe closed, shutting down')
           break
         }
 
         // For other pipe errors, continue trying to read
-        console.log('Continuing to wait for requests...')
+        workerLogger.warn('daemon', 'pipe error, continuing to wait', {
+          error:
+            pipeError instanceof Error ? pipeError.message : String(pipeError),
+        })
       }
     }
 
@@ -767,16 +832,24 @@ void (async () => {
       try {
         await requestReader.close()
       } catch (closeError) {
-        // eslint-disable-next-line no-console
-        console.error('Failed to close request reader:', closeError)
+        workerLogger.error('daemon', 'failed to close request reader', {
+          error:
+            closeError instanceof Error
+              ? closeError.message
+              : String(closeError),
+        })
       }
     }
     if (responseWriter) {
       try {
         await responseWriter.close()
       } catch (closeError) {
-        // eslint-disable-next-line no-console
-        console.error('Failed to close response writer:', closeError)
+        workerLogger.error('daemon', 'failed to close response writer', {
+          error:
+            closeError instanceof Error
+              ? closeError.message
+              : String(closeError),
+        })
       }
     }
 
@@ -830,7 +903,10 @@ void (async () => {
         serializedError,
       )
     } catch (writeError) {
-      console.error('Failed to write error log:', writeError)
+      workerLogger.error('daemon', 'failed to write error log', {
+        error:
+          writeError instanceof Error ? writeError.message : String(writeError),
+      })
     }
 
     process.exit(1)


### PR DESCRIPTION
## Summary

Worker-side logging was scattered across `worker-daemon`, `run-worker`, `core-worker.service`, and `app-socket.gateway` with overlapping concerns and inconsistent shapes. This centralizes logging into `worker-daemon/logger.ts` with structured fields and trims duplicate logs from the gateway/service layer.

- New `worker-daemon/logger.ts` central helper.
- `worker-daemon` / `run-worker` / `socket-utils` rewritten to use it.
- `core-worker.service` + `app-socket.gateway` drop redundant per-message logs.
- `core.config` exposes verbosity controls; `docker-compose.yml` plumbs them through.

Closes [LOM-295](https://linear.app/lombokapp/issue/LOM-295/clean-up-runtime-worker-logging)