### PR TITLE
design(LOM-302): move theme switch from navbar into sidebar

### DIFF
--- a/packages/ui/src/components/sidebar/components/menu.tsx
+++ b/packages/ui/src/components/sidebar/components/menu.tsx
@@ -10,6 +10,7 @@ import { CollapseMenuButton } from './collapse-menu-button'
 import { NotificationsTrigger } from './notifications-trigger'
 import { SidebarGroup } from './sidebar-group'
 import { SidebarItem } from './sidebar-item'
+import { ThemeToggleTrigger } from './theme-toggle-trigger'
 
 interface MenuProps {
   isOpen: boolean | undefined
@@ -68,8 +69,9 @@ export function Menu({
           </ul>
         </nav>
       </ScrollArea>
-      <div className="space-y-1 px-3 pb-2">
+      <div className="space-y-1 border-t px-3 pb-2 pt-2">
         <NotificationsTrigger isOpen={isOpen} />
+        <ThemeToggleTrigger isOpen={isOpen} />
         <SidebarItem
           icon={LogOut}
           label="Sign out"

--- a/packages/ui/src/components/sidebar/components/navbar.tsx
+++ b/packages/ui/src/components/sidebar/components/navbar.tsx
@@ -11,7 +11,6 @@ import { cn } from '@lombokapp/ui-toolkit/utils/tailwind'
 import React from 'react'
 import { Link } from 'react-router'
 
-import { ModeToggle } from '../../mode-toggle/mode-toggle'
 import { SheetMenu } from './sheet-menu'
 import { UserNav } from './user-nav'
 
@@ -68,7 +67,6 @@ export function Navbar({ breadcrumbs }: NavbarProps) {
         </div>
         {authContext.viewer && (
           <div className="flex shrink-0 items-center justify-end gap-2 px-2">
-            <ModeToggle />
             <UserNav
               onSignout={() => authContext.logout()}
               viewer={authContext.viewer}

--- a/packages/ui/src/components/sidebar/components/theme-toggle-trigger.tsx
+++ b/packages/ui/src/components/sidebar/components/theme-toggle-trigger.tsx
@@ -1,0 +1,67 @@
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from '@lombokapp/ui-toolkit/components/dropdown-menu/dropdown-menu'
+import { MonitorIcon, MoonIcon, SunIcon } from 'lucide-react'
+
+import { useTheme } from '@/src/contexts/theme'
+
+import { SidebarItem } from './sidebar-item'
+
+interface ThemeToggleTriggerProps {
+  isOpen: boolean | undefined
+}
+
+const THEME_META = {
+  light: { icon: SunIcon, label: 'Light theme' },
+  dark: { icon: MoonIcon, label: 'Dark theme' },
+  system: { icon: MonitorIcon, label: 'System theme' },
+} as const
+
+type ThemeKey = keyof typeof THEME_META
+
+function isThemeKey(value: string): value is ThemeKey {
+  return value === 'light' || value === 'dark' || value === 'system'
+}
+
+export function ThemeToggleTrigger({ isOpen }: ThemeToggleTriggerProps) {
+  const { theme, setTheme } = useTheme()
+  const isSidebarCollapsed = isOpen === false
+  const active: ThemeKey = isThemeKey(theme) ? theme : 'system'
+  const { icon, label } = THEME_META[active]
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <SidebarItem
+          icon={icon}
+          label={label}
+          isOpen={isOpen}
+          asChild
+          data-testid="theme-toggle"
+        />
+      </DropdownMenuTrigger>
+      <DropdownMenuContent
+        side={isSidebarCollapsed ? 'right' : 'top'}
+        align="start"
+        sideOffset={8}
+        className="min-w-[10rem]"
+      >
+        <DropdownMenuItem onClick={() => setTheme('light')}>
+          <SunIcon className="mr-2 size-4" />
+          Light
+        </DropdownMenuItem>
+        <DropdownMenuItem onClick={() => setTheme('dark')}>
+          <MoonIcon className="mr-2 size-4" />
+          Dark
+        </DropdownMenuItem>
+        <DropdownMenuItem onClick={() => setTheme('system')}>
+          <MonitorIcon className="mr-2 size-4" />
+          System
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  )
+}


### PR DESCRIPTION
## Summary

Relocates the light/dark/system theme toggle from the top-right navbar into the sidebar menu. Removes the standalone navbar `ModeToggle` and adds a new `ThemeToggleTrigger` sidebar item whose dropdown lays out correctly whether the sidebar is collapsed (popover anchors right) or expanded (above the trigger).

The new sidebar item carries the existing `data-testid="theme-toggle"` so `theme.ui-e2e-spec` keeps passing unchanged.

Closes [LOM-302](https://linear.app/lombokapp/issue/LOM-302/move-theme-switch-from-navbar-into-sidebar)