### PR TITLE
feat(LOM-301): allow apps to attach extra details when minting an app-user token

### DIFF
--- a/packages/api/src/app/services/app-socket-message.handler.ts
+++ b/packages/api/src/app/services/app-socket-message.handler.ts
@@ -9,6 +9,8 @@ import {
   AppSocketMessageSchemaMap,
 } from '@lombokapp/types'
 import { AsyncWorkError, buildUnexpectedError } from '@lombokapp/worker-utils'
+import { eq } from 'drizzle-orm'
+import { sessionsTable } from 'src/auth/entities/session.entity'
 import type { JWTService } from 'src/auth/services/jwt.service'
 import type { EventService } from 'src/event/services/event.service'
 import type { FolderService } from 'src/folders/services/folder.service'
@@ -128,6 +130,9 @@ export async function handleAppSocketMessage(
         result: await appService.createAppUserAccessTokenAsApp({
           actor: { appIdentifier: requestingAppIdentifier },
           userId: parsedRequest.data.userId,
+          ...(parsedRequest.data.extra
+            ? { extra: parsedRequest.data.extra }
+            : {}),
         }),
       }
     case 'EMIT_EVENT':
@@ -216,12 +221,28 @@ export async function handleAppSocketMessage(
             error: { code: 401, message: 'Token app identifier mismatch' },
           }
         }
