### PR TITLE
feat(LOM-298): support "mounts" property in docker resource config

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -30,6 +30,7 @@
       "version": "0.1.0",
       "dependencies": {
         "dockerode": "catalog:",
+        "zod": "catalog:",
       },
       "devDependencies": {
         "@eslint/js": "catalog:",

--- a/docker/docker-bridge/package.json
+++ b/docker/docker-bridge/package.json
@@ -13,7 +13,8 @@
     "prettier:fix": "prettier --write ."
   },
   "dependencies": {
-    "dockerode": "catalog:"
+    "dockerode": "catalog:",
+    "zod": "catalog:"
   },
   "devDependencies": {
     "@types/dockerode": "catalog:",

--- a/docker/docker-bridge/src/docker/adapter.ts
+++ b/docker/docker-bridge/src/docker/adapter.ts
@@ -1,5 +1,7 @@
 import type net from 'node:net'
 
+import { z } from 'zod'
+
 export interface ExecOptions {
   tty: boolean
   env?: string[]
@@ -24,12 +26,84 @@ export interface ContainerInfo {
   state: string
 }
 
+// ─── Mount schema — Zod, peer of the API-side schema in packages/api's
+// DTO. Validates at the bridge boundary (defence in depth) and is the
+// single source of truth for the BridgeMount TS type below.
+
+const driverConfigSchema = z.object({
+  name: z.string().nonempty(),
+  options: z.record(z.string(), z.string()).optional(),
+})
+
+const volumeOptionsSchema = z.object({
+  noCopy: z.boolean(),
+  labels: z.record(z.string(), z.string()),
+  driverConfig: driverConfigSchema,
+  subpath: z.string().nonempty().optional(),
+})
+
+const bindOptionsSchema = z.object({
+  propagation: z.enum([
+    'private',
+    'rprivate',
+    'shared',
+    'rshared',
+    'slave',
+    'rslave',
+  ]),
+  nonRecursive: z.boolean().optional(),
+  createMountpoint: z.boolean().optional(),
+  readOnlyNonRecursive: z.boolean().optional(),
+  readOnlyForceRecursive: z.boolean().optional(),
+})
+
+const tmpfsOptionsSchema = z.object({
+  sizeBytes: z.number().positive(),
+  mode: z.number(),
+  options: z.array(z.array(z.string())).nonempty().optional(),
+})
+
+// `source` lives on each variant — its nullability is type-dependent:
+//   • volume — optional (omitted = anonymous volume)
+//   • bind   — required (must name a host path)
+//   • tmpfs  — forbidden (no backing path; in-memory filesystem)
+const mountBase = {
+  target: z.string().nonempty(),
+  readOnly: z.boolean().optional(),
+  consistency: z
+    .enum(['default', 'consistent', 'cached', 'delegated'])
+    .optional(),
+}
+
+export const bridgeMountSchema = z.discriminatedUnion('type', [
+  z.object({
+    ...mountBase,
+    type: z.literal('volume'),
+    source: z.string().nonempty().nullable(),
+    volumeOptions: volumeOptionsSchema.optional(),
+  }),
+  z.object({
+    ...mountBase,
+    type: z.literal('bind'),
+    source: z.string().nonempty(),
+    bindOptions: bindOptionsSchema.optional(),
+  }),
+  z.object({
+    ...mountBase,
+    type: z.literal('tmpfs'),
+    source: z.never().optional(),
+    tmpfsOptions: tmpfsOptionsSchema.optional(),
+  }),
+])
+
+export type BridgeMount = z.infer<typeof bridgeMountSchema>
+
 export interface CreateContainerOptions {
   image: string
   labels: Record<string, string>
   env?: Record<string, string>
   extraHosts?: string[]
-  volumes?: string[]
+  mounts?: BridgeMount[]
   networkMode?: string
   gpus?: { driver: string; deviceIds: string[] }
   capAdd?: string[]

--- a/docker/docker-bridge/src/docker/dockerode-adapter.ts
+++ b/docker/docker-bridge/src/docker/dockerode-adapter.ts
@@ -259,9 +259,80 @@ export class DockerodeAdapter implements DockerAdapter {
   async createContainer(
     options: CreateContainerOptions,
   ): Promise<BridgeContainerInfo> {
+    const mounts: Dockerode.MountSettings[] =
+      options.mounts
+        ?.map((m) => {
+          const base = {
+            Type: m.type,
+            Target: m.target,
+            ...{ Source: m.source ?? '' },
+            ...(m.readOnly !== undefined ? { ReadOnly: m.readOnly } : {}),
+            ...(m.consistency !== undefined
+              ? { Consistency: m.consistency }
+              : {}),
+          }
+
+          switch (m.type) {
+            case 'volume': {
+              const vo = m.volumeOptions
+              if (!vo) {
+                return base
+              }
+              const dc = vo.driverConfig
+              const VolumeOptions = {
+                NoCopy: vo.noCopy,
+                Labels: vo.labels,
+                ...(vo.subpath !== undefined ? { Subpath: vo.subpath } : {}),
+                DriverConfig: {
+                  Name: dc.name,
+                  Options: dc.options ?? {},
+                },
+              }
+              return { ...base, source: m.source ?? undefined, VolumeOptions }
+            }
+            case 'bind': {
+              const bo = m.bindOptions
+              if (!bo) {
+                return base
+              }
+              const BindOptions = {
+                Propagation: bo.propagation,
+                ...(bo.nonRecursive !== undefined
+                  ? { NonRecursive: bo.nonRecursive }
+                  : {}),
+                ...(bo.createMountpoint !== undefined
+                  ? { CreateMountpoint: bo.createMountpoint }
+                  : {}),
+                ...(bo.readOnlyNonRecursive !== undefined
+                  ? { ReadOnlyNonRecursive: bo.readOnlyNonRecursive }
+                  : {}),
+                ...(bo.readOnlyForceRecursive !== undefined
+                  ? { ReadOnlyForceRecursive: bo.readOnlyForceRecursive }
+                  : {}),
+              }
+              return { ...base, source: m.source, BindOptions }
+            }
+            case 'tmpfs': {
+              const to = m.tmpfsOptions
+              if (!to) {
+                return base
+              }
+              const TmpfsOptions = {
+                SizeBytes: to.sizeBytes,
+                Mode: to.mode,
+                ...(to.options ? { Options: to.options } : {}),
+              }
+              return { ...base, TmpfsOptions }
+            }
+            default:
+              return undefined
+          }
+        })
+        .filter((m) => m !== undefined) ?? []
+
     const hostConfig: Dockerode.HostConfig = {
       ExtraHosts: options.extraHosts,
-      Binds: options.volumes,
+      ...(mounts.length ? { Mounts: mounts } : {}),
       NetworkMode: options.networkMode,
       CapAdd: options.capAdd,
       CapDrop: options.capDrop,
@@ -289,26 +360,47 @@ export class DockerodeAdapter implements DockerAdapter {
       PidsLimit: options.pidsLimit,
       Runtime: options.runtime,
       Sysctls: options.sysctls,
-    }
 
-    if (options.restartPolicy) {
-      hostConfig.RestartPolicy = {
-        Name: options.restartPolicy,
-        ...(options.restartPolicy === 'on-failure'
-          ? { MaximumRetryCount: 5 }
-          : {}),
-      }
-    }
+      ...(options.restartPolicy
+        ? {
+            RestartPolicy: {
+              Name: options.restartPolicy,
+              MaximumRetryCount:
+                options.restartPolicy === 'on-failure' ? 5 : undefined,
+            },
+          }
+        : {}),
 
-    if (options.ports) {
-      const exposedPorts: Record<string, object> = {}
-      const portBindings: Record<string, { HostPort: string }[]> = {}
-      for (const p of options.ports) {
-        const key = `${p.container}/${p.protocol}`
-        exposedPorts[key] = {}
-        portBindings[key] = [{ HostPort: String(p.host) }]
-      }
-      hostConfig.PortBindings = portBindings
+      ...(options.ulimits
+        ? {
+            Ulimits: Object.entries(options.ulimits).map(
+              ([name, { soft, hard }]) => ({
+                Name: name,
+                Soft: soft,
+                Hard: hard,
+              }),
+            ),
+          }
+        : {}),
+      ...(options.gpus
+        ? {
+            DeviceRequests: [
+              {
+                Driver: options.gpus.driver,
+                DeviceIDs: options.gpus.deviceIds,
+                Capabilities: [['gpu']],
+              },
+            ],
+          }
+        : {}),
+
+      ...(options.ports
+        ? {
+            PortBindings: Object.fromEntries(
+              options.ports.map((p) => [`${p.container}/${p.protocol}`, {}]),
+            ),
+          }
+        : {}),
     }
 
     if (options.ulimits) {

--- a/packages/api/src/core/utils/data-template.util.ts
+++ b/packages/api/src/core/utils/data-template.util.ts
@@ -180,17 +180,166 @@ async function resolveTemplateExpression(
   return found ? value : undefined
 }
 
-async function resolveValue(
-  value: JsonSerializableValue,
+type FilterMode = 'include' | 'exclude'
+
+interface KeyFilterRule {
+  path: string[]
+  mode: FilterMode
+}
+
+interface KeyFilter {
+  defaultMode: FilterMode
+  rules: KeyFilterRule[]
+}
+
+function pathEquals(a: string[], b: string[]): boolean {
+  if (a.length !== b.length) {
+    return false
+  }
+  for (let i = 0; i < a.length; i++) {
+    if (a[i] !== b[i]) {
+      return false
+    }
+  }
+  return true
+}
+
+function isPrefixOrEqual(prefix: string[], path: string[]): boolean {
+  if (prefix.length > path.length) {
+    return false
+  }
+  for (let i = 0; i < prefix.length; i++) {
+    if (prefix[i] !== path[i]) {
+      return false
+    }
+  }
+  return true
+}
+
+function isStrictPrefix(prefix: string[], path: string[]): boolean {
+  return prefix.length < path.length && isPrefixOrEqual(prefix, path)
+}
+
+function buildKeyFilter(
+  onlyKeys: string[][] | undefined,
+  omitKeys: string[][] | undefined,
+): KeyFilter | undefined {
+  const hasOnly = !!onlyKeys && onlyKeys.length > 0
+  const hasOmit = !!omitKeys && omitKeys.length > 0
+  if (!hasOnly && !hasOmit) {
+    return undefined
+  }
+
+  if (hasOnly && hasOmit) {
+    for (const o of onlyKeys) {
+      for (const x of omitKeys) {
+        if (pathEquals(o, x)) {
+          throw new Error(
+            `dataFromTemplate: path [${o.join('.')}] appears in both onlyKeys and omitKeys`,
+          )
+        }
+      }
+    }
+  }
+
+  const rules: KeyFilterRule[] = []
+  if (hasOnly) {
+    for (const p of onlyKeys) {
+      rules.push({ path: p, mode: 'include' })
+    }
+  }
+  if (hasOmit) {
+    for (const p of omitKeys) {
+      rules.push({ path: p, mode: 'exclude' })
+    }
+  }
+
+  return {
+    // If onlyKeys is provided, the default is to exclude everything not listed.
+    // With only omitKeys, the default is to include everything not listed.
+    defaultMode: hasOnly ? 'exclude' : 'include',
+    rules,
+  }
+}
+
+function effectiveMode(filter: KeyFilter, path: string[]): FilterMode {
+  let longest: KeyFilterRule | null = null
+  for (const rule of filter.rules) {
+    if (
+      isPrefixOrEqual(rule.path, path) &&
+      (!longest || rule.path.length > longest.path.length)
+    ) {
+      longest = rule
+    }
+  }
+  return longest ? longest.mode : filter.defaultMode
+}
+
+function decideKey(
+  filter: KeyFilter,
+  newPath: string[],
+): 'resolveAll' | 'passthrough' | 'recurse' {
+  const hasDeeper = filter.rules.some((r) => isStrictPrefix(newPath, r.path))
+  if (hasDeeper) {
+    return 'recurse'
+  }
+  return effectiveMode(filter, newPath) === 'include'
+    ? 'resolveAll'
+    : 'passthrough'
+}
+
+async function resolveValue<
+  T = JsonSerializableValue,
+  R extends T | JsonSerializableObject = T | JsonSerializableObject,
+>(
+  value: T,
   inputs: { objects: Record<string, unknown>; functions: AvailableFunctions },
   validate: boolean,
-): Promise<JsonSerializableValue> {
+  filter?: KeyFilter,
+  path: string[] = [],
+): Promise<R> {
+  if (Array.isArray(value)) {
+    return Promise.all(
+      value.map((entry) => resolveValue(entry, inputs, validate, filter, path)),
+    ) as R
+  }
+
+  if (value !== null && typeof value === 'object') {
+    const resolvedObject: JsonSerializableObject = {}
+    for (const [key, entry] of Object.entries(
+      value as JsonSerializableObject,
+    )) {
+      const newPath = [...path, key]
+      const decision = filter ? decideKey(filter, newPath) : 'resolveAll'
+      if (decision === 'passthrough') {
+        resolvedObject[key] = entry
+      } else if (decision === 'resolveAll') {
+        resolvedObject[key] = await resolveValue(entry, inputs, validate)
+      } else {
+        resolvedObject[key] = await resolveValue(
+          entry,
+          inputs,
+          validate,
+          filter,
+          newPath,
+        )
+      }
+    }
+    return resolvedObject as R
+  }
+
+  // Primitive reached while filter is still in "recurse" mode: deeper rules
+  // can't apply to a leaf, so honour the effective mode at this path.
+  if (filter && effectiveMode(filter, path) === 'exclude') {
+    return value as R
+  }
+
   if (typeof value === 'string') {
     // Find all template expressions in the string
     const matches = Array.from(value.matchAll(TEMPLATE_EXPRESSION))
 
     if (matches.length === 0) {
-      return value
+      return value as R
     }
 
     // If the entire string is a single template expression, return the resolved value directly
@@ -206,11 +355,11 @@ async function resolveValue(
         inputs,
         { validate },
       )
-      return resolved === undefined ? null : resolved
+      return (resolved === undefined ? null : resolved) as R
     }
 
     // Multiple template expressions - resolve each and concatenate
-    let result = value
+    let result = value as string
     for (const match of matches) {
       const expression = match.groups?.expression
       const matchString = match[0]
@@ -229,28 +378,14 @@ async function resolveValue(
         result = result.replace(matchString, resolvedStr)
       }
     }
-    return result
+    return result as R
   }
 
-  if (Array.isArray(value)) {
-    return Promise.all(
-      value.map((entry) => resolveValue(entry, inputs, validate)),
-    )
-  }
-
-  if (value !== null && typeof value === 'object') {
-    const resolvedObject: JsonSerializableObject = {}
-    for (const [key, entry] of Object.entries(value)) {
-      resolvedObject[key] = await resolveValue(entry, inputs, validate)
-    }
-    return resolvedObject
-  }
-
-  return value
+  return value as R
 }
 
 export async function dataFromTemplate(
-  data: Record<string, JsonSerializableValue>,
+  data: Record<string, JsonSerializableValue | undefined>,
   {
     objects = {},
     functions = {},
@@ -261,20 +396,25 @@ export async function dataFromTemplate(
     objects: {},
     functions: {},
   },
-  options = { validate: false },
+  options: {
+    validate?: boolean
+    onlyKeys?: string[][]
+    omitKeys?: string[][]
+  } = {},
 ): Promise<JsonSerializableObject> {
   if (!isJsonValue(data)) {
     throw new Error('Data is not a valid JSON value')
   }
 
-  const parsedData: JsonSerializableObject = {}
-  for (const [key, value] of Object.entries(data)) {
-    parsedData[key] = await resolveValue(
-      value,
-      { objects, functions },
-      options.validate,
-    )
-  }
+  const validate = options.validate ?? false
+  const filter = buildKeyFilter(options.onlyKeys, options.omitKeys)
 
-  return parsedData
+  const resolved = await resolveValue(
+    data,
+    { objects, functions },
+    validate,
+    filter,
+    [],
+  )
+  return resolved
 }

--- a/packages/api/src/core/utils/data-template.util.unit-spec.ts
+++ b/packages/api/src/core/utils/data-template.util.unit-spec.ts
@@ -903,4 +903,198 @@ describe('dataFromTemplate', () => {
       })
     })
   })
+
+  describe('onlyKeys / omitKeys filtering', () => {
+    const ctx: JsonSerializableObject = {
+      event: {
+        data: {
+          folderId: 'folder-123',
+          someValue: 'testes',
+        },
+      },
+    }
+
+    it('resolves only keys listed in onlyKeys, passes through others', async () => {
+      const parsed = await dataFromTemplate(
+        {
+          resolved: '{{ event.data.folderId }}',
+          skipped: '{{ event.data.folderId }}',
+        },
+        { objects: ctx },
+        { onlyKeys: [['resolved']] },
+      )
+
+      expect(parsed).toEqual({
+        resolved: 'folder-123',
+        skipped: '{{ event.data.folderId }}',
+      })
+    })
+
+    it('passes through keys listed in omitKeys, resolves others', async () => {
+      const parsed = await dataFromTemplate(
+        {
+          resolved: '{{ event.data.folderId }}',
+          skipped: '{{ event.data.folderId }}',
+        },
+        { objects: ctx },
+        { omitKeys: [['skipped']] },
+      )
+
+      expect(parsed).toEqual({
+        resolved: 'folder-123',
+        skipped: '{{ event.data.folderId }}',
+      })
+    })
+
+    it('applies onlyKeys to nested paths', async () => {
+      const parsed = await dataFromTemplate(
+        {
+          meta: {
+            title: '{{ event.data.folderId }}',
+            note: '{{ event.data.someValue }}',
+          },
+          other: '{{ event.data.folderId }}',
+        },
+        { objects: ctx },
+        { onlyKeys: [['meta', 'title']] },
+      )
+
+      expect(parsed).toEqual({
+        meta: {
+          title: 'folder-123',
+          note: '{{ event.data.someValue }}',
+        },
+        other: '{{ event.data.folderId }}',
+      })
+    })
+
+    it('applies omitKeys to nested paths', async () => {
+      const parsed = await dataFromTemplate(
+        {
+          meta: {
+            title: '{{ event.data.folderId }}',
+            note: '{{ event.data.someValue }}',
+          },
+          other: '{{ event.data.folderId }}',
+        },
+        { objects: ctx },
+        { omitKeys: [['meta', 'title']] },
+      )
+
+      expect(parsed).toEqual({
+        meta: {
+          title: '{{ event.data.folderId }}',
+          note: 'testes',
+        },
+        other: 'folder-123',
+      })
+    })
+
+    it('treats keys with literal dots as single segments', async () => {
+      const parsed = await dataFromTemplate(
+        {
+          'foo.bar': '{{ event.data.folderId }}',
+          foo: { bar: '{{ event.data.folderId }}' },
+        },
+        { objects: ctx },
+        { onlyKeys: [['foo.bar']] },
+      )
+
+      expect(parsed).toEqual({
+        'foo.bar': 'folder-123',
+        foo: { bar: '{{ event.data.folderId }}' },
+      })
+    })
+
+    it('inherits mode to all children of a matched path', async () => {
+      const parsed = await dataFromTemplate(
+        {
+          meta: {
+            title: '{{ event.data.folderId }}',
+            nested: { deep: '{{ event.data.someValue }}' },
+          },
+        },
+        { objects: ctx },
+        { onlyKeys: [['meta']] },
+      )
+
+      expect(parsed).toEqual({
+        meta: {
+          title: 'folder-123',
+          nested: { deep: 'testes' },
+        },
+      })
+    })
+
+    it('lets a deeper omitKeys rule override a broader onlyKeys rule', async () => {
+      const parsed = await dataFromTemplate(
+        {
+          meta: {
+            title: '{{ event.data.folderId }}',
+            secret: {
+              token: '{{ event.data.someValue }}',
+            },
+          },
+          other: '{{ event.data.folderId }}',
+        },
+        { objects: ctx },
+        {
+          onlyKeys: [['meta']],
+          omitKeys: [['meta', 'secret']],
+        },
+      )
+
+      expect(parsed).toEqual({
+        meta: {
+          title: 'folder-123',
+          secret: {
+            token: '{{ event.data.someValue }}',
+          },
+        },
+        other: '{{ event.data.folderId }}',
+      })
+    })
+
+    it('lets a deeper onlyKeys rule override a broader omitKeys rule', async () => {
+      const parsed = await dataFromTemplate(
+        {
+          meta: {
+            title: '{{ event.data.folderId }}',
+            public: {
+              slug: '{{ event.data.someValue }}',
+            },
+          },
+          other: '{{ event.data.folderId }}',
+        },
+        { objects: ctx },
+        {
+          omitKeys: [['meta']],
+          onlyKeys: [['meta', 'public']],
+        },
+      )
+
+      expect(parsed).toEqual({
+        meta: {
+          title: '{{ event.data.folderId }}',
+          public: {
+            slug: 'testes',
+          },
+        },
+        other: '{{ event.data.folderId }}',
+      })
+    })
+
+    it('throws when the same path is present in both onlyKeys and omitKeys', () => {
+      expect(() =>
+        dataFromTemplate(
+          { meta: { secret: '{{ event.data.folderId }}' } },
+          { objects: ctx },
+          {
+            onlyKeys: [['meta', 'secret']],
+            omitKeys: [['meta', 'secret']],
+          },
+        ),
+      ).toThrow(/appears in both onlyKeys and omitKeys/)
+    })
+  })
 })

--- a/packages/api/src/docker/dto/docker-resource-config-input.dto.ts
+++ b/packages/api/src/docker/dto/docker-resource-config-input.dto.ts
@@ -1,7 +1,97 @@
 import { z } from 'zod'
 
+// ─── Mount schema
+//
+// Docker's Mount API declares every field on VolumeOptions, BindOptions,
+// and TmpfsOptions as optional (each has a runtime default), which means
+// `{}` is accepted by the API but does nothing. To keep our schema
+// accurate to *effective* surface area (configs that actually change
+// behaviour), each options object is modelled as a oneOf: at least one
+// field must be present, so the empty-object shape is unrepresentable
+// at both the type and runtime-validation layers.
+
+const driverConfigSchema = z.object({
+  // Name identifies the driver — a DriverConfig without it is meaningless,
+  // so this is the one genuinely required field inside the options tree.
+  name: z.string().nonempty(),
+  options: z.record(z.string(), z.string()).optional(),
+  // Lombok-managed: a path segment that must be created under the volume's
+  // root before the real container starts, then appended to the driver's
+  // `device` path. Not forwarded to Docker — the mount helper strips it
+  // and rewrites `device` to `device + "/" + createSubpath`.
+  createSubpath: z.string().nonempty().optional(),
+})
+
+// Each options object is a union of partial shapes, one per field, with
+// that field promoted to required. Zod's `.required({ key: true })`
+// preserves field-level types in the inferred output, so `z.infer`
+// produces a properly-narrowed TS union where `{}` is unrepresentable.
+
+const volumeOptionsSchema = z.object({
+  noCopy: z.boolean().optional(),
+  labels: z.record(z.string(), z.string()).optional(),
+  driverConfig: driverConfigSchema,
+  subpath: z.string().nonempty().optional(),
+})
+
+const bindOptionsSchema = z.object({
+  propagation: z.enum([
+    'private',
+    'rprivate',
+    'shared',
+    'rshared',
+    'slave',
+    'rslave',
+  ]),
+  nonRecursive: z.boolean().optional(),
+  createMountpoint: z.boolean().optional(),
+  readOnlyNonRecursive: z.boolean().optional(),
+  readOnlyForceRecursive: z.boolean().optional(),
+})
+
+const tmpfsOptionsSchema = z.object({
+  sizeBytes: z.number().positive(),
+  mode: z.number(),
+  options: z.array(z.array(z.string())).nonempty().optional(),
+})
+
+// Fields common to every mount type. `source` lives on each variant
+// because its nullability is type-dependent:
+//   • volume — optional (omitted = anonymous volume, the NFS use case)
+//   • bind   — required (must name a host path)
+//   • tmpfs  — forbidden (no backing path; in-memory filesystem)
+const mountBase = {
+  target: z.string().nonempty(),
+  readOnly: z.boolean().optional(),
+}
+
+export const mountSchema = z.discriminatedUnion('type', [
+  z.object({
+    ...mountBase,
+    type: z.literal('volume'),
+    source: z.string().nonempty().nullable(),
+    volumeOptions: volumeOptionsSchema.optional(),
+  }),
+  z.object({
+    ...mountBase,
+    type: z.literal('bind'),
+    source: z.string().nonempty(),
+    bindOptions: bindOptionsSchema.optional(),
+  }),
+  // `z.never().optional()` → field must be undefined/absent; any value is
+  // a parse error and the inferred type is `source?: undefined`.
+  z.object({
+    ...mountBase,
+    type: z.literal('tmpfs'),
+    source: z.never(),
+    tmpfsOptions: tmpfsOptionsSchema.optional(),
+  }),
+])
+
+export type DockerResourceMount = z.infer<typeof mountSchema>
+
 export const dockerResourceConfigDataSchema = z.object({
-  volumes: z.string().array().optional(),
+  mounts: mountSchema.array().optional(),
   env: z.record(z.string(), z.string()).optional(),
   gpus: z
     .object({ driver: z.string(), deviceIds: z.string().array() })

--- a/packages/api/src/docker/services/client/docker-client.service.ts
+++ b/packages/api/src/docker/services/client/docker-client.service.ts
@@ -192,6 +192,9 @@ export class DockerClientService {
     const result = await this.bridgeRequest<BridgeContainerInfo>(
       'POST',
       `/docker/${hostId}/containers`,
+      // Options contain typed nested objects (mounts, ports, gpus, …) that
+      // don't satisfy `JsonSerializableValue`'s index-signature requirement,
+      // but are structurally JSON-serializable at runtime.
       createPayload,
     )
     return toBridgeContainerInfo(result)

--- a/packages/api/src/docker/services/client/docker-client.types.ts
+++ b/packages/api/src/docker/services/client/docker-client.types.ts
@@ -1,4 +1,7 @@
 import type { JsonSerializableObject } from '@lombokapp/types'
+import type { z } from 'zod'
+
+import type { mountSchema } from '../../dto/docker-resource-config-input.dto'
 
 export interface ContainerInfo {
   id: string
@@ -10,12 +13,17 @@ export interface ContainerInfo {
   createdAt: string
 }
 
+// Single source of truth — derived from the Zod schema in the DTO. Picks
+// up the mount-type discriminator, the oneOf constraint on each options
+// object, and the `driverConfig.name` requirement automatically.
+export type ClientMount = z.infer<typeof mountSchema>
+
 export interface FindOrCreateContainerOptions {
   image: string
   labels: Record<string, string>
   env?: Record<string, string>
   extraHosts?: string[]
-  volumes?: string[]
+  mounts?: ClientMount[]
   networkMode?: string
   gpus?: { driver: string; deviceIds: string[] }
   capAdd?: string[]

--- a/packages/api/src/docker/services/docker-jobs.service.ts
+++ b/packages/api/src/docker/services/docker-jobs.service.ts
@@ -21,6 +21,7 @@ import { buildPlatformOrigin } from 'src/core/utils/platform-origin.util'
 import { waitForCondition } from 'src/core/utils/wait.util'
 import { OrmService } from 'src/orm/orm.service'
 
+import type { DockerResourceMount } from '../dto/docker-resource-config-input.dto'
 import type { DockerResourceConfig } from '../entities/docker-profile-resource-assignment.entity'
 import {
   type ContainerCreateOptions,
@@ -62,6 +63,44 @@ export const DOCKER_LABELS = {
   STANDALONE_CONTAINER_ID: 'lombok.standalone_container_id',
 } as const
 
+/** Image used by the ephemeral mkdir helper that pre-creates mount source paths. */
+const MOUNT_INIT_HELPER_IMAGE = 'alpine:3.20'
+
+/** Polling parameters for awaiting the helper container's exit. */
+const MOUNT_INIT_WAIT_OPTIONS = {
+  retryPeriodMs: 200,
+  maxRetries: 150,
+  totalMaxDurationMs: 30000,
+}
+
+/**
+ * Extract all container-side destination paths (the `target` field) from a
+ * set of mount configs. Returns an empty array when `mounts` is nullish or
+ * empty. Order is preserved; duplicates are not deduplicated.
+ */
+export function extractMountTargets(
+  mounts: DockerResourceMount[] | undefined | null,
+): string[] {
+  return (mounts ?? []).map((mount) => mount.target)
+}
+
+/**
+ * Subset of {@link extractMountTargets} limited to mounts whose contents
+ * we own and may safely chown. Excludes volume mounts backed by an external
+ * driver (e.g. NFS): those directories are managed by the remote server and
+ * `chown` from the client side typically fails under `root_squash`.
+ */
+export function extractChownableMountTargets(
+  mounts: DockerResourceMount[] | undefined | null,
+): string[] {
+  return (mounts ?? [])
+    .filter(
+      (mount) =>
+        !(mount.type === 'volume' && mount.volumeOptions?.driverConfig),
+    )
+    .map((mount) => mount.target)
+}
+
 @Injectable({ scope: Scope.DEFAULT })
 export class DockerJobsService {
   private readonly logger = new Logger(DockerJobsService.name)
@@ -83,6 +122,127 @@ export class DockerJobsService {
     this.dockerHostManagementService =
       _dockerHostManagementService as DockerHostManagementService
     this.dockerClientService = _dockerClientService as DockerClientService
+  }
+
+  /**
+   * Resolve lombok-managed `driverConfig.createSubpath` on volume mounts:
+   * pre-create the subdirectory on the backing filesystem, then rewrite
+   * `device` to include it so the real container mounts the final path.
+   *
+   * For each matching mount, runs an ephemeral alpine helper that mounts
+   * the volume with its original `device` (which must already exist) and
+   * does `mkdir -p /parent/<createSubpath>`. `createSubpath` is then
+   * stripped from `driverConfig` (it's not a Docker field) and appended
+   * to `driverConfig.options.device` before the real mount.
+   *
+   * Mounts without `createSubpath` pass through unchanged.
+   */
+  private async initializeMountSourcePaths(
+    hostId: string,
+    mounts: DockerResourceMount[] | undefined,
+  ): Promise<DockerResourceMount[] | undefined> {
+    if (!mounts?.length) {
+      return mounts
+    }
+
+    const result: DockerResourceMount[] = []
+    for (const mount of mounts) {
+      if (
+        mount.type !== 'volume' ||
+        !mount.volumeOptions?.driverConfig.createSubpath
+      ) {
+        result.push(mount)
+        continue
+      }
+
+      const { createSubpath, ...driverConfigForDocker } =
+        mount.volumeOptions.driverConfig
+
+      await this.ensureVolumeSubpathExists(
+        hostId,
+        driverConfigForDocker,
+        createSubpath,
+      )
+
+      const existingDevice = driverConfigForDocker.options?.device ?? ''
+      const appendedDevice =
+        existingDevice.replace(/\/+$/, '') +
+        '/' +
+        createSubpath.replace(/^\/+/, '')
+
+      result.push({
+        ...mount,
+        volumeOptions: {
+          ...mount.volumeOptions,
+          driverConfig: {
+            ...driverConfigForDocker,
+            options: {
+              ...(driverConfigForDocker.options ?? {}),
+              device: appendedDevice,
+            },
+          },
+        },
+      })
+    }
+    return result
+  }
+
+  private async ensureVolumeSubpathExists(
+    hostId: string,
+    driverConfig: NonNullable<
+      NonNullable<
+        Extract<DockerResourceMount, { type: 'volume' }>['volumeOptions']
+      >['driverConfig']
+    >,
+    subpath: string,
+  ): Promise<void> {
+    await this.dockerClientService
+      .pullImage(hostId, MOUNT_INIT_HELPER_IMAGE)
+      .catch((error: unknown) => {
+        this.logger.debug(
+          `Pulling ${MOUNT_INIT_HELPER_IMAGE} failed (assuming cached): ${error instanceof Error ? error.message : String(error)}`,
+        )
+      })
+
+    const container = await this.dockerClientService.createContainer(hostId, {
+      image: MOUNT_INIT_HELPER_IMAGE,
+      labels: {
+        [DOCKER_LABELS.PLATFORM_HOST]: this._coreConfig.platformHost,
+        [DOCKER_LABELS.CONTAINER_TYPE]: 'mount-init',
+      },
+      mounts: [
+        {
+          source: null,
+          type: 'volume',
+          target: '/parent',
+          volumeOptions: { driverConfig },
+        },
+      ],
+      command: ['mkdir', '-p', `/parent/${subpath}`],
+      start: true,
+    })
+
+    try {
+      await waitForCondition(
+        async () => {
+          const info = await this.dockerClientService.findContainerById(
+            hostId,
+            container.id,
+          )
+          return info?.state === 'exited'
+        },
+        `Mount source init timed out (subpath="${subpath}")`,
+        MOUNT_INIT_WAIT_OPTIONS,
+      )
+    } finally {
+      await this.dockerClientService
+        .removeContainer(hostId, container.id, { force: true })
+        .catch((error: unknown) => {
+          this.logger.warn(
+            `Failed to remove mount-init container ${container.id}: ${error instanceof Error ? error.message : String(error)}`,
+          )
+        })
+    }
   }
 
   /**
@@ -362,22 +522,32 @@ export class DockerJobsService {
     const { hostId, ...config } = await this.resolveDockerHostConfigForProfile(
       attributes.profileKey,
     )
-
-    // Resolve {{ }} template expressions in volumes with runtime context
-    let resolvedVolumes = config.volumes
-    if (config.volumes?.length && templateContext) {
-      const resolved = await dataFromTemplate(
-        { volumes: config.volumes },
-        { objects: templateContext },
-      )
-      resolvedVolumes = resolved.volumes as string[]
+    // Resolve {{ }} template expressions in mounts with runtime context.
+    // Strings anywhere in the mount structure (notably `source` and
+    // `volumeOptions.driverConfig.options.device`) are interpolated.
+    if (config.mounts?.length && templateContext) {
+      config.mounts = (await Promise.all(
+        config.mounts.map(async (mount) => {
+          return dataFromTemplate(
+            mount,
+            { objects: templateContext },
+            { onlyKeys: [['source'], ['volumeOptions']] },
+          )
+        }),
+      )) as typeof config.mounts
     }
+
+    // Pre-create host-side source paths (e.g. NFS subpaths) so the real
+    // container start doesn't fail on a missing directory. Also rewrites
+    // mounts that use `driverConfig.createSubpath` — strips the field and
+    // appends its value to `device`.
+    config.mounts = await this.initializeMountSourcePaths(hostId, config.mounts)
 
     const container = await this.dockerClientService.findOrCreateContainer(
       hostId,
       {
         ...config,
-        volumes: resolvedVolumes,
+        mounts: config.mounts,
         image,
         labels: { ...config.labels, ...labels },
         start: true,
@@ -406,11 +576,11 @@ export class DockerJobsService {
 
       const platformUrl = buildPlatformOrigin(this._coreConfig)
 
-      // Extract container-side mount points from volumes (format: host:container[:opts])
-      // so provision can chown them to the container's default user.
-      const containerMountPoints = (resolvedVolumes ?? [])
-        .map((v) => v.split(':')[1])
-        .filter((p): p is string => !!p)
+      // Extract container-side mount points so provision can chown them to
+      // the container's default user. Skip external-driver volumes (e.g.
+      // NFS) — those are managed by the remote server and `root_squash`
+      // will reject client-side chown.
+      const containerMountPoints = extractChownableMountTargets(config.mounts)
 
       const provisionExec = await this.dockerClientService.execInContainer(
         hostId,

--- a/packages/api/src/docker/tests/docker-host-management.e2e-spec.ts
+++ b/packages/api/src/docker/tests/docker-host-management.e2e-spec.ts
@@ -323,7 +323,7 @@ describe('Docker Host Management', () => {
           dockerHostId: host.id,
           config: {
             gpus: { driver: 'nvidia', deviceIds: ['0'] },
-            volumes: ['/tmp/cache:/cache'],
+            mounts: [{ type: 'bind', source: '/tmp/cache', target: '/cache' }],
           },
         },
       },
@@ -334,7 +334,7 @@ describe('Docker Host Management', () => {
     expect(assignment.profileKey).toBe('dummy_profile')
     expect(assignment.dockerHostId).toBe(host.id)
     expect(assignment.configHashes.gpus).toBeDefined()
-    expect(assignment.configHashes.volumes).toBeDefined()
+    expect(assignment.configHashes.mounts).toBeDefined()
     expect(assignment.configHashes.gpus).toMatch(/^[0-9a-f]{12}$/)
   })
 
@@ -437,7 +437,9 @@ describe('Docker Host Management', () => {
         appIdentifier: TEST_APP_SLUG,
         profileKey: '_default',
         dockerHostId: host.id,
-        config: { volumes: ['/data:/data'] },
+        config: {
+          mounts: [{ type: 'bind', source: '/data', target: '/data' }],
+        },
       },
     })
 
@@ -454,8 +456,8 @@ describe('Docker Host Management', () => {
     )
     expect(resolved.response.status).toBe(200)
     expect(resolved.data?.result.hostId).toBe(host.id)
-    expect(resolved.data?.result.resourceConfig?.volumes).toEqual([
-      '/data:/data',
+    expect(resolved.data?.result.resourceConfig?.mounts).toEqual([
+      { type: 'bind', source: '/data', target: '/data' },
     ])
   })
 

--- a/packages/api/src/docker/tests/docker.e2e-spec.ts
+++ b/packages/api/src/docker/tests/docker.e2e-spec.ts
@@ -355,7 +355,13 @@ describe('Docker Jobs', () => {
           profileKey: 'dummy_profile',
           config: {
             gpus: { driver: 'nvidia', deviceIds: ['0'] },
-            volumes: ['/app/model_cache:/mnt/user/appdata/somepath'],
+            mounts: [
+              {
+                type: 'bind',
+                source: '/app/model_cache',
+                target: '/mnt/user/appdata/somepath',
+              },
+            ],
           },
         },
       ],
@@ -447,7 +453,13 @@ describe('Docker Jobs', () => {
         'lombok.platform_url': 'http://localhost:3000',
       },
       start: true,
-      volumes: ['/app/model_cache:/mnt/user/appdata/somepath'],
+      mounts: [
+        {
+          type: 'bind',
+          source: '/app/model_cache',
+          target: '/mnt/user/appdata/somepath',
+        },
+      ],
     })
 
     await testModule?.services.appService.executeAppDockerJob({
@@ -474,15 +486,30 @@ describe('Docker Jobs', () => {
     })
   })
 
-  it('should resolve {{ }} template expressions in volume configuration', async () => {
-    // Override the profile assignment to use template volumes
+  it('should pass structured mounts through to findOrCreateContainer with template interpolation', async () => {
+    // Profile config sets a driver-backed volume mount with an anonymous
+    // source and a templated NFS device path — this is the NFS-from-unraid
+    // pattern: volume type, no Source, driverConfig.options.device templated.
     await testModule!.services.ormService.db
       .update(dockerProfileResourceAssignmentsTable)
       .set({
         config: {
-          volumes: [
-            '/data/{{appIdentifier}}:/mnt/appdata',
-            '/static:/mnt/static',
+          mounts: [
+            {
+              type: 'volume',
+              source: null,
+              target: '/workspace',
+              volumeOptions: {
+                driverConfig: {
+                  name: 'local',
+                  options: {
+                    type: 'nfs',
+                    o: 'addr=192.0.2.1,nfsvers=4,rw,hard,noatime',
+                    device: ':/mnt/user/codicle/{{appIdentifier}}',
+                  },
+                },
+              },
+            },
           ],
         },
       })
@@ -509,9 +536,42 @@ describe('Docker Jobs', () => {
     })
 
     const findOrCreateContainerCall = findOrCreateContainerSpy.mock.calls[0]!
-    expect(findOrCreateContainerCall[1].volumes).toEqual([
-      `/data/${TEST_APP_SLUG}:/mnt/appdata`,
-      '/static:/mnt/static',
+    expect(findOrCreateContainerCall[1].mounts).toEqual([
+      {
+        type: 'volume',
+        source: null,
+        target: '/workspace',
+        volumeOptions: {
+          driverConfig: {
+            name: 'local',
+            options: {
+              type: 'nfs',
+              o: 'addr=192.0.2.1,nfsvers=4,rw,hard,noatime',
+              device: `:/mnt/user/codicle/${TEST_APP_SLUG}`,
+            },
+          },
+        },
+      },
+    ])
+    // Source was omitted — must not leak as undefined either.
+    expect(findOrCreateContainerCall[1].mounts?.[0]?.source).toBeNull()
+
+    // Mount targets should also appear in the chown path list passed to
+    // provisioning so the NFS-backed /workspace gets the right owner.
+    expect(execSpy.mock.calls[0]).toEqual([
+      TEST_DOCKER_HOST_ID,
+      '1',
+      [
+        'lombok-worker-agent',
+        'provision',
+        '--secret',
+        expect.any(String),
+        expect.stringContaining('LOMBOK_PLATFORM_TOKEN='),
+        expect.stringContaining('LOMBOK_PLATFORM_TOKEN_TYPE='),
+        expect.stringContaining('LOMBOK_PLATFORM_URL='),
+        expect.stringContaining('LOMBOK_APP_IDENTIFIER='),
+      ],
+      { user: 'root' },
     ])
   })
 
@@ -590,7 +650,13 @@ describe('Docker Jobs', () => {
       env: {
         LOMBOK_PROVISION_SECRET: expect.any(String),
       },
-      volumes: ['/app/model_cache:/mnt/user/appdata/somepath'],
+      mounts: [
+        {
+          type: 'bind',
+          source: '/app/model_cache',
+          target: '/mnt/user/appdata/somepath',
+        },
+      ],
       gpus: {
         deviceIds: ['0'],
         driver: 'nvidia',

--- a/packages/api/src/openapi.json
+++ b/packages/api/src/openapi.json
@@ -32366,10 +32366,182 @@
                 "config": {
                   "type": "object",
                   "properties": {
-                    "volumes": {
+                    "mounts": {
                       "type": "array",
                       "items": {
-                        "type": "string"
+                        "oneOf": [
+                          {
+                            "type": "object",
+                            "properties": {
+                              "target": {
+                                "type": "string",
+                                "minLength": 1
+                              },
+                              "readOnly": {
+                                "type": "boolean"
+                              },
+                              "type": {
+                                "type": "string",
+                                "const": "volume"
+                              },
+                              "source": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ],
+                                "minLength": 1
+                              },
+                              "volumeOptions": {
+                                "type": "object",
+                                "properties": {
+                                  "noCopy": {
+                                    "type": "boolean"
+                                  },
+                                  "labels": {
+                                    "$ref": "#/components/schemas/StringMapDTO"
+                                  },
+                                  "driverConfig": {
+                                    "type": "object",
+                                    "properties": {
+                                      "name": {
+                                        "type": "string",
+                                        "minLength": 1
+                                      },
+                                      "options": {
+                                        "$ref": "#/components/schemas/StringMapDTO"
+                                      },
+                                      "createSubpath": {
+                                        "type": "string",
+                                        "minLength": 1
+                                      }
+                                    },
+                                    "required": [
+                                      "name"
+                                    ]
+                                  },
+                                  "subpath": {
+                                    "type": "string",
+                                    "minLength": 1
+                                  }
+                                },
+                                "required": [
+                                  "driverConfig"
+                                ]
+                              }
+                            },
+                            "required": [
+                              "target",
+                              "type",
+                              "source"
+                            ]
+                          },
+                          {
+                            "type": "object",
+                            "properties": {
+                              "target": {
+                                "type": "string",
+                                "minLength": 1
+                              },
+                              "readOnly": {
+                                "type": "boolean"
+                              },
+                              "type": {
+                                "type": "string",
+                                "const": "bind"
+                              },
+                              "source": {
+                                "type": "string",
+                                "minLength": 1
+                              },
+                              "bindOptions": {
+                                "type": "object",
+                                "properties": {
+                                  "propagation": {
+                                    "type": "string",
+                                    "enum": [
+                                      "private",
+                                      "rprivate",
+                                      "shared",
+                                      "rshared",
+                                      "slave",
+                                      "rslave"
+                                    ]
+                                  },
+                                  "nonRecursive": {
+                                    "type": "boolean"
+                                  },
+                                  "createMountpoint": {
+                                    "type": "boolean"
+                                  },
+                                  "readOnlyNonRecursive": {
+                                    "type": "boolean"
+                                  },
+                                  "readOnlyForceRecursive": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "propagation"
+                                ]
+                              }
+                            },
+                            "required": [
+                              "target",
+                              "type",
+                              "source"
+                            ]
+                          },
+                          {
+                            "type": "object",
+                            "properties": {
+                              "target": {
+                                "type": "string",
+                                "minLength": 1
+                              },
+                              "readOnly": {
+                                "type": "boolean"
+                              },
+                              "type": {
+                                "type": "string",
+                                "const": "tmpfs"
+                              },
+                              "source": {
+                                "not": {}
+                              },
+                              "tmpfsOptions": {
+                                "type": "object",
+                                "properties": {
+                                  "sizeBytes": {
+                                    "type": "number",
+                                    "exclusiveMinimum": 0
+                                  },
+                                  "mode": {
+                                    "type": "number"
+                                  },
+                                  "options": {
+                                    "minItems": 1,
+                                    "type": "array",
+                                    "items": {
+                                      "type": "array",
+                                      "items": {
+                                        "type": "string"
+                                      }
+                                    }
+                                  }
+                                },
+                                "required": [
+                                  "sizeBytes",
+                                  "mode"
+                                ]
+                              }
+                            },
+                            "required": [
+                              "target",
+                              "type",
+                              "source"
+                            ]
+                          }
+                        ]
                       }
                     },
                     "env": {
@@ -32625,10 +32797,182 @@
                   "null"
                 ],
                 "properties": {
-                  "volumes": {
+                  "mounts": {
                     "type": "array",
                     "items": {
-                      "type": "string"
+                      "oneOf": [
+                        {
+                          "type": "object",
+                          "properties": {
+                            "target": {
+                              "type": "string",
+                              "minLength": 1
+                            },
+                            "readOnly": {
+                              "type": "boolean"
+                            },
+                            "type": {
+                              "type": "string",
+                              "const": "volume"
+                            },
+                            "source": {
+                              "type": [
+                                "string",
+                                "null"
+                              ],
+                              "minLength": 1
+                            },
+                            "volumeOptions": {
+                              "type": "object",
+                              "properties": {
+                                "noCopy": {
+                                  "type": "boolean"
+                                },
+                                "labels": {
+                                  "$ref": "#/components/schemas/StringMapDTO"
+                                },
+                                "driverConfig": {
+                                  "type": "object",
+                                  "properties": {
+                                    "name": {
+                                      "type": "string",
+                                      "minLength": 1
+                                    },
+                                    "options": {
+                                      "$ref": "#/components/schemas/StringMapDTO"
+                                    },
+                                    "createSubpath": {
+                                      "type": "string",
+                                      "minLength": 1
+                                    }
+                                  },
+                                  "required": [
+                                    "name"
+                                  ]
+                                },
+                                "subpath": {
+                                  "type": "string",
+                                  "minLength": 1
+                                }
+                              },
+                              "required": [
+                                "driverConfig"
+                              ]
+                            }
+                          },
+                          "required": [
+                            "target",
+                            "type",
+                            "source"
+                          ]
+                        },
+                        {
+                          "type": "object",
+                          "properties": {
+                            "target": {
+                              "type": "string",
+                              "minLength": 1
+                            },
+                            "readOnly": {
+                              "type": "boolean"
+                            },
+                            "type": {
+                              "type": "string",
+                              "const": "bind"
+                            },
+                            "source": {
+                              "type": "string",
+                              "minLength": 1
+                            },
+                            "bindOptions": {
+                              "type": "object",
+                              "properties": {
+                                "propagation": {
+                                  "type": "string",
+                                  "enum": [
+                                    "private",
+                                    "rprivate",
+                                    "shared",
+                                    "rshared",
+                                    "slave",
+                                    "rslave"
+                                  ]
+                                },
+                                "nonRecursive": {
+                                  "type": "boolean"
+                                },
+                                "createMountpoint": {
+                                  "type": "boolean"
+                                },
+                                "readOnlyNonRecursive": {
+                                  "type": "boolean"
+                                },
+                                "readOnlyForceRecursive": {
+                                  "type": "boolean"
+                                }
+                              },
+                              "required": [
+                                "propagation"
+                              ]
+                            }
+                          },
+                          "required": [
+                            "target",
+                            "type",
+                            "source"
+                          ]
+                        },
+                        {
+                          "type": "object",
+                          "properties": {
+                            "target": {
+                              "type": "string",
+                              "minLength": 1
+                            },
+                            "readOnly": {
+                              "type": "boolean"
+                            },
+                            "type": {
+                              "type": "string",
+                              "const": "tmpfs"
+                            },
+                            "source": {
+                              "not": {}
+                            },
+                            "tmpfsOptions": {
+                              "type": "object",
+                              "properties": {
+                                "sizeBytes": {
+                                  "type": "number",
+                                  "exclusiveMinimum": 0
+                                },
+                                "mode": {
+                                  "type": "number"
+                                },
+                                "options": {
+                                  "minItems": 1,
+                                  "type": "array",
+                                  "items": {
+                                    "type": "array",
+                                    "items": {
+                                      "type": "string"
+                                    }
+                                  }
+                                }
+                              },
+                              "required": [
+                                "sizeBytes",
+                                "mode"
+                              ]
+                            }
+                          },
+                          "required": [
+                            "target",
+                            "type",
+                            "source"
+                          ]
+                        }
+                      ]
                     }
                   },
                   "env": {
@@ -32870,10 +33214,182 @@
               "config": {
                 "type": "object",
                 "properties": {
-                  "volumes": {
+                  "mounts": {
                     "type": "array",
                     "items": {
-                      "type": "string"
+                      "oneOf": [
+                        {
+                          "type": "object",
+                          "properties": {
+                            "target": {
+                              "type": "string",
+                              "minLength": 1
+                            },
+                            "readOnly": {
+                              "type": "boolean"
+                            },
+                            "type": {
+                              "type": "string",
+                              "const": "volume"
+                            },
+                            "source": {
+                              "type": [
+                                "string",
+                                "null"
+                              ],
+                              "minLength": 1
+                            },
+                            "volumeOptions": {
+                              "type": "object",
+                              "properties": {
+                                "noCopy": {
+                                  "type": "boolean"
+                                },
+                                "labels": {
+                                  "$ref": "#/components/schemas/StringMapDTO"
+                                },
+                                "driverConfig": {
+                                  "type": "object",
+                                  "properties": {
+                                    "name": {
+                                      "type": "string",
+                                      "minLength": 1
+                                    },
+                                    "options": {
+                                      "$ref": "#/components/schemas/StringMapDTO"
+                                    },
+                                    "createSubpath": {
+                                      "type": "string",
+                                      "minLength": 1
+                                    }
+                                  },
+                                  "required": [
+                                    "name"
+                                  ]
+                                },
+                                "subpath": {
+                                  "type": "string",
+                                  "minLength": 1
+                                }
+                              },
+                              "required": [
+                                "driverConfig"
+                              ]
+                            }
+                          },
+                          "required": [
+                            "target",
+                            "type",
+                            "source"
+                          ]
+                        },
+                        {
+                          "type": "object",
+                          "properties": {
+                            "target": {
+                              "type": "string",
+                              "minLength": 1
+                            },
+                            "readOnly": {
+                              "type": "boolean"
+                            },
+                            "type": {
+                              "type": "string",
+                              "const": "bind"
+                            },
+                            "source": {
+                              "type": "string",
+                              "minLength": 1
+                            },
+                            "bindOptions": {
+                              "type": "object",
+                              "properties": {
+                                "propagation": {
+                                  "type": "string",
+                                  "enum": [
+                                    "private",
+                                    "rprivate",
+                                    "shared",
+                                    "rshared",
+                                    "slave",
+                                    "rslave"
+                                  ]
+                                },
+                                "nonRecursive": {
+                                  "type": "boolean"
+                                },
+                                "createMountpoint": {
+                                  "type": "boolean"
+                                },
+                                "readOnlyNonRecursive": {
+                                  "type": "boolean"
+                                },
+                                "readOnlyForceRecursive": {
+                                  "type": "boolean"
+                                }
+                              },
+                              "required": [
+                                "propagation"
+                              ]
+                            }
+                          },
+                          "required": [
+                            "target",
+                            "type",
+                            "source"
+                          ]
+                        },
+                        {
+                          "type": "object",
+                          "properties": {
+                            "target": {
+                              "type": "string",
+                              "minLength": 1
+                            },
+                            "readOnly": {
+                              "type": "boolean"
+                            },
+                            "type": {
+                              "type": "string",
+                              "const": "tmpfs"
+                            },
+                            "source": {
+                              "not": {}
+                            },
+                            "tmpfsOptions": {
+                              "type": "object",
+                              "properties": {
+                                "sizeBytes": {
+                                  "type": "number",
+                                  "exclusiveMinimum": 0
+                                },
+                                "mode": {
+                                  "type": "number"
+                                },
+                                "options": {
+                                  "minItems": 1,
+                                  "type": "array",
+                                  "items": {
+                                    "type": "array",
+                                    "items": {
+                                      "type": "string"
+                                    }
+                                  }
+                                }
+                              },
+                              "required": [
+                                "sizeBytes",
+                                "mode"
+                              ]
+                            }
+                          },
+                          "required": [
+                            "target",
+                            "type",
+                            "source"
+                          ]
+                        }
+                      ]
                     }
                   },
                   "env": {
@@ -33128,10 +33644,182 @@
             "type": "object",
             "default": {},
             "properties": {
-              "volumes": {
+              "mounts": {
                 "type": "array",
                 "items": {
-                  "type": "string"
+                  "oneOf": [
+                    {
+                      "type": "object",
+                      "properties": {
+                        "target": {
+                          "type": "string",
+                          "minLength": 1
+                        },
+                        "readOnly": {
+                          "type": "boolean"
+                        },
+                        "type": {
+                          "type": "string",
+                          "const": "volume"
+                        },
+                        "source": {
+                          "type": [
+                            "string",
+                            "null"
+                          ],
+                          "minLength": 1
+                        },
+                        "volumeOptions": {
+                          "type": "object",
+                          "properties": {
+                            "noCopy": {
+                              "type": "boolean"
+                            },
+                            "labels": {
+                              "$ref": "#/components/schemas/StringMapDTO"
+                            },
+                            "driverConfig": {
+                              "type": "object",
+                              "properties": {
+                                "name": {
+                                  "type": "string",
+                                  "minLength": 1
+                                },
+                                "options": {
+                                  "$ref": "#/components/schemas/StringMapDTO"
+                                },
+                                "createSubpath": {
+                                  "type": "string",
+                                  "minLength": 1
+                                }
+                              },
+                              "required": [
+                                "name"
+                              ]
+                            },
+                            "subpath": {
+                              "type": "string",
+                              "minLength": 1
+                            }
+                          },
+                          "required": [
+                            "driverConfig"
+                          ]
+                        }
+                      },
+                      "required": [
+                        "target",
+                        "type",
+                        "source"
+                      ]
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "target": {
+                          "type": "string",
+                          "minLength": 1
+                        },
+                        "readOnly": {
+                          "type": "boolean"
+                        },
+                        "type": {
+                          "type": "string",
+                          "const": "bind"
+                        },
+                        "source": {
+                          "type": "string",
+                          "minLength": 1
+                        },
+                        "bindOptions": {
+                          "type": "object",
+                          "properties": {
+                            "propagation": {
+                              "type": "string",
+                              "enum": [
+                                "private",
+                                "rprivate",
+                                "shared",
+                                "rshared",
+                                "slave",
+                                "rslave"
+                              ]
+                            },
+                            "nonRecursive": {
+                              "type": "boolean"
+                            },
+                            "createMountpoint": {
+                              "type": "boolean"
+                            },
+                            "readOnlyNonRecursive": {
+                              "type": "boolean"
+                            },
+                            "readOnlyForceRecursive": {
+                              "type": "boolean"
+                            }
+                          },
+                          "required": [
+                            "propagation"
+                          ]
+                        }
+                      },
+                      "required": [
+                        "target",
+                        "type",
+                        "source"
+                      ]
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "target": {
+                          "type": "string",
+                          "minLength": 1
+                        },
+                        "readOnly": {
+                          "type": "boolean"
+                        },
+                        "type": {
+                          "type": "string",
+                          "const": "tmpfs"
+                        },
+                        "source": {
+                          "not": {}
+                        },
+                        "tmpfsOptions": {
+                          "type": "object",
+                          "properties": {
+                            "sizeBytes": {
+                              "type": "number",
+                              "exclusiveMinimum": 0
+                            },
+                            "mode": {
+                              "type": "number"
+                            },
+                            "options": {
+                              "minItems": 1,
+                              "type": "array",
+                              "items": {
+                                "type": "array",
+                                "items": {
+                                  "type": "string"
+                                }
+                              }
+                            }
+                          },
+                          "required": [
+                            "sizeBytes",
+                            "mode"
+                          ]
+                        }
+                      },
+                      "required": [
+                        "target",
+                        "type",
+                        "source"
+                      ]
+                    }
+                  ]
                 }
               },
               "env": {
@@ -33357,10 +34045,182 @@
           "config": {
             "type": "object",
             "properties": {
-              "volumes": {
+              "mounts": {
                 "type": "array",
                 "items": {
-                  "type": "string"
+                  "oneOf": [
+                    {
+                      "type": "object",
+                      "properties": {
+                        "target": {
+                          "type": "string",
+                          "minLength": 1
+                        },
+                        "readOnly": {
+                          "type": "boolean"
+                        },
+                        "type": {
+                          "type": "string",
+                          "const": "volume"
+                        },
+                        "source": {
+                          "type": [
+                            "string",
+                            "null"
+                          ],
+                          "minLength": 1
+                        },
+                        "volumeOptions": {
+                          "type": "object",
+                          "properties": {
+                            "noCopy": {
+                              "type": "boolean"
+                            },
+                            "labels": {
+                              "$ref": "#/components/schemas/StringMapDTO"
+                            },
+                            "driverConfig": {
+                              "type": "object",
+                              "properties": {
+                                "name": {
+                                  "type": "string",
+                                  "minLength": 1
+                                },
+                                "options": {
+                                  "$ref": "#/components/schemas/StringMapDTO"
+                                },
+                                "createSubpath": {
+                                  "type": "string",
+                                  "minLength": 1
+                                }
+                              },
+                              "required": [
+                                "name"
+                              ]
+                            },
+                            "subpath": {
+                              "type": "string",
+                              "minLength": 1
+                            }
+                          },
+                          "required": [
+                            "driverConfig"
+                          ]
+                        }
+                      },
+                      "required": [
+                        "target",
+                        "type",
+                        "source"
+                      ]
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "target": {
+                          "type": "string",
+                          "minLength": 1
+                        },
+                        "readOnly": {
+                          "type": "boolean"
+                        },
+                        "type": {
+                          "type": "string",
+                          "const": "bind"
+                        },
+                        "source": {
+                          "type": "string",
+                          "minLength": 1
+                        },
+                        "bindOptions": {
+                          "type": "object",
+                          "properties": {
+                            "propagation": {
+                              "type": "string",
+                              "enum": [
+                                "private",
+                                "rprivate",
+                                "shared",
+                                "rshared",
+                                "slave",
+                                "rslave"
+                              ]
+                            },
+                            "nonRecursive": {
+                              "type": "boolean"
+                            },
+                            "createMountpoint": {
+                              "type": "boolean"
+                            },
+                            "readOnlyNonRecursive": {
+                              "type": "boolean"
+                            },
+                            "readOnlyForceRecursive": {
+                              "type": "boolean"
+                            }
+                          },
+                          "required": [
+                            "propagation"
+                          ]
+                        }
+                      },
+                      "required": [
+                        "target",
+                        "type",
+                        "source"
+                      ]
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "target": {
+                          "type": "string",
+                          "minLength": 1
+                        },
+                        "readOnly": {
+                          "type": "boolean"
+                        },
+                        "type": {
+                          "type": "string",
+                          "const": "tmpfs"
+                        },
+                        "source": {
+                          "not": {}
+                        },
+                        "tmpfsOptions": {
+                          "type": "object",
+                          "properties": {
+                            "sizeBytes": {
+                              "type": "number",
+                              "exclusiveMinimum": 0
+                            },
+                            "mode": {
+                              "type": "number"
+                            },
+                            "options": {
+                              "minItems": 1,
+                              "type": "array",
+                              "items": {
+                                "type": "array",
+                                "items": {
+                                  "type": "string"
+                                }
+                              }
+                            }
+                          },
+                          "required": [
+                            "sizeBytes",
+                            "mode"
+                          ]
+                        }
+                      },
+                      "required": [
+                        "target",
+                        "type",
+                        "source"
+                      ]
+                    }
+                  ]
                 }
               },
               "env": {
@@ -33618,10 +34478,182 @@
                 "config": {
                   "type": "object",
                   "properties": {
-                    "volumes": {
+                    "mounts": {
                       "type": "array",
                       "items": {
-                        "type": "string"
+                        "oneOf": [
+                          {
+                            "type": "object",
+                            "properties": {
+                              "target": {
+                                "type": "string",
+                                "minLength": 1
+                              },
+                              "readOnly": {
+                                "type": "boolean"
+                              },
+                              "type": {
+                                "type": "string",
+                                "const": "volume"
+                              },
+                              "source": {
+                                "type": [
+                                  "string",
+                                  "null"
+                                ],
+                                "minLength": 1
+                              },
+                              "volumeOptions": {
+                                "type": "object",
+                                "properties": {
+                                  "noCopy": {
+                                    "type": "boolean"
+                                  },
+                                  "labels": {
+                                    "$ref": "#/components/schemas/StringMapDTO"
+                                  },
+                                  "driverConfig": {
+                                    "type": "object",
+                                    "properties": {
+                                      "name": {
+                                        "type": "string",
+                                        "minLength": 1
+                                      },
+                                      "options": {
+                                        "$ref": "#/components/schemas/StringMapDTO"
+                                      },
+                                      "createSubpath": {
+                                        "type": "string",
+                                        "minLength": 1
+                                      }
+                                    },
+                                    "required": [
+                                      "name"
+                                    ]
+                                  },
+                                  "subpath": {
+                                    "type": "string",
+                                    "minLength": 1
+                                  }
+                                },
+                                "required": [
+                                  "driverConfig"
+                                ]
+                              }
+                            },
+                            "required": [
+                              "target",
+                              "type",
+                              "source"
+                            ]
+                          },
+                          {
+                            "type": "object",
+                            "properties": {
+                              "target": {
+                                "type": "string",
+                                "minLength": 1
+                              },
+                              "readOnly": {
+                                "type": "boolean"
+                              },
+                              "type": {
+                                "type": "string",
+                                "const": "bind"
+                              },
+                              "source": {
+                                "type": "string",
+                                "minLength": 1
+                              },
+                              "bindOptions": {
+                                "type": "object",
+                                "properties": {
+                                  "propagation": {
+                                    "type": "string",
+                                    "enum": [
+                                      "private",
+                                      "rprivate",
+                                      "shared",
+                                      "rshared",
+                                      "slave",
+                                      "rslave"
+                                    ]
+                                  },
+                                  "nonRecursive": {
+                                    "type": "boolean"
+                                  },
+                                  "createMountpoint": {
+                                    "type": "boolean"
+                                  },
+                                  "readOnlyNonRecursive": {
+                                    "type": "boolean"
+                                  },
+                                  "readOnlyForceRecursive": {
+                                    "type": "boolean"
+                                  }
+                                },
+                                "required": [
+                                  "propagation"
+                                ]
+                              }
+                            },
+                            "required": [
+                              "target",
+                              "type",
+                              "source"
+                            ]
+                          },
+                          {
+                            "type": "object",
+                            "properties": {
+                              "target": {
+                                "type": "string",
+                                "minLength": 1
+                              },
+                              "readOnly": {
+                                "type": "boolean"
+                              },
+                              "type": {
+                                "type": "string",
+                                "const": "tmpfs"
+                              },
+                              "source": {
+                                "not": {}
+                              },
+                              "tmpfsOptions": {
+                                "type": "object",
+                                "properties": {
+                                  "sizeBytes": {
+                                    "type": "number",
+                                    "exclusiveMinimum": 0
+                                  },
+                                  "mode": {
+                                    "type": "number"
+                                  },
+                                  "options": {
+                                    "minItems": 1,
+                                    "type": "array",
+                                    "items": {
+                                      "type": "array",
+                                      "items": {
+                                        "type": "string"
+                                      }
+                                    }
+                                  }
+                                },
+                                "required": [
+                                  "sizeBytes",
+                                  "mode"
+                                ]
+                              }
+                            },
+                            "required": [
+                              "target",
+                              "type",
+                              "source"
+                            ]
+                          }
+                        ]
                       }
                     },
                     "env": {
@@ -33893,10 +34925,182 @@
               "config": {
                 "type": "object",
                 "properties": {
-                  "volumes": {
+                  "mounts": {
                     "type": "array",
                     "items": {
-                      "type": "string"
+                      "oneOf": [
+                        {
+                          "type": "object",
+                          "properties": {
+                            "target": {
+                              "type": "string",
+                              "minLength": 1
+                            },
+                            "readOnly": {
+                              "type": "boolean"
+                            },
+                            "type": {
+                              "type": "string",
+                              "const": "volume"
+                            },
+                            "source": {
+                              "type": [
+                                "string",
+                                "null"
+                              ],
+                              "minLength": 1
+                            },
+                            "volumeOptions": {
+                              "type": "object",
+                              "properties": {
+                                "noCopy": {
+                                  "type": "boolean"
+                                },
+                                "labels": {
+                                  "$ref": "#/components/schemas/StringMapDTO"
+                                },
+                                "driverConfig": {
+                                  "type": "object",
+                                  "properties": {
+                                    "name": {
+                                      "type": "string",
+                                      "minLength": 1
+                                    },
+                                    "options": {
+                                      "$ref": "#/components/schemas/StringMapDTO"
+                                    },
+                                    "createSubpath": {
+                                      "type": "string",
+                                      "minLength": 1
+                                    }
+                                  },
+                                  "required": [
+                                    "name"
+                                  ]
+                                },
+                                "subpath": {
+                                  "type": "string",
+                                  "minLength": 1
+                                }
+                              },
+                              "required": [
+                                "driverConfig"
+                              ]
+                            }
+                          },
+                          "required": [
+                            "target",
+                            "type",
+                            "source"
+                          ]
+                        },
+                        {
+                          "type": "object",
+                          "properties": {
+                            "target": {
+                              "type": "string",
+                              "minLength": 1
+                            },
+                            "readOnly": {
+                              "type": "boolean"
+                            },
+                            "type": {
+                              "type": "string",
+                              "const": "bind"
+                            },
+                            "source": {
+                              "type": "string",
+                              "minLength": 1
+                            },
+                            "bindOptions": {
+                              "type": "object",
+                              "properties": {
+                                "propagation": {
+                                  "type": "string",
+                                  "enum": [
+                                    "private",
+                                    "rprivate",
+                                    "shared",
+                                    "rshared",
+                                    "slave",
+                                    "rslave"
+                                  ]
+                                },
+                                "nonRecursive": {
+                                  "type": "boolean"
+                                },
+                                "createMountpoint": {
+                                  "type": "boolean"
+                                },
+                                "readOnlyNonRecursive": {
+                                  "type": "boolean"
+                                },
+                                "readOnlyForceRecursive": {
+                                  "type": "boolean"
+                                }
+                              },
+                              "required": [
+                                "propagation"
+                              ]
+                            }
+                          },
+                          "required": [
+                            "target",
+                            "type",
+                            "source"
+                          ]
+                        },
+                        {
+                          "type": "object",
+                          "properties": {
+                            "target": {
+                              "type": "string",
+                              "minLength": 1
+                            },
+                            "readOnly": {
+                              "type": "boolean"
+                            },
+                            "type": {
+                              "type": "string",
+                              "const": "tmpfs"
+                            },
+                            "source": {
+                              "not": {}
+                            },
+                            "tmpfsOptions": {
+                              "type": "object",
+                              "properties": {
+                                "sizeBytes": {
+                                  "type": "number",
+                                  "exclusiveMinimum": 0
+                                },
+                                "mode": {
+                                  "type": "number"
+                                },
+                                "options": {
+                                  "minItems": 1,
+                                  "type": "array",
+                                  "items": {
+                                    "type": "array",
+                                    "items": {
+                                      "type": "string"
+                                    }
+                                  }
+                                }
+                              },
+                              "required": [
+                                "sizeBytes",
+                                "mode"
+                              ]
+                            }
+                          },
+                          "required": [
+                            "target",
+                            "type",
+                            "source"
+                          ]
+                        }
+                      ]
                     }
                   },
                   "env": {
@@ -34167,10 +35371,182 @@
             "type": "object",
             "default": {},
             "properties": {
-              "volumes": {
+              "mounts": {
                 "type": "array",
                 "items": {
-                  "type": "string"
+                  "oneOf": [
+                    {
+                      "type": "object",
+                      "properties": {
+                        "target": {
+                          "type": "string",
+                          "minLength": 1
+                        },
+                        "readOnly": {
+                          "type": "boolean"
+                        },
+                        "type": {
+                          "type": "string",
+                          "const": "volume"
+                        },
+                        "source": {
+                          "type": [
+                            "string",
+                            "null"
+                          ],
+                          "minLength": 1
+                        },
+                        "volumeOptions": {
+                          "type": "object",
+                          "properties": {
+                            "noCopy": {
+                              "type": "boolean"
+                            },
+                            "labels": {
+                              "$ref": "#/components/schemas/StringMapDTO"
+                            },
+                            "driverConfig": {
+                              "type": "object",
+                              "properties": {
+                                "name": {
+                                  "type": "string",
+                                  "minLength": 1
+                                },
+                                "options": {
+                                  "$ref": "#/components/schemas/StringMapDTO"
+                                },
+                                "createSubpath": {
+                                  "type": "string",
+                                  "minLength": 1
+                                }
+                              },
+                              "required": [
+                                "name"
+                              ]
+                            },
+                            "subpath": {
+                              "type": "string",
+                              "minLength": 1
+                            }
+                          },
+                          "required": [
+                            "driverConfig"
+                          ]
+                        }
+                      },
+                      "required": [
+                        "target",
+                        "type",
+                        "source"
+                      ]
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "target": {
+                          "type": "string",
+                          "minLength": 1
+                        },
+                        "readOnly": {
+                          "type": "boolean"
+                        },
+                        "type": {
+                          "type": "string",
+                          "const": "bind"
+                        },
+                        "source": {
+                          "type": "string",
+                          "minLength": 1
+                        },
+                        "bindOptions": {
+                          "type": "object",
+                          "properties": {
+                            "propagation": {
+                              "type": "string",
+                              "enum": [
+                                "private",
+                                "rprivate",
+                                "shared",
+                                "rshared",
+                                "slave",
+                                "rslave"
+                              ]
+                            },
+                            "nonRecursive": {
+                              "type": "boolean"
+                            },
+                            "createMountpoint": {
+                              "type": "boolean"
+                            },
+                            "readOnlyNonRecursive": {
+                              "type": "boolean"
+                            },
+                            "readOnlyForceRecursive": {
+                              "type": "boolean"
+                            }
+                          },
+                          "required": [
+                            "propagation"
+                          ]
+                        }
+                      },
+                      "required": [
+                        "target",
+                        "type",
+                        "source"
+                      ]
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "target": {
+                          "type": "string",
+                          "minLength": 1
+                        },
+                        "readOnly": {
+                          "type": "boolean"
+                        },
+                        "type": {
+                          "type": "string",
+                          "const": "tmpfs"
+                        },
+                        "source": {
+                          "not": {}
+                        },
+                        "tmpfsOptions": {
+                          "type": "object",
+                          "properties": {
+                            "sizeBytes": {
+                              "type": "number",
+                              "exclusiveMinimum": 0
+                            },
+                            "mode": {
+                              "type": "number"
+                            },
+                            "options": {
+                              "minItems": 1,
+                              "type": "array",
+                              "items": {
+                                "type": "array",
+                                "items": {
+                                  "type": "string"
+                                }
+                              }
+                            }
+                          },
+                          "required": [
+                            "sizeBytes",
+                            "mode"
+                          ]
+                        }
+                      },
+                      "required": [
+                        "target",
+                        "type",
+                        "source"
+                      ]
+                    }
+                  ]
                 }
               },
               "env": {
@@ -34419,10 +35795,182 @@
             "type": "object",
             "default": {},
             "properties": {
-              "volumes": {
+              "mounts": {
                 "type": "array",
                 "items": {
-                  "type": "string"
+                  "oneOf": [
+                    {
+                      "type": "object",
+                      "properties": {
+                        "target": {
+                          "type": "string",
+                          "minLength": 1
+                        },
+                        "readOnly": {
+                          "type": "boolean"
+                        },
+                        "type": {
+                          "type": "string",
+                          "const": "volume"
+                        },
+                        "source": {
+                          "type": [
+                            "string",
+                            "null"
+                          ],
+                          "minLength": 1
+                        },
+                        "volumeOptions": {
+                          "type": "object",
+                          "properties": {
+                            "noCopy": {
+                              "type": "boolean"
+                            },
+                            "labels": {
+                              "$ref": "#/components/schemas/StringMapDTO"
+                            },
+                            "driverConfig": {
+                              "type": "object",
+                              "properties": {
+                                "name": {
+                                  "type": "string",
+                                  "minLength": 1
+                                },
+                                "options": {
+                                  "$ref": "#/components/schemas/StringMapDTO"
+                                },
+                                "createSubpath": {
+                                  "type": "string",
+                                  "minLength": 1
+                                }
+                              },
+                              "required": [
+                                "name"
+                              ]
+                            },
+                            "subpath": {
+                              "type": "string",
+                              "minLength": 1
+                            }
+                          },
+                          "required": [
+                            "driverConfig"
+                          ]
+                        }
+                      },
+                      "required": [
+                        "target",
+                        "type",
+                        "source"
+                      ]
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "target": {
+                          "type": "string",
+                          "minLength": 1
+                        },
+                        "readOnly": {
+                          "type": "boolean"
+                        },
+                        "type": {
+                          "type": "string",
+                          "const": "bind"
+                        },
+                        "source": {
+                          "type": "string",
+                          "minLength": 1
+                        },
+                        "bindOptions": {
+                          "type": "object",
+                          "properties": {
+                            "propagation": {
+                              "type": "string",
+                              "enum": [
+                                "private",
+                                "rprivate",
+                                "shared",
+                                "rshared",
+                                "slave",
+                                "rslave"
+                              ]
+                            },
+                            "nonRecursive": {
+                              "type": "boolean"
+                            },
+                            "createMountpoint": {
+                              "type": "boolean"
+                            },
+                            "readOnlyNonRecursive": {
+                              "type": "boolean"
+                            },
+                            "readOnlyForceRecursive": {
+                              "type": "boolean"
+                            }
+                          },
+                          "required": [
+                            "propagation"
+                          ]
+                        }
+                      },
+                      "required": [
+                        "target",
+                        "type",
+                        "source"
+                      ]
+                    },
+                    {
+                      "type": "object",
+                      "properties": {
+                        "target": {
+                          "type": "string",
+                          "minLength": 1
+                        },
+                        "readOnly": {
+                          "type": "boolean"
+                        },
+                        "type": {
+                          "type": "string",
+                          "const": "tmpfs"
+                        },
+                        "source": {
+                          "not": {}
+                        },
+                        "tmpfsOptions": {
+                          "type": "object",
+                          "properties": {
+                            "sizeBytes": {
+                              "type": "number",
+                              "exclusiveMinimum": 0
+                            },
+                            "mode": {
+                              "type": "number"
+                            },
+                            "options": {
+                              "minItems": 1,
+                              "type": "array",
+                              "items": {
+                                "type": "array",
+                                "items": {
+                                  "type": "string"
+                                }
+                              }
+                            }
+                          },
+                          "required": [
+                            "sizeBytes",
+                            "mode"
+                          ]
+                        }
+                      },
+                      "required": [
+                        "target",
+                        "type",
+                        "source"
+                      ]
+                    }
+                  ]
                 }
               },
               "env": {

--- a/packages/api/src/shared/http-exception-filter.ts
+++ b/packages/api/src/shared/http-exception-filter.ts
@@ -19,11 +19,8 @@ export class HttpExceptionFilter implements ExceptionFilter {
     // Get the request object from the arguments host
     const request = ctx.getRequest<Request>()
     this.logger.debug(
-      'API EXCEPTION (%s %s):',
-      request.method,
-      request.url,
+      `API EXCEPTION (${request.method} ${request.url}):`,
       exception,
-      exception.stack,
     )
 
     // Get the status code from the exception

--- a/packages/api/src/socket/app/app-socket.gateway.ts
+++ b/packages/api/src/socket/app/app-socket.gateway.ts
@@ -210,7 +210,6 @@ export class AppSocketGateway implements OnGatewayConnection, OnGatewayInit {
                     return socket.join(roomKey)
                   },
                 ),
-                // eslint-disable-next-line promise/no-nesting
               ).then(() => {
                 socket.onAny((event: string, ...args: unknown[]) => {
                   if (event === 'APP_API') {

--- a/packages/types/src/api-paths.d.ts
+++ b/packages/types/src/api-paths.d.ts
@@ -7291,7 +7291,48 @@ export interface components {
                 profileKey: string;
                 dockerHostId: string;
                 config: {
-                    volumes?: string[];
+                    mounts?: ({
+                        target: string;
+                        readOnly?: boolean;
+                        /** @constant */
+                        type: "volume";
+                        source: string | null;
+                        volumeOptions?: {
+                            noCopy?: boolean;
+                            labels?: components["schemas"]["StringMapDTO"];
+                            driverConfig: {
+                                name: string;
+                                options?: components["schemas"]["StringMapDTO"];
+                                createSubpath?: string;
+                            };
+                            subpath?: string;
+                        };
+                    } | {
+                        target: string;
+                        readOnly?: boolean;
+                        /** @constant */
+                        type: "bind";
+                        source: string;
+                        bindOptions?: {
+                            /** @enum {string} */
+                            propagation: "private" | "rprivate" | "shared" | "rshared" | "slave" | "rslave";
+                            nonRecursive?: boolean;
+                            createMountpoint?: boolean;
+                            readOnlyNonRecursive?: boolean;
+                            readOnlyForceRecursive?: boolean;
+                        };
+                    } | {
+                        target: string;
+                        readOnly?: boolean;
+                        /** @constant */
+                        type: "tmpfs";
+                        source: unknown;
+                        tmpfsOptions?: {
+                            sizeBytes: number;
+                            mode: number;
+                            options?: string[][];
+                        };
+                    })[];
                     env?: components["schemas"]["StringMapDTO"];
                     gpus?: {
                         driver: string;
@@ -7356,7 +7397,48 @@ export interface components {
                 hostLabel: string;
                 hostEndpoint: string;
                 resourceConfig: {
-                    volumes?: string[];
+                    mounts?: ({
+                        target: string;
+                        readOnly?: boolean;
+                        /** @constant */
+                        type: "volume";
+                        source: string | null;
+                        volumeOptions?: {
+                            noCopy?: boolean;
+                            labels?: components["schemas"]["StringMapDTO"];
+                            driverConfig: {
+                                name: string;
+                                options?: components["schemas"]["StringMapDTO"];
+                                createSubpath?: string;
+                            };
+                            subpath?: string;
+                        };
+                    } | {
+                        target: string;
+                        readOnly?: boolean;
+                        /** @constant */
+                        type: "bind";
+                        source: string;
+                        bindOptions?: {
+                            /** @enum {string} */
+                            propagation: "private" | "rprivate" | "shared" | "rshared" | "slave" | "rslave";
+                            nonRecursive?: boolean;
+                            createMountpoint?: boolean;
+                            readOnlyNonRecursive?: boolean;
+                            readOnlyForceRecursive?: boolean;
+                        };
+                    } | {
+                        target: string;
+                        readOnly?: boolean;
+                        /** @constant */
+                        type: "tmpfs";
+                        source: unknown;
+                        tmpfsOptions?: {
+                            sizeBytes: number;
+                            mode: number;
+                            options?: string[][];
+                        };
+                    })[];
                     env?: components["schemas"]["StringMapDTO"];
                     gpus?: {
                         driver: string;
@@ -7419,7 +7501,48 @@ export interface components {
                 profileKey: string;
                 dockerHostId: string;
                 config: {
-                    volumes?: string[];
+                    mounts?: ({
+                        target: string;
+                        readOnly?: boolean;
+                        /** @constant */
+                        type: "volume";
+                        source: string | null;
+                        volumeOptions?: {
+                            noCopy?: boolean;
+                            labels?: components["schemas"]["StringMapDTO"];
+                            driverConfig: {
+                                name: string;
+                                options?: components["schemas"]["StringMapDTO"];
+                                createSubpath?: string;
+                            };
+                            subpath?: string;
+                        };
+                    } | {
+                        target: string;
+                        readOnly?: boolean;
+                        /** @constant */
+                        type: "bind";
+                        source: string;
+                        bindOptions?: {
+                            /** @enum {string} */
+                            propagation: "private" | "rprivate" | "shared" | "rshared" | "slave" | "rslave";
+                            nonRecursive?: boolean;
+                            createMountpoint?: boolean;
+                            readOnlyNonRecursive?: boolean;
+                            readOnlyForceRecursive?: boolean;
+                        };
+                    } | {
+                        target: string;
+                        readOnly?: boolean;
+                        /** @constant */
+                        type: "tmpfs";
+                        source: unknown;
+                        tmpfsOptions?: {
+                            sizeBytes: number;
+                            mode: number;
+                            options?: string[][];
+                        };
+                    })[];
                     env?: components["schemas"]["StringMapDTO"];
                     gpus?: {
                         driver: string;
@@ -7485,7 +7608,48 @@ export interface components {
             dockerHostId: string;
             /** @default {} */
             config: {
-                volumes?: string[];
+                mounts?: ({
+                    target: string;
+                    readOnly?: boolean;
+                    /** @constant */
+                    type: "volume";
+                    source: string | null;
+                    volumeOptions?: {
+                        noCopy?: boolean;
+                        labels?: components["schemas"]["StringMapDTO"];
+                        driverConfig: {
+                            name: string;
+                            options?: components["schemas"]["StringMapDTO"];
+                            createSubpath?: string;
+                        };
+                        subpath?: string;
+                    };
+                } | {
+                    target: string;
+                    readOnly?: boolean;
+                    /** @constant */
+                    type: "bind";
+                    source: string;
+                    bindOptions?: {
+                        /** @enum {string} */
+                        propagation: "private" | "rprivate" | "shared" | "rshared" | "slave" | "rslave";
+                        nonRecursive?: boolean;
+                        createMountpoint?: boolean;
+                        readOnlyNonRecursive?: boolean;
+                        readOnlyForceRecursive?: boolean;
+                    };
+                } | {
+                    target: string;
+                    readOnly?: boolean;
+                    /** @constant */
+                    type: "tmpfs";
+                    source: unknown;
+                    tmpfsOptions?: {
+                        sizeBytes: number;
+                        mode: number;
+                        options?: string[][];
+                    };
+                })[];
                 env?: components["schemas"]["StringMapDTO"];
                 gpus?: {
                     driver: string;
@@ -7544,7 +7708,48 @@ export interface components {
             /** Format: uuid */
             dockerHostId?: string;
             config?: {
-                volumes?: string[];
+                mounts?: ({
+                    target: string;
+                    readOnly?: boolean;
+                    /** @constant */
+                    type: "volume";
+                    source: string | null;
+                    volumeOptions?: {
+                        noCopy?: boolean;
+                        labels?: components["schemas"]["StringMapDTO"];
+                        driverConfig: {
+                            name: string;
+                            options?: components["schemas"]["StringMapDTO"];
+                            createSubpath?: string;
+                        };
+                        subpath?: string;
+                    };
+                } | {
+                    target: string;
+                    readOnly?: boolean;
+                    /** @constant */
+                    type: "bind";
+                    source: string;
+                    bindOptions?: {
+                        /** @enum {string} */
+                        propagation: "private" | "rprivate" | "shared" | "rshared" | "slave" | "rslave";
+                        nonRecursive?: boolean;
+                        createMountpoint?: boolean;
+                        readOnlyNonRecursive?: boolean;
+                        readOnlyForceRecursive?: boolean;
+                    };
+                } | {
+                    target: string;
+                    readOnly?: boolean;
+                    /** @constant */
+                    type: "tmpfs";
+                    source: unknown;
+                    tmpfsOptions?: {
+                        sizeBytes: number;
+                        mode: number;
+                        options?: string[][];
+                    };
+                })[];
                 env?: components["schemas"]["StringMapDTO"];
                 gpus?: {
                     driver: string;
@@ -7614,7 +7819,48 @@ export interface components {
                 desiredStatus: "running" | "stopped";
                 containerId: string;
                 config: {
-                    volumes?: string[];
+                    mounts?: ({
+                        target: string;
+                        readOnly?: boolean;
+                        /** @constant */
+                        type: "volume";
+                        source: string | null;
+                        volumeOptions?: {
+                            noCopy?: boolean;
+                            labels?: components["schemas"]["StringMapDTO"];
+                            driverConfig: {
+                                name: string;
+                                options?: components["schemas"]["StringMapDTO"];
+                                createSubpath?: string;
+                            };
+                            subpath?: string;
+                        };
+                    } | {
+                        target: string;
+                        readOnly?: boolean;
+                        /** @constant */
+                        type: "bind";
+                        source: string;
+                        bindOptions?: {
+                            /** @enum {string} */
+                            propagation: "private" | "rprivate" | "shared" | "rshared" | "slave" | "rslave";
+                            nonRecursive?: boolean;
+                            createMountpoint?: boolean;
+                            readOnlyNonRecursive?: boolean;
+                            readOnlyForceRecursive?: boolean;
+                        };
+                    } | {
+                        target: string;
+                        readOnly?: boolean;
+                        /** @constant */
+                        type: "tmpfs";
+                        source: unknown;
+                        tmpfsOptions?: {
+                            sizeBytes: number;
+                            mode: number;
+                            options?: string[][];
+                        };
+                    })[];
                     env?: components["schemas"]["StringMapDTO"];
                     gpus?: {
                         driver: string;
@@ -7684,7 +7930,48 @@ export interface components {
                 desiredStatus: "running" | "stopped";
                 containerId: string;
                 config: {
-                    volumes?: string[];
+                    mounts?: ({
+                        target: string;
+                        readOnly?: boolean;
+                        /** @constant */
+                        type: "volume";
+                        source: string | null;
+                        volumeOptions?: {
+                            noCopy?: boolean;
+                            labels?: components["schemas"]["StringMapDTO"];
+                            driverConfig: {
+                                name: string;
+                                options?: components["schemas"]["StringMapDTO"];
+                                createSubpath?: string;
+                            };
+                            subpath?: string;
+                        };
+                    } | {
+                        target: string;
+                        readOnly?: boolean;
+                        /** @constant */
+                        type: "bind";
+                        source: string;
+                        bindOptions?: {
+                            /** @enum {string} */
+                            propagation: "private" | "rprivate" | "shared" | "rshared" | "slave" | "rslave";
+                            nonRecursive?: boolean;
+                            createMountpoint?: boolean;
+                            readOnlyNonRecursive?: boolean;
+                            readOnlyForceRecursive?: boolean;
+                        };
+                    } | {
+                        target: string;
+                        readOnly?: boolean;
+                        /** @constant */
+                        type: "tmpfs";
+                        source: unknown;
+                        tmpfsOptions?: {
+                            sizeBytes: number;
+                            mode: number;
+                            options?: string[][];
+                        };
+                    })[];
                     env?: components["schemas"]["StringMapDTO"];
                     gpus?: {
                         driver: string;
@@ -7757,7 +8044,48 @@ export interface components {
             desiredStatus: "running" | "stopped";
             /** @default {} */
             config: {
-                volumes?: string[];
+                mounts?: ({
+                    target: string;
+                    readOnly?: boolean;
+                    /** @constant */
+                    type: "volume";
+                    source: string | null;
+                    volumeOptions?: {
+                        noCopy?: boolean;
+                        labels?: components["schemas"]["StringMapDTO"];
+                        driverConfig: {
+                            name: string;
+                            options?: components["schemas"]["StringMapDTO"];
+                            createSubpath?: string;
+                        };
+                        subpath?: string;
+                    };
+                } | {
+                    target: string;
+                    readOnly?: boolean;
+                    /** @constant */
+                    type: "bind";
+                    source: string;
+                    bindOptions?: {
+                        /** @enum {string} */
+                        propagation: "private" | "rprivate" | "shared" | "rshared" | "slave" | "rslave";
+                        nonRecursive?: boolean;
+                        createMountpoint?: boolean;
+                        readOnlyNonRecursive?: boolean;
+                        readOnlyForceRecursive?: boolean;
+                    };
+                } | {
+                    target: string;
+                    readOnly?: boolean;
+                    /** @constant */
+                    type: "tmpfs";
+                    source: unknown;
+                    tmpfsOptions?: {
+                        sizeBytes: number;
+                        mode: number;
+                        options?: string[][];
+                    };
+                })[];
                 env?: components["schemas"]["StringMapDTO"];
                 gpus?: {
                     driver: string;
@@ -7826,7 +8154,48 @@ export interface components {
             desiredStatus: "running" | "stopped";
             /** @default {} */
             config: {
-                volumes?: string[];
+                mounts?: ({
+                    target: string;
+                    readOnly?: boolean;
+                    /** @constant */
+                    type: "volume";
+                    source: string | null;
+                    volumeOptions?: {
+                        noCopy?: boolean;
+                        labels?: components["schemas"]["StringMapDTO"];
+                        driverConfig: {
+                            name: string;
+                            options?: components["schemas"]["StringMapDTO"];
+                            createSubpath?: string;
+                        };
+                        subpath?: string;
+                    };
+                } | {
+                    target: string;
+                    readOnly?: boolean;
+                    /** @constant */
+                    type: "bind";
+                    source: string;
+                    bindOptions?: {
+                        /** @enum {string} */
+                        propagation: "private" | "rprivate" | "shared" | "rshared" | "slave" | "rslave";
+                        nonRecursive?: boolean;
+                        createMountpoint?: boolean;
+                        readOnlyNonRecursive?: boolean;
+                        readOnlyForceRecursive?: boolean;
+                    };
+                } | {
+                    target: string;
+                    readOnly?: boolean;
+                    /** @constant */
+                    type: "tmpfs";
+                    source: unknown;
+                    tmpfsOptions?: {
+                        sizeBytes: number;
+                        mode: number;
+                        options?: string[][];
+                    };
+                })[];
                 env?: components["schemas"]["StringMapDTO"];
                 gpus?: {
                     driver: string;

--- a/packages/ui/src/views/server/docker/container-config-form.tsx
+++ b/packages/ui/src/views/server/docker/container-config-form.tsx
@@ -35,6 +35,8 @@ function stringToLines(s: string): string[] {
     .filter(Boolean)
 }
 
+type ConfigMount = NonNullable<DockerContainerResourceConfig['mounts']>[number]
+
 function stringToKeyValueRecord(s: string): Record<string, string> | undefined {
   const entries: Record<string, string> = {}
   for (const line of s.split('\n')) {
@@ -48,6 +50,42 @@ function stringToKeyValueRecord(s: string): Record<string, string> | undefined {
     }
   }
   return Object.keys(entries).length > 0 ? entries : undefined
+}
+
+function mountsToJson(val: ConfigMount[] | undefined): string {
+  if (!val || val.length === 0) {
+    return ''
+  }
+  return JSON.stringify(val, null, 2)
+}
+
+// Parse the textarea contents. Returns undefined for empty/whitespace
+// (meaning "no mounts configured"). Returns the parsed array for well-
+// formed JSON. Returns the error string itself so the caller can preserve
+// the user's in-progress input on the server round-trip — the server will
+// still reject it via Zod validation, which is the source of truth.
+function mountsFromJson(
+  s: string,
+):
+  | { kind: 'empty' }
+  | { kind: 'valid'; value: ConfigMount[] }
+  | { kind: 'invalid'; error: string } {
+  const trimmed = s.trim()
+  if (!trimmed) {
+    return { kind: 'empty' }
+  }
+  try {
+    const parsed: unknown = JSON.parse(trimmed)
+    if (!Array.isArray(parsed)) {
+      return { kind: 'invalid', error: 'Expected a JSON array of mounts' }
+    }
+    return { kind: 'valid', value: parsed as ConfigMount[] }
+  } catch (err) {
+    return {
+      kind: 'invalid',
+      error: err instanceof Error ? err.message : String(err),
+    }
+  }
 }
 
 // ─── Sub-components ───────────────────────────────────────────────────────
@@ -100,7 +138,7 @@ export function loadConfigState(
   cfg: DockerContainerResourceConfig,
 ): ContainerConfigState {
   return {
-    volumes: parseStringArray(cfg.volumes),
+    mounts: mountsToJson(cfg.mounts),
     tmpfs: parseKeyValueRecord(cfg.tmpfs),
     devices: parseStringArray(cfg.devices),
     env: (() => {
@@ -171,9 +209,11 @@ export function buildConfigFromState(
 ): DockerContainerResourceConfig {
   const config: DockerContainerResourceConfig = {}
 
-  const volLines = stringToLines(s.volumes)
-  if (volLines.length > 0) {
-    config.volumes = volLines
+  // Mounts is a JSON textarea. Well-formed JSON wins; invalid / in-progress
+  // input drops the field (server would reject it anyway). Empty = omit.
+  const parsedMounts = mountsFromJson(s.mounts)
+  if (parsedMounts.kind === 'valid') {
+    config.mounts = parsedMounts.value
   }
   const tmpfsRecord = stringToKeyValueRecord(s.tmpfs)
   if (tmpfsRecord) {
@@ -329,7 +369,7 @@ export function buildConfigFromState(
 }
 
 export interface ContainerConfigState {
-  volumes: string
+  mounts: string
   tmpfs: string
   devices: string
   env: string
@@ -368,7 +408,7 @@ export interface ContainerConfigState {
 }
 
 export const EMPTY_CONFIG_STATE: ContainerConfigState = {
-  volumes: '',
+  mounts: '',
   tmpfs: '',
   devices: '',
   env: '',
@@ -435,6 +475,8 @@ export function ContainerConfigForm({
       state.ports.map((p, i) => (i === index ? { ...p, [field]: value } : p)),
     )
 
+  const mountsParse = mountsFromJson(state.mounts)
+
   return (
     <div className="relative flex max-h-max min-h-0 rounded-lg border border-muted/40 bg-muted">
       <div className="pointer-events-none absolute -inset-x-px -top-px z-10 h-7 rounded-t-lg bg-linear-to-b from-muted to-transparent" />
@@ -444,14 +486,28 @@ export function ContainerConfigForm({
           {/* ── Storage ─────────────────────────────────────────── */}
           <div className="flex flex-col gap-3">
             <h3 className="text-sm font-medium">Storage</h3>
-            <ConfigTextarea
-              id="cfg-volumes"
-              label="Volumes"
-              placeholder={'/host/path:/container/path\n/data:/data:ro'}
-              hint="One volume mount per line."
-              value={state.volumes}
-              onChange={(v) => set('volumes', v)}
-            />
+            <div className="flex flex-col gap-1.5">
+              <Label htmlFor="cfg-mounts">Mounts (JSON)</Label>
+              <textarea
+                id="cfg-mounts"
+                className="min-h-[120px] w-full rounded-md border border-input bg-background px-3 py-2 font-mono text-sm placeholder:text-muted-foreground"
+                placeholder={`[\n  {\n    "type": "volume",\n    "target": "/workspace",\n    "volumeOptions": {\n      "driverConfig": {\n        "name": "local",\n        "options": {\n          "type": "nfs",\n          "o": "addr=10.0.0.5,nfsvers=4,rw",\n          "device": ":/mnt/user/codicle/{{appIdentifier}}"\n        }\n      }\n    }\n  }\n]`}
+                value={state.mounts}
+                onChange={(e) => set('mounts', e.target.value)}
+                rows={10}
+                spellCheck={false}
+              />
+              {mountsParse.kind === 'invalid' ? (
+                <p className="text-xs text-destructive">
+                  Invalid JSON: {mountsParse.error}
+                </p>
+              ) : (
+                <p className="text-xs text-muted-foreground">
+                  JSON array of Docker mounts. Strings (e.g. {'{{ '}
+                  appIdentifier {'}}'}) are templatable. Empty = no mounts.
+                </p>
+              )}
+            </div>
             <div className="grid grid-cols-2 gap-3">
               <ConfigTextarea
                 id="cfg-tmpfs"


### PR DESCRIPTION
## Summary

Docker resource config only exposed `volumes` (host:container bind mounts). Apps couldn't request named volumes, tmpfs mounts, or other Docker mount types without us inventing a Lombok-specific shorthand. Adds a parallel `mounts` field carrying the full Docker mount object.

- `docker-resource-config-input.dto` extended with `mounts`.
- `docker-jobs.service` (~200-line refactor): accept `mounts` alongside `volumes`; resolve/validate and expand template tokens consistently.
- `docker-bridge` (`adapter` + `dockerode-adapter`) passes mounts through to the Docker socket.
- `data-template.util` covers mount targets/sources; new unit spec.
- e2e: `docker.e2e-spec` + `docker-host-management.e2e-spec` extended.
- openapi + `api-paths.d.ts` regenerated.

> **Stacked PR** — depends on #229 (LOM-297). Targets `mekpans/lom-297-...`; will retarget to `main` once upstream lands.

Closes [LOM-298](https://linear.app/lombokapp/issue/LOM-298/support-mounts-property-in-docker-resource-config)