### PR TITLE
fix(LOM-308): worker agent robustness + structured error details capture

### DIFF
--- a/docker/worker-agent/internal/runner/cancel.go
+++ b/docker/worker-agent/internal/runner/cancel.go
@@ -29,7 +29,7 @@ type CancelJobConfig struct {
 
 // CancelJob cancels a running job, killing the worker process and recording failure
 // It handles both exec_per_job and persistent_http interfaces appropriately
-func CancelJob(config CancelJobConfig, errorCode string, errorMessage string) error {
+func CancelJob(config CancelJobConfig, errorCode string, errorMessage string, errorDetails map[string]any) error {
 	// Determine which interface type we're dealing with
 	workerKind := config.JobState.WorkerKind
 	if workerKind == "" {
@@ -151,6 +151,7 @@ func CancelJob(config CancelJobConfig, errorCode string, errorMessage string) er
 			Error: &types.JobError{
 				Code:    errorCode,
 				Message: errorMessage,
+				Details: errorDetails,
 			},
 		}
 		if err := config.PlatformClient.SignalCompletion(ctx, config.Payload.JobID, completionReq); err != nil {
@@ -161,16 +162,20 @@ func CancelJob(config CancelJobConfig, errorCode string, errorMessage string) er
 	}
 
 	// Output result to stdout for the platform to capture
+	errMap := map[string]interface{}{
+		"code":    errorCode,
+		"message": errorMessage,
+	}
+	if len(errorDetails) > 0 {
+		errMap["details"] = errorDetails
+	}
 	result := map[string]interface{}{
 		"success":   false,
 		"exit_code": 1,
 		"job_id":    config.Payload.JobID,
 		"job_class": config.Payload.JobClass,
 		"timing":    timing,
-		"error": map[string]interface{}{
-			"code":    errorCode,
-			"message": errorMessage,
-		},
+		"error":     errMap,
 	}
 
 	resultJSON, _ := json.Marshal(result)
@@ -186,6 +191,7 @@ func CancelJob(config CancelJobConfig, errorCode string, errorMessage string) er
 		Error: &types.JobError{
 			Code:    errorCode,
 			Message: errorMessage,
+			Details: errorDetails,
 		},
 	}
 	if err := state.WriteJobResult(jobResult); err != nil {

--- a/docker/worker-agent/internal/runner/exec.go
+++ b/docker/worker-agent/internal/runner/exec.go
@@ -135,6 +135,12 @@ func RunExecPerJob(payload *types.JobPayload, jobStartTime time.Time) error {
 			"worker_startup_time_seconds": workerStartupDuration.Seconds(),
 		}
 
+		startErrorMessage := fmt.Sprintf("failed to start worker: %s", err.Error())
+		startErrorDetails := map[string]any{
+			"worker_command":   payload.WorkerCommand,
+			"underlying_error": err.Error(),
+		}
+
 		// Signal completion to platform if available
 		if platformClient != nil {
 			ctx := context.Background()
@@ -142,7 +148,8 @@ func RunExecPerJob(payload *types.JobPayload, jobStartTime time.Time) error {
 				Success: false,
 				Error: &types.JobError{
 					Code:    "WORKER_START_ERROR",
-					Message: fmt.Sprintf("failed to start worker: %s", err.Error()),
+					Message: startErrorMessage,
+					Details: startErrorDetails,
 				},
 			}
 			if err := platformClient.SignalCompletion(ctx, payload.JobID, completionReq); err != nil {
@@ -159,7 +166,8 @@ func RunExecPerJob(payload *types.JobPayload, jobStartTime time.Time) error {
 			"timing":    timing,
 			"error": map[string]interface{}{
 				"code":    "WORKER_START_ERROR",
-				"message": fmt.Sprintf("failed to start worker: %s", err.Error()),
+				"message": startErrorMessage,
+				"details": startErrorDetails,
 			},
 		}
 
@@ -175,7 +183,8 @@ func RunExecPerJob(payload *types.JobPayload, jobStartTime time.Time) error {
 			ExitCode: func() *int { v := 1; return &v }(),
 			Error: &types.JobError{
 				Code:    "WORKER_START_ERROR",
-				Message: fmt.Sprintf("failed to start worker: %s", err.Error()),
+				Message: startErrorMessage,
+				Details: startErrorDetails,
 			},
 		}
 		if err := state.WriteJobResult(jobResult); err != nil {
@@ -209,7 +218,9 @@ func RunExecPerJob(payload *types.JobPayload, jobStartTime time.Time) error {
 				JobStartTime:    jobStartTime,
 				WorkerStartTime: workerStartTime,
 				ExecCmd:         cmd,
-			}, "PLATFORM_START_SIGNAL_ERROR", fmt.Sprintf("failed to signal start to platform: %v", err))
+			}, "PLATFORM_START_SIGNAL_ERROR", fmt.Sprintf("failed to signal start to platform: %v", err), map[string]any{
+				"underlying_error": err.Error(),
+			})
 
 			os.Exit(1)
 			return cancelErr
@@ -255,12 +266,28 @@ func RunExecPerJob(payload *types.JobPayload, jobStartTime time.Time) error {
 
 	var workerResult interface{}
 	var workerResultRaw json.RawMessage
-	// Read worker result from result file written by worker to JOB_RESULT_FILE
+	var workerSuppliedError *types.JobError
+	// Read worker result from result file written by worker to JOB_RESULT_FILE.
+	// Workers MAY return either a plain result object, or a structured envelope
+	// `{"success": false, "error": {"code": ..., "message": ..., "details": ...}}`
+	// to signal a failure with rich context.
 	if resultData, err := os.ReadFile(resultFilePath); err == nil {
 		var parsedResult interface{}
 		if err := json.Unmarshal(resultData, &parsedResult); err == nil {
 			workerResult = parsedResult
 			workerResultRaw = resultData
+		}
+
+		// Try to extract a worker-supplied structured error. Honored only when
+		// the envelope shape is well-formed: `error` is an object with a
+		// non-empty code (so we don't pick up unrelated `error` fields in
+		// arbitrary worker output).
+		var envelope struct {
+			Error *types.JobError `json:"error,omitempty"`
+		}
+		if err := json.Unmarshal(resultData, &envelope); err == nil &&
+			envelope.Error != nil && envelope.Error.Code != "" {
+			workerSuppliedError = envelope.Error
 		}
 	}
 
@@ -308,21 +335,36 @@ func RunExecPerJob(payload *types.JobPayload, jobStartTime time.Time) error {
 
 		// Signal completion to platform
 		ctx := context.Background()
-		completionSuccess := exitCode == 0 && !uploadFailed
+		completionSuccess := exitCode == 0 && !uploadFailed && workerSuppliedError == nil
 		completionReq := &types.CompletionRequest{
 			Success:     completionSuccess,
 			Result:      workerResultRaw,
 			OutputFiles: outputFiles,
 		}
 		if exitCode != 0 {
-			completionReq.Error = &types.JobError{
-				Code:    "WORKER_EXIT_ERROR",
-				Message: fmt.Sprintf("worker exited with code %d: %s", exitCode, exitError),
+			if workerSuppliedError != nil {
+				// Prefer the worker's own structured error when available.
+				completionReq.Error = workerSuppliedError
+			} else {
+				completionReq.Error = &types.JobError{
+					Code:    "WORKER_EXIT_ERROR",
+					Message: fmt.Sprintf("worker exited with code %d: %s", exitCode, exitError),
+					Details: map[string]any{
+						"exit_code": exitCode,
+					},
+				}
 			}
+		} else if workerSuppliedError != nil {
+			// Worker exited 0 but signalled a structured failure in its result
+			// file. Treat as failure and forward the worker's error verbatim.
+			completionReq.Error = workerSuppliedError
 		} else if uploadFailed {
 			completionReq.Error = &types.JobError{
 				Code:    "FILE_UPLOAD_ERROR",
 				Message: fmt.Sprintf("failed to upload output files: %v", uploadError),
+				Details: map[string]any{
+					"underlying_error": uploadError.Error(),
+				},
 			}
 		}
 
@@ -339,8 +381,9 @@ func RunExecPerJob(payload *types.JobPayload, jobStartTime time.Time) error {
 		"worker_startup_time_seconds": workerStartupDuration.Seconds(),
 	}
 
-	// Determine final success status (job fails if worker failed OR upload failed)
-	finalSuccess := exitCode == 0 && !uploadFailed
+	// Determine final success status (job fails if worker exited non-zero,
+	// upload failed, or the worker emitted a structured error envelope).
+	finalSuccess := exitCode == 0 && !uploadFailed && workerSuppliedError == nil
 
 	result := map[string]interface{}{
 		"success":   finalSuccess,
@@ -360,16 +403,42 @@ func RunExecPerJob(payload *types.JobPayload, jobStartTime time.Time) error {
 		result["output_files"] = outputFiles
 	}
 
+	// Pick the canonical error to surface for this job, mirroring the
+	// completion-signal logic above.
+	var finalError *types.JobError
 	if exitCode != 0 {
-		result["error"] = map[string]interface{}{
-			"code":    "WORKER_EXIT_ERROR",
-			"message": fmt.Sprintf("worker exited with code %d: %s", exitCode, exitError),
+		if workerSuppliedError != nil {
+			finalError = workerSuppliedError
+		} else {
+			finalError = &types.JobError{
+				Code:    "WORKER_EXIT_ERROR",
+				Message: fmt.Sprintf("worker exited with code %d: %s", exitCode, exitError),
+				Details: map[string]any{
+					"exit_code": exitCode,
+				},
+			}
 		}
+	} else if workerSuppliedError != nil {
+		finalError = workerSuppliedError
 	} else if uploadFailed {
-		result["error"] = map[string]interface{}{
-			"code":    "FILE_UPLOAD_ERROR",
-			"message": fmt.Sprintf("failed to upload output files: %v", uploadError),
+		finalError = &types.JobError{
+			Code:    "FILE_UPLOAD_ERROR",
+			Message: fmt.Sprintf("failed to upload output files: %v", uploadError),
+			Details: map[string]any{
+				"underlying_error": uploadError.Error(),
+			},
 		}
+	}
+
+	if finalError != nil {
+		errMap := map[string]interface{}{
+			"code":    finalError.Code,
+			"message": finalError.Message,
+		}
+		if len(finalError.Details) > 0 {
+			errMap["details"] = finalError.Details
+		}
+		result["error"] = errMap
 	}
 
 	resultJSON, _ := json.Marshal(result)
@@ -387,16 +456,8 @@ func RunExecPerJob(payload *types.JobPayload, jobStartTime time.Time) error {
 	if workerResult != nil {
 		jobResult.Result = workerResult
 	}
-	if exitCode != 0 {
-		jobResult.Error = &types.JobError{
-			Code:    "WORKER_EXIT_ERROR",
-			Message: fmt.Sprintf("worker exited with code %d: %s", exitCode, exitError),
-		}
-	} else if uploadFailed {
-		jobResult.Error = &types.JobError{
-			Code:    "FILE_UPLOAD_ERROR",
-			Message: fmt.Sprintf("failed to upload output files: %v", uploadError),
-		}
+	if finalError != nil {
+		jobResult.Error = finalError
 	}
 	if err := state.WriteJobResult(jobResult); err != nil {
 		logs.WriteAgentLog(logs.LogLevelWarn, "Failed to write job result", map[string]any{
@@ -413,7 +474,9 @@ func RunExecPerJob(payload *types.JobPayload, jobStartTime time.Time) error {
 		jobState.Status = "success"
 	} else {
 		jobState.Status = "failed"
-		if exitCode != 0 {
+		if finalError != nil {
+			jobState.Error = finalError.Message
+		} else if exitCode != 0 {
 			jobState.Error = fmt.Sprintf("worker exited with code %d", exitCode)
 		} else if uploadFailed {
 			jobState.Error = fmt.Sprintf("failed to upload output files: %v", uploadError)
@@ -426,8 +489,9 @@ func RunExecPerJob(payload *types.JobPayload, jobStartTime time.Time) error {
 		})
 	}
 
-	// Exit with the worker's exit code, or error code if upload/completion signal failed
-	if completionSignalFailed || uploadFailed {
+	// Exit non-zero if anything went wrong: worker exit, upload failure,
+	// completion signal failure, or worker-supplied structured error.
+	if completionSignalFailed || uploadFailed || workerSuppliedError != nil {
 		os.Exit(1)
 	}
 	if exitCode != 0 {

--- a/docker/worker-agent/internal/runner/http.go
+++ b/docker/worker-agent/internal/runner/http.go
@@ -116,6 +116,11 @@ func RunPersistentHTTP(payload *types.JobPayload, jobStartTime time.Time) error 
 		workerStartupDurationActual := time.Since(workerStartupStartTime)
 		totalJobDuration := time.Since(jobStartTime)
 
+		errorDetails := map[string]any{
+			"port":            workerPort,
+			"readiness_error": err.Error(),
+		}
+
 		// Signal completion to platform if available
 		if platformClient != nil {
 			ctx := context.Background()
@@ -124,6 +129,7 @@ func RunPersistentHTTP(payload *types.JobPayload, jobStartTime time.Time) error 
 				Error: &types.JobError{
 					Code:    "WORKER_NOT_READY",
 					Message: err.Error(),
+					Details: errorDetails,
 				},
 			}
 			if err := platformClient.SignalCompletion(ctx, payload.JobID, completionReq); err != nil {
@@ -137,6 +143,7 @@ func RunPersistentHTTP(payload *types.JobPayload, jobStartTime time.Time) error 
 			"error": map[string]interface{}{
 				"code":    "WORKER_NOT_READY",
 				"message": err.Error(),
+				"details": errorDetails,
 			},
 			"timing": map[string]interface{}{
 				"total_time_seconds":          totalJobDuration.Seconds(),
@@ -177,7 +184,10 @@ func RunPersistentHTTP(payload *types.JobPayload, jobStartTime time.Time) error 
 				JobStartTime:    jobStartTime,
 				WorkerStartTime: workerStartupStartTime,
 				WorkerPID:       workerState.PID,
-			}, "PLATFORM_START_SIGNAL_ERROR", fmt.Sprintf("failed to signal start to platform: %v", err))
+			}, "PLATFORM_START_SIGNAL_ERROR", fmt.Sprintf("failed to signal start to platform: %v", err), map[string]any{
+				"underlying_error": err.Error(),
+				"worker_pid":       workerState.PID,
+			})
 
 			os.Exit(1)
 			return cancelErr
@@ -209,12 +219,19 @@ func RunPersistentHTTP(payload *types.JobPayload, jobStartTime time.Time) error 
 		workerStartupDurationActual := time.Since(workerStartupStartTime)
 		totalJobDuration := time.Since(jobStartTime)
 
+		errorDetails := map[string]any{
+			"port":             workerPort,
+			"submit_url":       submitURL,
+			"underlying_error": err.Error(),
+		}
+
 		result := map[string]interface{}{
 			"success": false,
 			"job_id":  payload.JobID,
 			"error": map[string]interface{}{
 				"code":    "JOB_SUBMIT_FAILED",
 				"message": err.Error(),
+				"details": errorDetails,
 			},
 			"timing": map[string]interface{}{
 				"total_time_seconds":          totalJobDuration.Seconds(),
@@ -251,6 +268,20 @@ func RunPersistentHTTP(payload *types.JobPayload, jobStartTime time.Time) error 
 		workerStartupDurationActual := time.Since(workerStartupStartTime)
 		totalJobDuration := time.Since(jobStartTime)
 
+		errorDetails := map[string]any{
+			"port":             workerPort,
+			"http_status_code": resp.StatusCode,
+		}
+		// Preserve any worker-supplied details from the rejection response.
+		if submitResp.Error != nil {
+			if submitResp.Error.Code != "" {
+				errorDetails["worker_error_code"] = submitResp.Error.Code
+			}
+			if len(submitResp.Error.Details) > 0 {
+				errorDetails["worker_error_details"] = submitResp.Error.Details
+			}
+		}
+
 		// Signal completion to platform if available
 		if platformClient != nil {
 			ctx := context.Background()
@@ -259,6 +290,7 @@ func RunPersistentHTTP(payload *types.JobPayload, jobStartTime time.Time) error 
 				Error: &types.JobError{
 					Code:    "JOB_NOT_ACCEPTED",
 					Message: errMsg,
+					Details: errorDetails,
 				},
 			}
 			if err := platformClient.SignalCompletion(ctx, payload.JobID, completionReq); err != nil {
@@ -272,6 +304,7 @@ func RunPersistentHTTP(payload *types.JobPayload, jobStartTime time.Time) error 
 			"error": map[string]interface{}{
 				"code":    "JOB_NOT_ACCEPTED",
 				"message": errMsg,
+				"details": errorDetails,
 			},
 			"timing": map[string]interface{}{
 				"total_time_seconds":          totalJobDuration.Seconds(),
@@ -340,6 +373,11 @@ func RunPersistentHTTP(payload *types.JobPayload, jobStartTime time.Time) error 
 		workerStartupDurationActual := time.Since(workerStartupStartTime)
 		totalJobDuration := time.Since(jobStartTime)
 
+		errorDetails := map[string]any{
+			"port":            workerPort,
+			"timeout_seconds": jobPollTimeout.Seconds(),
+		}
+
 		// Signal completion to platform if available
 		if platformClient != nil {
 			ctx := context.Background()
@@ -348,6 +386,7 @@ func RunPersistentHTTP(payload *types.JobPayload, jobStartTime time.Time) error 
 				Error: &types.JobError{
 					Code:    "JOB_POLL_TIMEOUT",
 					Message: jobState.Error,
+					Details: errorDetails,
 				},
 			}
 			if err := platformClient.SignalCompletion(ctx, payload.JobID, completionReq); err != nil {
@@ -361,6 +400,7 @@ func RunPersistentHTTP(payload *types.JobPayload, jobStartTime time.Time) error 
 			"error": map[string]interface{}{
 				"code":    "JOB_POLL_TIMEOUT",
 				"message": jobState.Error,
+				"details": errorDetails,
 			},
 			"timing": map[string]interface{}{
 				"job_execution_time_seconds":  jobExecutionDuration.Seconds(),

--- a/docker/worker-agent/internal/types/payload.go
+++ b/docker/worker-agent/internal/types/payload.go
@@ -100,12 +100,13 @@ type HTTPJobResponse struct {
 }
 
 // JobError represents an error from a job execution.
-// Supports both structured {"code":"...","message":"..."} and plain string
+// Supports both structured {"code":"...","message":"...","details":{...}} and plain string
 // formats during JSON unmarshaling, so that validation errors from workers
 // that return {"error":"some string"} don't cause parse failures.
 type JobError struct {
-	Code    string `json:"code"`
-	Message string `json:"message"`
+	Code    string         `json:"code"`
+	Message string         `json:"message"`
+	Details map[string]any `json:"details,omitempty"`
 }
 
 // UnmarshalJSON handles both string and object error formats from workers.

--- a/docker/worker-agent/internal/types/payload_test.go
+++ b/docker/worker-agent/internal/types/payload_test.go
@@ -1,0 +1,104 @@
+package types
+
+import (
+	"encoding/json"
+	"reflect"
+	"testing"
+)
+
+func TestJobError_UnmarshalJSON_PlainString(t *testing.T) {
+	var got JobError
+	if err := json.Unmarshal([]byte(`"boom"`), &got); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if got.Code != "UNKNOWN" {
+		t.Errorf("Code = %q, want %q", got.Code, "UNKNOWN")
+	}
+	if got.Message != "boom" {
+		t.Errorf("Message = %q, want %q", got.Message, "boom")
+	}
+	if got.Details != nil {
+		t.Errorf("Details = %v, want nil", got.Details)
+	}
+}
+
+func TestJobError_UnmarshalJSON_StructuredWithoutDetails(t *testing.T) {
+	var got JobError
+	if err := json.Unmarshal([]byte(`{"code":"X","message":"Y"}`), &got); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if got.Code != "X" {
+		t.Errorf("Code = %q, want %q", got.Code, "X")
+	}
+	if got.Message != "Y" {
+		t.Errorf("Message = %q, want %q", got.Message, "Y")
+	}
+	if got.Details != nil {
+		t.Errorf("Details = %v, want nil", got.Details)
+	}
+}
+
+func TestJobError_UnmarshalJSON_StructuredWithDetails(t *testing.T) {
+	var got JobError
+	raw := `{"code":"X","message":"Y","details":{"foo":"bar","n":42,"nested":{"k":"v"}}}`
+	if err := json.Unmarshal([]byte(raw), &got); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if got.Code != "X" {
+		t.Errorf("Code = %q, want %q", got.Code, "X")
+	}
+	if got.Message != "Y" {
+		t.Errorf("Message = %q, want %q", got.Message, "Y")
+	}
+	wantDetails := map[string]any{
+		"foo":    "bar",
+		"n":      float64(42), // json.Unmarshal decodes numbers as float64 into any
+		"nested": map[string]any{"k": "v"},
+	}
+	if !reflect.DeepEqual(map[string]any(got.Details), wantDetails) {
+		t.Errorf("Details = %#v, want %#v", got.Details, wantDetails)
+	}
+}
+
+func TestJobError_MarshalJSON_RoundTrip(t *testing.T) {
+	original := JobError{
+		Code:    "X",
+		Message: "Y",
+		Details: map[string]any{"foo": "bar"},
+	}
+
+	encoded, err := json.Marshal(original)
+	if err != nil {
+		t.Fatalf("marshal failed: %v", err)
+	}
+
+	var decoded JobError
+	if err := json.Unmarshal(encoded, &decoded); err != nil {
+		t.Fatalf("unmarshal failed: %v", err)
+	}
+
+	if decoded.Code != original.Code || decoded.Message != original.Message {
+		t.Errorf("round-trip mismatch: got %+v, want %+v", decoded, original)
+	}
+	if !reflect.DeepEqual(map[string]any(decoded.Details), original.Details) {
+		t.Errorf("round-trip Details mismatch: got %#v, want %#v", decoded.Details, original.Details)
+	}
+}
+
+func TestJobError_MarshalJSON_OmitsEmptyDetails(t *testing.T) {
+	original := JobError{Code: "X", Message: "Y"}
+
+	encoded, err := json.Marshal(original)
+	if err != nil {
+		t.Fatalf("marshal failed: %v", err)
+	}
+
+	// `details` should be omitted when nil/empty thanks to the `omitempty` tag.
+	wantJSON := `{"code":"X","message":"Y"}`
+	if string(encoded) != wantJSON {
+		t.Errorf("encoded = %s, want %s", string(encoded), wantJSON)
+	}
+}

--- a/docker/worker-job-runner/src/mock-worker.ts
+++ b/docker/worker-job-runner/src/mock-worker.ts
@@ -47,9 +47,28 @@ interface JobState {
   jobClass: string
   status: 'pending' | 'running' | 'success' | 'failed'
   result?: unknown
-  error?: { code: string; message: string }
+  error?: {
+    code: string
+    message: string
+    details?: Record<string, unknown>
+  }
   startedAt: string
   completedAt?: string
+}
+
+/**
+ * Error class that workers can throw to surface a structured error envelope
+ * (code, message, details) back to the worker-agent and platform.
+ */
+class MockJobError extends Error {
+  constructor(
+    public readonly code: string,
+    public readonly mockMessage: string,
+    public readonly details?: Record<string, unknown>,
+  ) {
+    super(mockMessage)
+    this.name = 'MockJobError'
+  }
 }
 
 // Store for tracking job states
@@ -719,6 +738,27 @@ const handleUpdatesDemo: JobHandler = async (input, ctx) => {
   return { updatesQueued: updates.length }
 }
 
+// Fails with a structured error envelope (code, message, details) so tests can
+// verify that the worker-agent forwards `details` end-to-end to the platform.
+interface FailWithDetailsInput {
+  code: string
+  message: string
+  details?: Record<string, unknown>
+}
+
+const handleFailWithDetails: JobHandler = (input, ctx) => {
+  if (
+    !isObject(input) ||
+    typeof (input as unknown as FailWithDetailsInput).code !== 'string' ||
+    typeof (input as unknown as FailWithDetailsInput).message !== 'string'
+  ) {
+    throw new Error('Invalid input: expected { code: string, message: string, details?: object }')
+  }
+  const { code, message, details } = input as unknown as FailWithDetailsInput
+  ctx.logger.log(`Throwing MockJobError ${code}: ${message}`)
+  throw new MockJobError(code, message, details)
+}
+
 // Job name registry
 const jobHandlers: Record<string, JobHandler> = {
   dummy_echo: handleDummyEcho,
@@ -752,6 +792,9 @@ const jobHandlers: Record<string, JobHandler> = {
 
   // Platform updates demonstration
   updates_demo: handleUpdatesDemo,
+
+  // Structured error envelope demonstration (for testing details propagation)
+  fail_with_details: handleFailWithDetails,
 }
 
 // =============================================================================
@@ -798,6 +841,21 @@ const executeJobAsync = async (
     // eslint-disable-next-line no-console
     console.log(`[job] Completed job_id=${jobId} job_class=${jobClass}`)
   } catch (err) {
+    if (err instanceof MockJobError) {
+      jobState.status = 'failed'
+      jobState.error = {
+        code: err.code,
+        message: err.mockMessage,
+        ...(err.details ? { details: err.details } : {}),
+      }
+      jobState.completedAt = new Date().toISOString()
+      ctx.logger.error(`Job failed: ${err.mockMessage}`)
+      // eslint-disable-next-line no-console
+      console.error(
+        `[job] Failed job_id=${jobId} job_class=${jobClass}: ${err.code} ${err.mockMessage}`,
+      )
+      return
+    }
     const message = err instanceof Error ? err.message : String(err)
     jobState.status = 'failed'
     jobState.error = {
@@ -1010,10 +1068,12 @@ const server = Bun.serve({
         response.error = jobState.error
       }
 
-      // Include and drain pending updates
+      // Include and drain pending progress updates. The agent expects this
+      // field as `progress_updates` (HTTPJobStatusResponse schema); using any
+      // other name causes the agent to silently drop them.
       const updates = pendingUpdates.get(jobId)
       if (updates && updates.length > 0) {
-        response.updates = updates
+        response.progress_updates = updates
         pendingUpdates.delete(jobId)
       }
 

--- a/docker/worker-job-runner/test/agent.test.ts
+++ b/docker/worker-job-runner/test/agent.test.ts
@@ -91,6 +91,7 @@ interface JobResult {
   error?: {
     code: string
     message: string
+    details?: Record<string, unknown>
   }
 }
 
@@ -118,7 +119,11 @@ interface UploadURLResponse {
 interface CompletionRequest {
   success: boolean
   result?: unknown
-  error?: { code: string; message: string }
+  error?: {
+    code: string
+    message: string
+    details?: Record<string, unknown>
+  }
   outputFiles?: Array<{ folderId: string; objectKey: string }>
 }
 
@@ -667,12 +672,12 @@ function startMockPlatformServer(): void {
         })
       }
 
-      // POST /api/v1/docker/jobs/{job_id}/update
-      const updateMatch = path.match(
-        /^\/api\/v1\/docker\/jobs\/([^/]+)\/update$/,
+      // POST /api/v1/docker/jobs/{job_id}/progress
+      const progressMatch = path.match(
+        /^\/api\/v1\/docker\/jobs\/([^/]+)\/progress$/,
       )
-      if (updateMatch && req.method === 'POST') {
-        const jobId = updateMatch[1]
+      if (progressMatch && req.method === 'POST') {
+        const jobId = progressMatch[1]
         const body = await req.json()
 
         mockPlatformState.updateRequests.push({
@@ -3146,6 +3151,126 @@ describe('Platform Agent', () => {
       expect(completionReq.body.success).toBe(false)
       expect(completionReq.body.error).toBeDefined()
       expect(completionReq.body.error?.code).toBe('WORKER_EXIT_ERROR')
+      // Synthesized error should include exit_code in details so the platform
+      // can show structured context to operators.
+      expect(completionReq.body.error?.details).toBeDefined()
+      expect(completionReq.body.error?.details?.exit_code).toBe(1)
+    })
+
+    test('exec_per_job forwards worker-supplied error envelope from JOB_RESULT_FILE', async () => {
+      const jobId = generateJobId('platform-exec-worker-error')
+      const errorEnvelope = {
+        success: false,
+        error: {
+          code: 'CUSTOM_WORKER_ERROR',
+          message: 'simulated structured failure',
+          details: { hint: 'check input', attempt: 3 },
+        },
+      }
+      // The worker writes a structured error envelope and exits non-zero.
+      const payload: JobPayload = {
+        job_id: jobId,
+        job_class: 'platform_exec_worker_error_test',
+        worker_command: [
+          'sh',
+          '-c',
+          `printf '%s' '${JSON.stringify(errorEnvelope)}' > "$JOB_RESULT_FILE" && exit 1`,
+        ],
+        interface: { kind: 'exec_per_job' },
+        job_input: {},
+        job_token: MOCK_JOB_TOKEN,
+        platform_url: getMockPlatformUrl(),
+      }
+
+      const { jobResult: result, exitCode } = await runJob(payload)
+
+      expect(exitCode).toBe(1)
+      expect(result.success).toBe(false)
+      // The agent should NOT synthesize WORKER_EXIT_ERROR — the worker's own
+      // structured error must be forwarded verbatim.
+      expect(result.error?.code).toBe('CUSTOM_WORKER_ERROR')
+      expect(result.error?.message).toBe('simulated structured failure')
+      expect(result.error?.details).toEqual({ hint: 'check input', attempt: 3 })
+
+      expect(mockPlatformState.completionRequests.length).toBe(1)
+      const completionReq = mockPlatformState.completionRequests[0]
+      expect(completionReq.body.success).toBe(false)
+      expect(completionReq.body.error?.code).toBe('CUSTOM_WORKER_ERROR')
+      expect(completionReq.body.error?.message).toBe(
+        'simulated structured failure',
+      )
+      expect(completionReq.body.error?.details).toEqual({
+        hint: 'check input',
+        attempt: 3,
+      })
+    })
+
+    test('exec_per_job treats worker-supplied error envelope as failure even on exit 0', async () => {
+      const jobId = generateJobId('platform-exec-worker-error-exit0')
+      const errorEnvelope = {
+        success: false,
+        error: {
+          code: 'WORKER_REPORTED_FAILURE',
+          message: 'business rule violation',
+        },
+      }
+      // Some workers may emit a structured failure but exit cleanly. The
+      // agent must still treat the job as failed and forward the error.
+      const payload: JobPayload = {
+        job_id: jobId,
+        job_class: 'platform_exec_worker_error_exit0_test',
+        worker_command: [
+          'sh',
+          '-c',
+          `printf '%s' '${JSON.stringify(errorEnvelope)}' > "$JOB_RESULT_FILE" && exit 0`,
+        ],
+        interface: { kind: 'exec_per_job' },
+        job_input: {},
+        job_token: MOCK_JOB_TOKEN,
+        platform_url: getMockPlatformUrl(),
+      }
+
+      const { jobResult: result, exitCode } = await runJob(payload)
+
+      expect(exitCode).toBe(1)
+      expect(result.success).toBe(false)
+      expect(result.error?.code).toBe('WORKER_REPORTED_FAILURE')
+      expect(result.error?.message).toBe('business rule violation')
+
+      expect(mockPlatformState.completionRequests.length).toBe(1)
+      const completionReq = mockPlatformState.completionRequests[0]
+      expect(completionReq.body.success).toBe(false)
+      expect(completionReq.body.error?.code).toBe('WORKER_REPORTED_FAILURE')
+    })
+
+    test('exec_per_job ignores malformed error envelope (no code) and synthesizes WORKER_EXIT_ERROR', async () => {
+      const jobId = generateJobId('platform-exec-malformed-envelope')
+      // Has an `error` field but no `code` — must NOT be honored. Falls back
+      // to the agent's synthesized WORKER_EXIT_ERROR.
+      const malformed = { error: { message: 'oops' } }
+      const payload: JobPayload = {
+        job_id: jobId,
+        job_class: 'malformed_envelope_test',
+        worker_command: [
+          'sh',
+          '-c',
+          `printf '%s' '${JSON.stringify(malformed)}' > "$JOB_RESULT_FILE" && exit 7`,
+        ],
+        interface: { kind: 'exec_per_job' },
+        job_input: {},
+        job_token: MOCK_JOB_TOKEN,
+        platform_url: getMockPlatformUrl(),
+      }
+
+      const { jobResult: result } = await runJob(payload)
+      expect(result.success).toBe(false)
+      expect(result.error?.code).toBe('WORKER_EXIT_ERROR')
+      expect(result.error?.details?.exit_code).toBe(7)
+
+      expect(mockPlatformState.completionRequests.length).toBe(1)
+      expect(mockPlatformState.completionRequests[0].body.error?.code).toBe(
+        'WORKER_EXIT_ERROR',
+      )
     })
 
     test('exec_per_job calls /start endpoint before job completes', async () => {
@@ -3335,6 +3460,43 @@ describe('Platform Agent', () => {
       expect(completionReq.jobId).toBe(jobId)
       expect(completionReq.body.success).toBe(true)
       expect(completionReq.body.result).toBeDefined()
+    })
+
+    test('persistent_http forwards worker error.details to platform', async () => {
+      const jobClass = 'fail_with_details_8240'
+      const port = 8240
+
+      const jobId = generateJobId('platform-http-error-details')
+      const payload: JobPayload = {
+        job_id: jobId,
+        job_class: jobClass,
+        worker_command: ['bun', 'run', 'src/mock-worker.ts'],
+        interface: { kind: 'persistent_http', port },
+        job_input: {
+          code: 'CUSTOM_HTTP_WORKER_ERROR',
+          message: 'persistent worker simulated failure',
+          details: { causedBy: 'unit_test', retryable: false },
+        },
+        job_token: MOCK_JOB_TOKEN,
+        platform_url: getMockPlatformUrl(),
+      }
+
+      const { jobResult: result } = await runJob(payload, [`APP_PORT=${port}`])
+
+      expect(result.success).toBe(false)
+
+      expect(mockPlatformState.completionRequests.length).toBe(1)
+      const completionReq = mockPlatformState.completionRequests[0]
+      expect(completionReq.jobId).toBe(jobId)
+      expect(completionReq.body.success).toBe(false)
+      expect(completionReq.body.error?.code).toBe('CUSTOM_HTTP_WORKER_ERROR')
+      expect(completionReq.body.error?.message).toBe(
+        'persistent worker simulated failure',
+      )
+      expect(completionReq.body.error?.details).toEqual({
+        causedBy: 'unit_test',
+        retryable: false,
+      })
     })
 
     test('file_output job uploads files via presigned URLs and signals completion', async () => {
@@ -3592,7 +3754,7 @@ describe('Platform Agent', () => {
         worker_command: [
           'sh',
           '-c',
-          `echo "starting work" && echo '__PLATFORM_UPDATE__|${updatePayload}' && echo "middle of work" && echo '__PLATFORM_UPDATE__|${updatePayload2}' && echo "done"`,
+          `echo "starting work" && echo '__PLATFORM_PROGRESS_UPDATE__|${updatePayload}' && echo "middle of work" && echo '__PLATFORM_PROGRESS_UPDATE__|${updatePayload2}' && echo "done"`,
         ],
         interface: { kind: 'exec_per_job' },
         job_input: { test: true },
@@ -3628,7 +3790,7 @@ describe('Platform Agent', () => {
 
       // Verify magic lines do NOT appear in the job log
       const jobLog = await readJobLog(jobId)
-      expect(jobLog).not.toContain('__PLATFORM_UPDATE__')
+      expect(jobLog).not.toContain('__PLATFORM_PROGRESS_UPDATE__')
       expect(jobLog).not.toContain(updatePayload)
 
       // Verify normal log lines ARE in the job log
@@ -3646,7 +3808,7 @@ describe('Platform Agent', () => {
         worker_command: [
           'sh',
           '-c',
-          `echo '__PLATFORM_UPDATE__|not valid json' && echo "normal output"`,
+          `echo '__PLATFORM_PROGRESS_UPDATE__|not valid json' && echo "normal output"`,
         ],
         interface: { kind: 'exec_per_job' },
         job_input: {},
@@ -3663,7 +3825,7 @@ describe('Platform Agent', () => {
 
       // Invalid magic line should NOT appear in the job log either
       const jobLog = await readJobLog(jobId)
-      expect(jobLog).not.toContain('__PLATFORM_UPDATE__')
+      expect(jobLog).not.toContain('__PLATFORM_PROGRESS_UPDATE__')
 
       // Normal output should be in the job log
       expect(jobLog).toContain('normal output')

--- a/packages/api/src/core-worker/core-worker.e2e-spec.ts
+++ b/packages/api/src/core-worker/core-worker.e2e-spec.ts
@@ -903,6 +903,7 @@ describe('Core Worker', () => {
                 details: {
                   originalError: {
                     code: 'CUSTOM_APP_ERROR_CODE_INVALID',
+                    details: {},
                     message: 'This is a custom error message from the app',
                     name: 'Error',
                     requeueDelayMs: {

--- a/packages/api/src/docker/services/client/docker-client.service.ts
+++ b/packages/api/src/docker/services/client/docker-client.service.ts
@@ -115,7 +115,6 @@ export class DockerClientService {
         url.searchParams.set(k, v)
       }
     }
-    console.log('bridge url', url.toString())
     const response = await fetch(url.toString(), {
       method,
       headers: {

--- a/packages/api/src/docker/tests/docker.e2e-spec.ts
+++ b/packages/api/src/docker/tests/docker.e2e-spec.ts
@@ -2148,6 +2148,160 @@ describe('Docker Jobs', () => {
     ])
   })
 
+  it('should persist error.details from the worker on a failure completion', async () => {
+    await createTestUser(testModule!, {
+      username: 'testuser',
+      password: '123',
+    })
+
+    execSpy.mockImplementation((_hostId, _containerId, command, _options?) => {
+      return Promise.resolve({
+        exitCode: 0,
+        stdout:
+          command[1] === 'job-state'
+            ? `{"job_id": "${command.at(-1)}", "job_class": "test_job", "status": "complete", "success": true, "started_at": "${new Date().toISOString()}"}`
+            : '',
+        stderr: '',
+      })
+    })
+
+    const { innerTask, dockerRunTask } = await triggerAppDockerHandledTask(
+      testModule!,
+      {
+        appIdentifier: TEST_APP_SLUG,
+        taskIdentifier: 'non_triggered_docker_worker_task',
+        taskData: { myTaskData: 'test' },
+      },
+    )
+
+    const parsedPayload = parseJobPayload(
+      execSpy.mock.calls[1]![2].at(-1) ?? '',
+    )
+    const jobToken = parsedPayload.jobToken
+    const jobId = parsedPayload.jobId
+
+    const startResponse = await _apiClient(jobToken).POST(
+      `/api/v1/docker/jobs/{jobId}/start`,
+      { params: { path: { jobId } } },
+    )
+    expect(responseStatus(startResponse)).toBe(200)
+
+    const errorDetails = {
+      stack: 'Error: boom\n  at handler (/app/worker.ts:42:5)',
+      attemptCount: 3,
+      hint: 'check input',
+    }
+
+    const completeResponse = await _apiClient(jobToken).POST(
+      `/api/v1/docker/jobs/{jobId}/complete`,
+      {
+        params: { path: { jobId } },
+        body: {
+          success: false,
+          error: {
+            code: 'CUSTOM_WORKER_ERROR',
+            message: 'simulated structured failure',
+            details: errorDetails,
+          },
+        },
+      },
+    )
+
+    expect(responseStatus(completeResponse)).toBe(200)
+
+    const completedInnerTask =
+      await testModule!.services.ormService.db.query.tasksTable.findFirst({
+        where: eq(tasksTable.id, innerTask.id),
+      })
+
+    expect(completedInnerTask?.success).toBe(false)
+    expect(completedInnerTask?.error).toEqual({
+      code: 'CUSTOM_WORKER_ERROR',
+      name: 'Error',
+      message: 'simulated structured failure',
+      details: errorDetails,
+    })
+
+    // The error system log entry should also carry the structured details
+    const errorLog = completedInnerTask?.systemLog.find(
+      (entry) => entry.logType === 'error',
+    )
+    expect(errorLog).toBeDefined()
+    expect((errorLog?.payload as { error?: unknown }).error).toEqual({
+      code: 'CUSTOM_WORKER_ERROR',
+      name: 'Error',
+      message: 'simulated structured failure',
+      details: errorDetails,
+    })
+
+    // The docker-run task should also reflect the failure with details.
+    const completedDockerTask =
+      await testModule!.services.ormService.db.query.tasksTable.findFirst({
+        where: eq(tasksTable.id, dockerRunTask.id),
+      })
+    expect(completedDockerTask?.success).toBe(false)
+    expect(completedDockerTask?.error?.details).toEqual(errorDetails)
+  })
+
+  it('should accept a failure completion without error.details (backwards compatible)', async () => {
+    await createTestUser(testModule!, {
+      username: 'testuser',
+      password: '123',
+    })
+
+    execSpy.mockImplementation((_hostId, _containerId, command, _options?) => {
+      return Promise.resolve({
+        exitCode: 0,
+        stdout:
+          command[1] === 'job-state'
+            ? `{"job_id": "${command.at(-1)}", "job_class": "test_job", "status": "complete", "success": true, "started_at": "${new Date().toISOString()}"}`
+            : '',
+        stderr: '',
+      })
+    })
+
+    const { innerTask } = await triggerAppDockerHandledTask(testModule!, {
+      appIdentifier: TEST_APP_SLUG,
+      taskIdentifier: 'non_triggered_docker_worker_task',
+      taskData: { myTaskData: 'test' },
+    })
+
+    const parsedPayload = parseJobPayload(
+      execSpy.mock.calls[1]![2].at(-1) ?? '',
+    )
+    const jobToken = parsedPayload.jobToken
+    const jobId = parsedPayload.jobId
+
+    await _apiClient(jobToken).POST(`/api/v1/docker/jobs/{jobId}/start`, {
+      params: { path: { jobId } },
+    })
+
+    const completeResponse = await _apiClient(jobToken).POST(
+      `/api/v1/docker/jobs/{jobId}/complete`,
+      {
+        params: { path: { jobId } },
+        body: {
+          success: false,
+          error: {
+            code: 'WORKER_EXIT_ERROR',
+            message: 'worker exited with code 1',
+          },
+        },
+      },
+    )
+    expect(responseStatus(completeResponse)).toBe(200)
+
+    const completedInnerTask =
+      await testModule!.services.ormService.db.query.tasksTable.findFirst({
+        where: eq(tasksTable.id, innerTask.id),
+      })
+
+    expect(completedInnerTask?.error?.code).toBe('WORKER_EXIT_ERROR')
+    // Without `details` being supplied, it must not appear on the persisted
+    // error or the agent will spuriously light up the details panel.
+    expect(completedInnerTask?.error?.details).toBeUndefined()
+  })
+
   it('should return unauthorized when lifecycle endpoints are called with an invalid token', async () => {
     const jobId = crypto.randomUUID()
 

--- a/packages/api/src/task/services/task.service.ts
+++ b/packages/api/src/task/services/task.service.ts
@@ -1294,6 +1294,8 @@ export class TaskService {
           : undefined
         if (onCompleteHandler.condition && !conditionInput.success) {
           this.logger.debug('Task onComplete condition evaluation failed:', {
+            ownerIdentifier: updatedTask.ownerIdentifier,
+            taskIdentifier: onCompleteHandler.taskIdentifier,
             condition: onCompleteHandler.condition,
             input: conditionInput,
           })

--- a/packages/core-worker/src/worker-scripts/worker-daemon/app-error-utils.ts
+++ b/packages/core-worker/src/worker-scripts/worker-daemon/app-error-utils.ts
@@ -58,6 +58,7 @@ export const getAsyncWorkErrorFromAppTaskError = (
     requeueDelayMs: error.requeueDelayMs,
     message: error.message,
     stack: error.stack,
+    details: error.details,
   }
 
   const [appTaskErrorValidationSuccess, errorMessage] =
@@ -77,6 +78,9 @@ export const getAsyncWorkErrorFromAppTaskError = (
         requeueDelayMs: error.requeueDelayMs,
         message: error.message.slice(0, MAX_STRING_LENGTH),
         stack: error.stack?.slice(0, MAX_STACK_LENGTH),
+        ...(Object.keys(error.details).length > 0
+          ? { details: error.details }
+          : {}),
       },
     })
   }


### PR DESCRIPTION
Tightens the worker-agent runner so app-task errors are captured with structured details and reported back faithfully.

- Go: `runner/cancel`, `runner/exec`, `runner/http`, `types/payload` + tests
- `worker-job-runner` mock + tests updated
- `docker.e2e-spec` + `core-worker.e2e-spec` assert the new error envelope
- `app-error-utils` lint tightened

Closes [LOM-308](https://linear.app/lombokapp/issue/LOM-308/worker-agent-robustness-fixes-structured-error-details-capture)