-        jwtService.verifyAppUserJWT({
+        const verified = jwtService.verifyAppUserJWT({
           token: parsedRequest.data.token,
           userId,
           appIdentifier: requestingAppIdentifier,
         })
-        return { result: { userId, success: true } }
+        const sessionId =
+          typeof verified.jti === 'string'
+            ? verified.jti.split(':')[0]
+            : undefined
+        let extra: JsonSerializableObject | undefined
+        if (sessionId) {
+          const session = await ormService.db.query.sessionsTable.findFirst({
+            where: eq(sessionsTable.id, sessionId),
+          })
+          if (session?.typeDetails) {
+            const { app: _app, ...rest } = session.typeDetails
+            if (Object.keys(rest).length > 0) {
+              extra = rest as JsonSerializableObject
+            }
+          }
+        }
+        return { result: { userId, success: true, extra } }
       } catch (error) {
         return {
           error: {

--- a/packages/api/src/app/services/app.service.ts
+++ b/packages/api/src/app/services/app.service.ts
@@ -8,6 +8,7 @@ import type {
   AppSearchResults,
   ExecuteAppDockerJobOptions,
   FolderScopeAppPermissions,
+  JsonSerializableObject,
   StorageAccessPolicy,
   UserScopeAppPermissions,
 } from '@lombokapp/types'
@@ -287,9 +288,11 @@ export class AppService {
   async createAppUserAccessTokenAsApp({
     actor,
     userId,
+    extra,
   }: {
     actor: { appIdentifier: string }
     userId: string
+    extra?: JsonSerializableObject
   }) {
     await this.validateAppUserAccess({
       appIdentifier: actor.appIdentifier,
@@ -307,17 +310,25 @@ export class AppService {
       throw new NotFoundException(`App not found: ${actor.appIdentifier}`)
     }
 
-    return this.sessionService.createAppUserSession(user, actor.appIdentifier)
+    return this.sessionService.createAppUserSession(
+      user,
+      actor.appIdentifier,
+      extra,
+    )
   }
 
-  async createAppUserSession(user: User, appIdentifier: string) {
+  async createAppUserSession(
+    user: User,
+    appIdentifier: string,
+    extra?: Record<string, string | number | boolean | null>,
+  ) {
     await this.validateAppUserAccess({ appIdentifier, userId: user.id })
     const app = await this.getApp(appIdentifier, { enabled: true })
     if (!app) {
       throw new NotFoundException(`App not found: ${appIdentifier}`)
     }
 
-    return this.sessionService.createAppUserSession(user, appIdentifier)
+    return this.sessionService.createAppUserSession(user, appIdentifier, extra)
   }
 
   async handleAppRequest(

--- a/packages/api/src/app/tests/app-socket.e2e-spec.ts
+++ b/packages/api/src/app/tests/app-socket.e2e-spec.ts
@@ -12,6 +12,7 @@ import {
 } from 'bun:test'
 import { eq } from 'drizzle-orm'
 import { io, type Socket } from 'socket.io-client'
+import { sessionsTable } from 'src/auth/entities/session.entity'
 import { eventsTable } from 'src/event/entities/event.entity'
 import { runWithThreadContext } from 'src/shared/thread-context'
 import { tasksTable } from 'src/task/entities/task.entity'
@@ -276,6 +277,119 @@ describe('App Socket Interface', () => {
       console.log(`'result' not in response:`, response)
       throw new Error('Expected result in response')
     }
+  })
+
+  it('persists extra typeDetails on GET_APP_USER_ACCESS_TOKEN', async () => {
+    socket = await connectSocket('test-instance-1')
+
+    const {
+      session: { accessToken: userToken },
+    } = await createTestUser(testModule!, {
+      username: 'extrauser',
+      password: '123',
+    })
+
+    const viewer =
+      await testModule!.services.ormService.db.query.usersTable.findFirst({
+        where: eq(usersTable.username, 'extrauser'),
+      })
+    const appIdentifier = SOCKET_TEST_APP_SLUG
+    const enableAppResponse = await testModule!
+      .apiClient(userToken)
+      .POST(`/api/v1/user/apps/{appIdentifier}/settings`, {
+        params: { path: { appIdentifier } },
+        body: {
+          folderScopePermissionsDefault: null,
+          enabled: true,
+          permissions: ['READ_USER'],
+          folderScopeEnabledDefault: true,
+        },
+      })
+    expect(enableAppResponse.response.status).toBe(201)
+
+    const extra = {
+      workspaceId: 'ws-123',
+      role: 'editor',
+      seat: 7,
+      trial: true,
+      note: null,
+    }
+
+    const response = await buildAppClient(
+      socket,
+      serverBaseUrl,
+    ).getAppUserAccessToken({
+      userId: viewer?.id ?? '',
+      extra,
+    })
+
+    if (!('result' in response)) {
+      throw new Error('Expected result in response')
+    }
+    expect(typeof response.result.accessToken).toBe('string')
+
+    const sessions =
+      await testModule!.services.ormService.db.query.sessionsTable.findMany({
+        where: eq(sessionsTable.userId, viewer?.id ?? ''),
+        orderBy: (s, { desc }) => [desc(s.createdAt)],
+      })
+    expect(sessions.length).toBeGreaterThan(0)
+    const session = sessions[0]!
+    expect(session.type).toBe('app_user')
+    expect(session.typeDetails).toEqual({
+      ...extra,
+      app: appIdentifier,
+    })
+  })
+
+  it('reserved app key in extra cannot override appIdentifier', async () => {
+    socket = await connectSocket('test-instance-1')
+
+    const {
+      session: { accessToken: userToken },
+    } = await createTestUser(testModule!, {
+      username: 'reserveduser',
+      password: '123',
+    })
+
+    const viewer =
+      await testModule!.services.ormService.db.query.usersTable.findFirst({
+        where: eq(usersTable.username, 'reserveduser'),
+      })
+    const appIdentifier = SOCKET_TEST_APP_SLUG
+    const enableAppResponse = await testModule!
+      .apiClient(userToken)
+      .POST(`/api/v1/user/apps/{appIdentifier}/settings`, {
+        params: { path: { appIdentifier } },
+        body: {
+          folderScopePermissionsDefault: null,
+          enabled: true,
+          permissions: ['READ_USER'],
+          folderScopeEnabledDefault: true,
+        },
+      })
+    expect(enableAppResponse.response.status).toBe(201)
+
+    const response = await buildAppClient(
+      socket,
+      serverBaseUrl,
+    ).getAppUserAccessToken({
+      userId: viewer?.id ?? '',
+      extra: { app: 'spoofed-app', tag: 'ok' },
+    })
+
+    if (!('result' in response)) {
+      throw new Error('Expected result in response')
+    }
+
+    const sessions =
+      await testModule!.services.ormService.db.query.sessionsTable.findMany({
+        where: eq(sessionsTable.userId, viewer?.id ?? ''),
+        orderBy: (s, { desc }) => [desc(s.createdAt)],
+      })
+    const session = sessions[0]!
+    expect(session.typeDetails?.app).toBe(appIdentifier)
+    expect(session.typeDetails?.tag).toBe('ok')
   })
 
   it('should handle TRIGGER_APP_TASK message', async () => {

--- a/packages/api/src/auth/entities/session.entity.ts
+++ b/packages/api/src/auth/entities/session.entity.ts
@@ -1,3 +1,4 @@
+import type { JsonSerializableObject } from '@lombokapp/types'
 import {
   index,
   jsonb,
@@ -14,10 +15,7 @@ export const sessionsTable = pgTable(
     hash: text('hash').notNull(),
     userId: uuid('user_id').notNull(),
     type: text('type').notNull(),
-    typeDetails:
-      jsonb('type_details').$type<
-        Record<string, string | number | boolean | null>
-      >(),
+    typeDetails: jsonb('type_details').$type<JsonSerializableObject>(),
     expiresAt: timestamp('expires_at').notNull(),
     createdAt: timestamp('created_at').notNull(),
     updatedAt: timestamp('updated_at').notNull(),

--- a/packages/api/src/auth/services/session.service.ts
+++ b/packages/api/src/auth/services/session.service.ts
@@ -1,3 +1,4 @@
+import { JsonSerializableObject } from '@lombokapp/types'
 import { Injectable, UnauthorizedException } from '@nestjs/common'
 import { and, eq } from 'drizzle-orm'
 import type { AccessTokenJWT } from 'src/auth/services/jwt.service'
@@ -52,7 +53,11 @@ export class SessionService {
     }
   }
 
-  async createAppUserSession(user: User, appIdentifier: string) {
+  async createAppUserSession(
+    user: User,
+    appIdentifier: string,
+    extra?: JsonSerializableObject,
+  ) {
     const secret = hashedTokenHelper.createSecretKey()
 
     const now = new Date()
@@ -62,6 +67,7 @@ export class SessionService {
       hash: hashedTokenHelper.createHash(secret),
       type: 'app_user',
       typeDetails: {
+        ...(extra ?? {}),
         app: appIdentifier,
       },
       expiresAt: sessionExpiresAt(now),

--- a/packages/api/src/mcp/services/mcp-token.service.ts
+++ b/packages/api/src/mcp/services/mcp-token.service.ts
@@ -75,15 +75,17 @@ export class McpTokenService {
       )
       .orderBy(desc(sessionsTable.createdAt))
 
-    return sessions.map((session) => ({
-      id: session.id,
-      clientName: String(session.typeDetails?.['clientName'] ?? ''),
-      createdAt: session.createdAt,
-      lastUsedAt:
-        session.typeDetails?.['lastUsedAt'] != null
-          ? String(session.typeDetails['lastUsedAt'])
-          : null,
-    }))
+    return sessions.map((session) => {
+      const clientNameValue = session.typeDetails?.['clientName']
+      const lastUsedAtValue = session.typeDetails?.['lastUsedAt']
+      return {
+        id: session.id,
+        clientName: typeof clientNameValue === 'string' ? clientNameValue : '',
+        createdAt: session.createdAt,
+        lastUsedAt:
+          typeof lastUsedAtValue === 'string' ? lastUsedAtValue : null,
+      }
+    })
   }
 
   async revokeMcpToken(userId: string, tokenId: string): Promise<void> {
@@ -135,10 +137,11 @@ export class McpTokenService {
       .where(eq(sessionsTable.id, session.id))
       .execute()
 
+    const clientNameValue = session.typeDetails?.['clientName']
     return {
       id: session.id,
       userId: session.userId,
-      clientName: String(session.typeDetails?.['clientName'] ?? ''),
+      clientName: typeof clientNameValue === 'string' ? clientNameValue : '',
     }
   }
 }

--- a/packages/core-worker/src/worker-scripts/worker-daemon/worker-daemon.ts
+++ b/packages/core-worker/src/worker-scripts/worker-daemon/worker-daemon.ts
@@ -10,7 +10,7 @@ import {
   createLombokAppPgDatabase,
   LombokAppPgClient,
 } from '@lombokapp/app-worker-sdk'
-import { type paths, type TaskDTO } from '@lombokapp/types'
+import type { JsonSerializableObject, paths, TaskDTO } from '@lombokapp/types'
 import type {
   WorkerModuleStartContext,
   WorkerRequest,
@@ -339,6 +339,7 @@ void (async () => {
           // Authenticate the user if Authorization header is present
           let userId: string | undefined
           let accessToken: string | undefined
+          let actorExtra: JsonSerializableObject | undefined
           let actor: Parameters<RequestHandler>[1]['actor']
 
           const authStartTime = Date.now()
@@ -399,6 +400,7 @@ void (async () => {
 
                 userId = authResult.result.userId
                 accessToken = token
+                actorExtra = authResult.result.extra
                 logTiming('authentication_complete', authStartTime, {
                   requestId: pipeRequest.id,
                   userId,
@@ -472,6 +474,7 @@ void (async () => {
                   return fetch(new Request(fetchRequest, { headers }))
                 },
               }),
+              extra: actorExtra ?? {},
             }
           }
 

--- a/packages/types/src/app-socket-message-schemas.ts
+++ b/packages/types/src/app-socket-message-schemas.ts
@@ -43,6 +43,7 @@ export const attemptStartHandleTaskByIdSchema = z.object({
 
 export const getAppUserAccessTokenSchema = z.object({
   userId: z.uuid(),
+  extra: jsonSerializableObjectSchema.optional(),
 })
 
 export const getContentSignedUrlsSchema = z.array(
@@ -315,6 +316,7 @@ export const AppSocketMessageResponseSchemaMap = {
     z.object({
       userId: z.string(),
       success: z.boolean(),
+      extra: jsonSerializableObjectSchema.optional(),
     }),
   ),
   EXECUTE_APP_DOCKER_JOB: executeAppDockerJobResponseSchema,

--- a/packages/types/src/apps.types.ts
+++ b/packages/types/src/apps.types.ts
@@ -9,6 +9,7 @@ import {
   appSlugSchema,
   workerIdentifierSchema,
 } from './identifiers.types'
+import type { JsonSerializableObject } from './json.types'
 import { jsonSerializableObjectSchema } from './json.types'
 import type { TaskOnCompleteConfig } from './task.types'
 import { taskConfigSchema, taskTriggerConfigSchema } from './task.types'
@@ -46,6 +47,7 @@ export type WorkerApiActor =
       actorType: 'user'
       userId?: string
       userApiClient: LombokApiClient
+      extra?: JsonSerializableObject
     }
   | {
       actorType: 'system'


### PR DESCRIPTION
## Summary

`MINT_APP_USER_TOKEN` now accepts an optional `extra` JSON object that is persisted on the session and surfaced to app worker code via the worker-daemon's actor metadata. Lets apps carry app-specific context (workspace ID, role, scope, etc.) into the session without an out-of-band lookup on every request.

- Schema/types: `MINT_APP_USER_TOKEN` accepts an optional `extra: JsonSerializableObject`.
- API: `app-socket-message.handler` + `app.service` plumb `extra` into session creation; `session.entity` + `session.service` persist on `typeDetails`.
- MCP: `mcp-token.service` adopts the same shape.
- Worker daemon: `actor.extra` is passed through to app worker code.
- Tests: `app-socket.e2e-spec` covers mint with/without `extra`, persistence, and reserved-key handling.

Closes [LOM-301](https://linear.app/lombokapp/issue/LOM-301/allow-apps-to-attach-extra-details-when-minting-an-app-user-token)