### PR TITLE
fix(LOM-307): worker token expiry — extend DockerContainerAppUserToken lifetime

### DIFF
--- a/packages/api/src/app/services/app.service.ts
+++ b/packages/api/src/app/services/app.service.ts
@@ -285,12 +285,14 @@ export class AppService {
     worker,
     platformAccess,
     extra,
+    accessTokenExpiresInSec,
   }: {
     actor: { appIdentifier: string }
     userId: string
     worker?: string
     platformAccess?: boolean
     extra?: JsonSerializableObject
+    accessTokenExpiresInSec?: number
   }) {
     await this.validateAppUserAccess({
       appIdentifier: actor.appIdentifier,
@@ -314,6 +316,9 @@ export class AppService {
       worker,
       platformAccess,
       extra,
+      ...(accessTokenExpiresInSec !== undefined
+        ? { accessTokenExpiresInSec }
+        : {}),
     })
   }
 

--- a/packages/api/src/auth/constants/duration.constants.ts
+++ b/packages/api/src/auth/constants/duration.constants.ts
@@ -11,6 +11,7 @@ export const enum AuthDurationSeconds {
   DockerContainerAppToken = 24 * 60 * 60, // long-lived app token for persistent docker containers
   AppActorAccessToken = 15 * 60, // app actor access tokens (runtime workers, shared docker containers)
   AppUserActorAccessToken = 5 * 60, // app_user actor access tokens (UI sessions and worker-context tokens)
+  DockerContainerAppUserToken = 24 * 60 * 60, // long-lived app_user token for persistent docker containers
 }
 
 /**

--- a/packages/api/src/auth/services/jwt.service.ts
+++ b/packages/api/src/auth/services/jwt.service.ts
@@ -258,6 +258,7 @@ export class JWTService {
     worker?: string
     platformAccess?: boolean
     extra?: JsonSerializableObject
+    accessTokenExpiresInSec?: number
   }): Promise<string> {
     assertExtraSize(params.extra)
     const platformAccess = JWTService.resolvePlatformAccess(params)
@@ -275,7 +276,9 @@ export class JWTService {
         subject: `${APP_USER_JWT_SUB_PREFIX}${params.session.userId}:${params.appIdentifier}`,
         audience: params.appIdentifier,
         jwtid: `${params.session.id}:${uuidV4()}`,
-        expiresInSec: AuthDurationSeconds.AppUserActorAccessToken,
+        expiresInSec:
+          params.accessTokenExpiresInSec ??
+          AuthDurationSeconds.AppUserActorAccessToken,
       },
     )
   }

--- a/packages/api/src/auth/services/session.service.ts
+++ b/packages/api/src/auth/services/session.service.ts
@@ -59,8 +59,10 @@ export class SessionService {
     worker?: string
     platformAccess?: boolean
     extra?: JsonSerializableObject
+    accessTokenExpiresInSec?: number
   }) {
-    const { user, appIdentifier, worker, extra } = params
+    const { user, appIdentifier, worker, extra, accessTokenExpiresInSec } =
+      params
     const platformAccess = JWTService.resolvePlatformAccess(params)
     const secret = hashedTokenHelper.createSecretKey()
 
@@ -95,6 +97,9 @@ export class SessionService {
       worker,
       platformAccess,
       extra,
+      ...(accessTokenExpiresInSec !== undefined
+        ? { accessTokenExpiresInSec }
+        : {}),
     })
     const refreshToken = hashedTokenHelper.encode(session.id, secret)
 

--- a/packages/api/src/docker/services/docker-worker-hook.service.ts
+++ b/packages/api/src/docker/services/docker-worker-hook.service.ts
@@ -21,6 +21,7 @@ import * as jose from 'jose'
 import { appsTable } from 'src/app/entities/app.entity'
 import { appFolderSettingsTable } from 'src/app/entities/app-folder-settings.entity'
 import { AppService } from 'src/app/services/app.service'
+import { AuthDurationSeconds } from 'src/auth/constants/duration.constants'
 import { JWTService } from 'src/auth/services/jwt.service'
 import { KeyDerivationService } from 'src/auth/services/key-derivation.service'
 import { coreConfig } from 'src/core/config'
@@ -271,6 +272,8 @@ export class DockerWorkerHookService {
         ...(typeof params.platformAccess === 'boolean'
           ? { platformAccess: params.platformAccess }
           : {}),
+        accessTokenExpiresInSec:
+          AuthDurationSeconds.DockerContainerAppUserToken,
       })
       return {
         token: result.accessToken,
@@ -311,6 +314,8 @@ export class DockerWorkerHookService {
         ...(claims.worker !== undefined ? { worker: claims.worker } : {}),
         platformAccess: claims.platformAccess,
         ...(claims.extra ? { extra: claims.extra } : {}),
+        accessTokenExpiresInSec:
+          AuthDurationSeconds.DockerContainerAppUserToken,
       })
       return {
         accessToken: result.accessToken,


### PR DESCRIPTION
Worker tokens were expiring inside the worker's normal job-running window. Adds a longer-lived `DockerContainerAppUserToken` duration and threads it through `app.service`, `jwt.service`, and `session.service`.

Closes [LOM-307](https://linear.app/lombokapp/issue/LOM-307/fix-worker-token-expiry-extend-dockercontainerappusertoken-lifetime)