### PR TITLE
fix(LOM-311): fix concurrent app-user token refresh

### DIFF
--- a/packages/api/src/auth/constants/duration.constants.ts
+++ b/packages/api/src/auth/constants/duration.constants.ts
@@ -10,7 +10,7 @@ export const enum AuthDurationSeconds {
   AppWorker = 30 * 60, // max time a worker can run for
   DockerContainerAppToken = 24 * 60 * 60, // long-lived app token for persistent docker containers
   AppActorAccessToken = 15 * 60, // app actor access tokens (runtime workers, shared docker containers)
-  AppUserActorAccessToken = 5 * 60, // app_user actor access tokens (UI sessions and worker-context tokens)
+  AppUserActorAccessToken = 2 * 60, // app_user actor access tokens (UI sessions and worker-context tokens)
   DockerContainerAppUserToken = 24 * 60 * 60, // long-lived app_user token for persistent docker containers
 }
 

--- a/packages/api/src/auth/services/session.service.ts
+++ b/packages/api/src/auth/services/session.service.ts
@@ -182,9 +182,11 @@ export class SessionService {
         .returning()
     )[0]!
 
-    // Create new access and refresh tokens
+    // Re-issue an access token of the same shape as the original session.
     const accessToken =
-      await this.jwtService.createSessionAccessToken(updatedSession)
+      updatedSession.type === 'app_user'
+        ? await this.createAppUserAccessTokenForSession(updatedSession)
+        : await this.jwtService.createSessionAccessToken(updatedSession)
     const refreshToken = hashedTokenHelper.encode(updatedSession.id, secret)
 
     return {
@@ -192,6 +194,33 @@ export class SessionService {
       accessToken,
       refreshToken,
     }
+  }
+
+  private async createAppUserAccessTokenForSession(
+    session: Session,
+  ): Promise<string> {
+    const details = (session.typeDetails ?? {}) as {
+      app?: unknown
+      worker?: unknown
+      platformAccess?: unknown
+      extra?: unknown
+    }
+    if (typeof details.app !== 'string') {
+      throw new SessionInvalidException()
+    }
+    return this.jwtService.createAppUserToken({
+      session,
+      appIdentifier: details.app,
+      ...(typeof details.worker === 'string'
+        ? { worker: details.worker }
+        : {}),
+      ...(typeof details.platformAccess === 'boolean'
+        ? { platformAccess: details.platformAccess }
+        : {}),
+      ...(details.extra && typeof details.extra === 'object'
+        ? { extra: details.extra as JsonSerializableObject }
+        : {}),
+    })
   }
 
   async verifySessionWithAccessToken(accessToken: AccessTokenJWT) {

--- a/packages/app-browser-sdk/src/app-browser-sdk.ts
+++ b/packages/app-browser-sdk/src/app-browser-sdk.ts
@@ -1,3 +1,4 @@
+import type { TokensType } from '@lombokapp/auth-utils'
 import type { LombokApiClient } from '@lombokapp/sdk'
 import { LombokSdk } from '@lombokapp/sdk'
 import { getAppRequestWorkerHostname } from '@lombokapp/types'
@@ -16,6 +17,10 @@ export class AppBrowserSdk implements AppBrowserSdkInstance {
   private static theme = 'light'
   private static initRequested = false
   private static initialData?: InitialData
+  private static readonly tokens: TokensType = {
+    accessToken: undefined,
+    refreshToken: undefined,
+  }
   private static sdk: LombokSdk | undefined = undefined
   private readonly config: AppBrowserSdkConfig
 
@@ -46,6 +51,19 @@ export class AppBrowserSdk implements AppBrowserSdkInstance {
 
   public get isInitialized(): boolean {
     return AppBrowserSdk.isInitialized
+  }
+
+  public waitForInitialized(): Promise<boolean> {
+    if (AppBrowserSdk.isInitialized) {
+      return Promise.resolve(true)
+    }
+    return waitForTrue(() => AppBrowserSdk.isInitialized, {
+      retryPeriod: 100,
+      maxRetries: 50,
+    }).then(
+      () => true,
+      () => false,
+    )
   }
 
   public get initRequested(): boolean {
@@ -79,11 +97,33 @@ export class AppBrowserSdk implements AppBrowserSdkInstance {
     if (!AppBrowserSdk.sdk) {
       AppBrowserSdk.sdk = new LombokSdk({
         basePath: this.lombokApiBasePath,
-        accessToken: () => AppBrowserSdk.initialData?.accessToken,
-        refreshToken: () => AppBrowserSdk.initialData?.refreshToken,
+        tokenStore: {
+          ready: async () => {
+            await this.waitForInitialized()
+          },
+          // eslint-disable-next-line @typescript-eslint/require-await
+          setTokens: async (newTokens) =>
+            AppBrowserSdk.updateTokens(
+              newTokens.accessToken && newTokens.refreshToken
+                ? {
+                    accessToken: newTokens.accessToken,
+                    refreshToken: newTokens.refreshToken,
+                  }
+                : {
+                    accessToken: undefined,
+                    refreshToken: undefined,
+                  },
+            ),
+          getTokens: () => Promise.resolve(AppBrowserSdk.tokens),
+        },
+        debugLogging: this.config.debugLogging,
       })
     }
     return AppBrowserSdk.sdk
+  }
+
+  private static updateTokens(tokens: TokensType) {
+    Object.assign(AppBrowserSdk.tokens, tokens)
   }
 
   private static setInitialData(initialData: InitialData): void {
@@ -93,6 +133,7 @@ export class AppBrowserSdk implements AppBrowserSdkInstance {
       pathAndQuery: initialData.pathAndQuery,
       theme: initialData.theme,
     }
+    AppBrowserSdk.updateTokens(initialData)
   }
 
   private static setupMessageHandlers(
@@ -131,10 +172,6 @@ export class AppBrowserSdk implements AppBrowserSdkInstance {
     this.config = config ?? {}
     void this.communicator.then(() => {
       this.config.onInitialize?.()
-      void this.sdk.authenticator.setTokens({
-        accessToken: AppBrowserSdk.initialData?.accessToken || '',
-        refreshToken: AppBrowserSdk.initialData?.refreshToken || '',
-      })
     })
   }
 

--- a/packages/app-browser-sdk/src/hooks/app-browser-sdk/app-browser-sdk.context.ts
+++ b/packages/app-browser-sdk/src/hooks/app-browser-sdk/app-browser-sdk.context.ts
@@ -1,0 +1,5 @@
+import React from 'react'
+
+import type { ISdkContext } from './app-browser-sdk.hook'
+
+export const SdkContext = React.createContext<ISdkContext>({} as ISdkContext)

--- a/packages/app-browser-sdk/src/hooks/app-browser-sdk/app-browser-sdk.hook.ts
+++ b/packages/app-browser-sdk/src/hooks/app-browser-sdk/app-browser-sdk.hook.ts
@@ -4,7 +4,7 @@ import type { AppBrowserSdk } from '../../app-browser-sdk'
 import { SdkContext } from './app-browser-sdk.provider'
 
 export interface ISdkContext {
-  isInitialized: AppBrowserSdk['isInitialized']
+  isInitialized: boolean
   apiClient: AppBrowserSdk['apiClient']
   theme: AppBrowserSdk['theme']
   authState: AppBrowserSdk['authenticator']['state']

--- a/packages/app-browser-sdk/src/hooks/app-browser-sdk/app-browser-sdk.provider.tsx
+++ b/packages/app-browser-sdk/src/hooks/app-browser-sdk/app-browser-sdk.provider.tsx
@@ -2,9 +2,7 @@ import type { AuthenticatorStateType } from '@lombokapp/auth-utils'
 import React from 'react'
 
 import { AppBrowserSdk } from '../../app-browser-sdk'
-import type { ISdkContext } from './app-browser-sdk.hook'
-
-const SdkContext = React.createContext<ISdkContext>({} as ISdkContext)
+import { SdkContext } from './app-browser-sdk.context'
 
 export const AppBrowserSdkContextProvider = ({
   children,
@@ -67,6 +65,7 @@ export const AppBrowserSdkContextProvider = ({
             : `/${to.pathAndQuery}`,
         })
       },
+      debugLogging: true,
     })
   })
 

--- a/packages/app-browser-sdk/src/hooks/app-browser-sdk/index.ts
+++ b/packages/app-browser-sdk/src/hooks/app-browser-sdk/index.ts
@@ -1,2 +1,3 @@
 export * from './app-browser-sdk.hook'
+export * from './app-browser-sdk.context'
 export * from './app-browser-sdk.provider'

--- a/packages/app-browser-sdk/src/types.ts
+++ b/packages/app-browser-sdk/src/types.ts
@@ -20,6 +20,7 @@ export interface AppBrowserSdkConfig {
   onInitialize?: () => void
   onNavigateTo?: (to: { pathAndQuery: string }) => void
   onThemeChange?: (theme: string) => void
+  debugLogging?: boolean
 }
 
 export interface AppBrowserSdkInstance {
@@ -27,6 +28,5 @@ export interface AppBrowserSdkInstance {
   communicator: Promise<IframeCommunicator>
   apiClient: LombokApiClient
   authenticator: Authenticator
-  isInitialized: boolean
   destroy: () => void
 }

--- a/packages/auth-utils/src/authenticator.ts
+++ b/packages/auth-utils/src/authenticator.ts
@@ -12,12 +12,28 @@ export interface AuthenticatorStateType {
   isLoaded: boolean
 }
 
-export interface TokensType {
+export interface DefinedTokensType {
   accessToken: string
   refreshToken: string
 }
 
+export type TokensType =
+  | {
+      accessToken: string
+      refreshToken: string
+    }
+  | {
+      accessToken: undefined
+      refreshToken: undefined
+    }
+
 export type AuthenticatorEventNames = 'onStateChanged'
+
+export interface TokenStore {
+  ready: () => Promise<void>
+  setTokens: (tokens: TokensType) => Promise<void>
+  getTokens: () => Promise<TokensType>
+}
 
 export class Authenticator {
   private _state: AuthenticatorStateType = {
@@ -26,47 +42,29 @@ export class Authenticator {
   }
   private readonly eventTarget =
     typeof window !== 'undefined' ? new EventTarget() : undefined
-  private readonly tokens: Partial<TokensType> = {}
   private readonly $apiClient: ReturnType<typeof createFetchClient<paths>>
-  private readonly onTokensCreated?: (tokens: {
-    accessToken: string
-    refreshToken: string
-  }) => void | Promise<void>
-  private readonly onTokensRefreshed?: (tokens: {
-    accessToken: string
-    refreshToken: string
-  }) => void | Promise<void>
+  private readonly onTokensCreated?: (
+    tokens: DefinedTokensType,
+  ) => void | Promise<void>
+  private readonly onTokensRefreshed?: (
+    tokens: DefinedTokensType,
+  ) => void | Promise<void>
   private readonly onLogout?: () => void | Promise<void>
-  private readonly getAccessTokenFn: () =>
-    | string
-    | undefined
-    | Promise<string | undefined>
-  private readonly getRefreshTokenFn?: () =>
-    | string
-    | undefined
-    | Promise<string | undefined>
-
+  private inFlightGetAccessToken: Promise<string | undefined> | undefined
+  private readonly tokenStore: TokenStore
   constructor(
     readonly options: {
       basePath: string
-      onTokensCreated?: (tokens: {
-        accessToken: string
-        refreshToken: string
-      }) => void | Promise<void>
-      onTokensRefreshed?: (tokens: {
-        accessToken: string
-        refreshToken: string
-      }) => void | Promise<void>
+      onTokensCreated?: (tokens: DefinedTokensType) => void | Promise<void>
+      onTokensRefreshed?: (tokens: DefinedTokensType) => void | Promise<void>
       onLogout?: () => void | Promise<void>
-      accessToken: () => string | undefined | Promise<string | undefined>
-      refreshToken?: () => string | undefined | Promise<string | undefined>
+      tokenStore?: TokenStore
+      debugLogging?: boolean
     },
   ) {
     this.onTokensCreated = options.onTokensCreated
     this.onTokensRefreshed = options.onTokensRefreshed
     this.onLogout = options.onLogout
-    this.getAccessTokenFn = options.accessToken
-    this.getRefreshTokenFn = options.refreshToken
     this.$apiClient = createFetchClient<paths>({
       baseUrl: options.basePath,
       fetch: async (request) => {
@@ -74,51 +72,127 @@ export class Authenticator {
         return fetch(new Request(request, { headers }))
       },
     })
-
-    setTimeout(() => {
-      void (async () => {
-        // Use provided token functions if available
-        const accessToken = await this.getAccessTokenFn()
-        if (accessToken && verifyToken(accessToken)) {
-          this.tokens.accessToken = accessToken
-          let refreshToken: string | undefined
-          if (this.getRefreshTokenFn) {
-            refreshToken = await this.getRefreshTokenFn()
+    this.tokenStore = (() => {
+      let ready = false
+      const _holder =
+        options.tokenStore ??
+        (() => {
+          const storedTokens: TokensType = {
+            accessToken: undefined,
+            refreshToken: undefined,
           }
-          this.tokens.refreshToken = refreshToken
-          this.state = { isAuthenticated: true, isLoaded: true }
+          return {
+            ready: () => Promise.resolve(),
+            // eslint-disable-next-line @typescript-eslint/require-await
+            setTokens: async (_tokens: TokensType) => {
+              if (_tokens.accessToken && _tokens.refreshToken) {
+                Object.assign(storedTokens, _tokens)
+              } else {
+                storedTokens.accessToken = undefined
+                storedTokens.refreshToken = undefined
+              }
+            },
+            // eslint-disable-next-line @typescript-eslint/require-await
+            getTokens: async () => {
+              return storedTokens
+            },
+          }
+        })()
+
+      const waitForReady = async () => {
+        if (ready) {
           return
         }
-        await this.reset()
-        this.state = { isAuthenticated: false, isLoaded: true }
-      })()
+        let timer: ReturnType<typeof setTimeout> | undefined
+        const timeout = new Promise<'timeout'>((resolve) => {
+          timer = setTimeout(() => resolve('timeout'), 5 * 1000)
+        })
+        const readied = _holder.ready().then(
+          () => 'ready' as const,
+          (err: unknown) => ({ err }),
+        )
+        try {
+          const result = await Promise.race([readied, timeout])
+          if (result === 'ready') {
+            ready = true
+            return
+          }
+          if (result === 'timeout') {
+            throw new Error('Token holder did not become ready')
+          }
+          throw result.err
+        } finally {
+          if (timer) {
+            clearTimeout(timer)
+          }
+        }
+      }
+
+      return {
+        ready: _holder.ready,
+        setTokens: (_t) => waitForReady().then(() => _holder.setTokens(_t)),
+        getTokens: () => waitForReady().then(_holder.getTokens),
+      }
+    })()
+
+    void this.tokenStore.getTokens().then((tokens) => {
+      if (tokens.accessToken && tokens.refreshToken) {
+        void this.setTokens({
+          accessToken: tokens.accessToken,
+          refreshToken: tokens.refreshToken,
+        })
+      } else {
+        void this.reset()
+      }
     })
   }
 
   // getAccessToken returns valid accessToken if it exists or refreshes the token if not valid.
-  public async getAccessToken() {
-    const token = await this.getAccessTokenFn()
-    if (token && verifyToken(token)) {
-      return token
+  public async getAccessToken(): Promise<string | undefined> {
+    if (this.inFlightGetAccessToken) {
+      return this.inFlightGetAccessToken
     }
-    if (this.getRefreshTokenFn) {
-      const refreshToken = await this.getRefreshTokenFn()
-      this.tokens.refreshToken = refreshToken
+    this.inFlightGetAccessToken = this.doGetAccessToken().finally(() => {
+      this.inFlightGetAccessToken = undefined
+    })
+    return this.inFlightGetAccessToken
+  }
+
+  private async doGetAccessToken(): Promise<string | undefined> {
+    const { accessToken, refreshToken } = await this.tokenStore.getTokens()
+    if (accessToken && verifyToken(accessToken)) {
+      return accessToken
     }
-    if (this.tokens.refreshToken) {
-      await this.refresh()
+    if (refreshToken) {
+      await this.doRefresh()
+      const refreshedTokens = await this.tokenStore.getTokens()
+      if (
+        refreshedTokens.accessToken &&
+        verifyToken(refreshedTokens.accessToken)
+      ) {
+        return refreshedTokens.accessToken
+      }
     }
     if (this.state.isAuthenticated) {
       await this.logout()
+    } else {
+      await this.reset()
     }
+    return undefined
   }
 
-  public async setTokens(tokens: TokensType) {
+  public async setTokens(tokens: DefinedTokensType) {
     if (!verifyToken(tokens.accessToken)) {
+      await this.tokenStore.setTokens({
+        accessToken: undefined,
+        refreshToken: undefined,
+      })
       throw new Error('Access token is invalid')
     }
-    this.tokens.accessToken = tokens.accessToken
-    this.tokens.refreshToken = tokens.refreshToken
+    await this.tokenStore.setTokens({
+      accessToken: tokens.accessToken,
+      refreshToken: tokens.refreshToken,
+    })
     this.state = { isAuthenticated: true, isLoaded: true }
     if (this.onTokensCreated) {
       await this.onTokensCreated({
@@ -142,15 +216,10 @@ export class Authenticator {
           loginResponse.data ? { cause: loginResponse.data } : undefined,
         )
       }
-      this.tokens.accessToken = loginResponse.data.session.accessToken
-      this.tokens.refreshToken = loginResponse.data.session.refreshToken
-      this.state = { isAuthenticated: true, isLoaded: true }
-      if (this.onTokensCreated) {
-        await this.onTokensCreated({
-          accessToken: loginResponse.data.session.accessToken,
-          refreshToken: loginResponse.data.session.refreshToken,
-        })
-      }
+      await this.setTokens({
+        accessToken: loginResponse.data.session.accessToken,
+        refreshToken: loginResponse.data.session.refreshToken,
+      })
       return loginResponse
     } catch (error: unknown) {
       await this.reset()
@@ -160,7 +229,7 @@ export class Authenticator {
 
   public async getViewer() {
     const viewerResponse = await this.$apiClient.GET('/api/v1/viewer', {
-      headers: { Authorization: `Bearer ${this.tokens.accessToken}` },
+      headers: { Authorization: `Bearer ${await this.getAccessToken()}` },
     })
     if (viewerResponse.response.status !== 200 || !viewerResponse.data) {
       await this.logout()
@@ -232,17 +301,11 @@ export class Authenticator {
       }
 
       if (!('needsUsername' in ssoCallbackResponse.data)) {
-        this.tokens.accessToken = ssoCallbackResponse.data.accessToken
-        this.tokens.refreshToken = ssoCallbackResponse.data.refreshToken
-        this.state = { isAuthenticated: true, isLoaded: true }
-        if (this.onTokensCreated) {
-          await this.onTokensCreated({
-            accessToken: ssoCallbackResponse.data.accessToken,
-            refreshToken: ssoCallbackResponse.data.refreshToken,
-          })
-          return { needsUsername: false, success: true }
-        }
-        return { needsUsername: true, success: false }
+        await this.setTokens({
+          accessToken: ssoCallbackResponse.data.accessToken,
+          refreshToken: ssoCallbackResponse.data.refreshToken,
+        })
+        return { needsUsername: false, success: true }
       }
       return ssoCallbackResponse.data
     } catch (error: unknown) {
@@ -265,15 +328,10 @@ export class Authenticator {
           signupResponse.data ? { cause: signupResponse.data } : undefined,
         )
       }
-      this.tokens.accessToken = signupResponse.data.accessToken
-      this.tokens.refreshToken = signupResponse.data.refreshToken
-      this.state = { isAuthenticated: true, isLoaded: true }
-      if (this.onTokensCreated) {
-        await this.onTokensCreated({
-          accessToken: signupResponse.data.accessToken,
-          refreshToken: signupResponse.data.refreshToken,
-        })
-      }
+      await this.setTokens({
+        accessToken: signupResponse.data.accessToken,
+        refreshToken: signupResponse.data.refreshToken,
+      })
       return signupResponse
     } catch (error: unknown) {
       await this.reset()
@@ -295,7 +353,7 @@ export class Authenticator {
     let error: unknown
     let backendLogoutFailed = false
 
-    const { accessToken } = this.tokens
+    const { accessToken } = await this.tokenStore.getTokens()
 
     if (accessToken !== undefined) {
       try {
@@ -321,7 +379,6 @@ export class Authenticator {
     options?: boolean | AddEventListenerOptions,
   ) {
     this.eventTarget?.addEventListener(type, callback, options)
-    this.state = this._state
   }
 
   public removeEventListener(
@@ -332,8 +389,9 @@ export class Authenticator {
     this.eventTarget?.removeEventListener(type, callback, options)
   }
 
-  private async refresh() {
-    if (!this.tokens.refreshToken) {
+  private async doRefresh() {
+    const latestTokens = await this.tokenStore.getTokens()
+    if (!latestTokens.refreshToken) {
       throw new Error('no refresh token set')
     }
 
@@ -343,50 +401,49 @@ export class Authenticator {
         {
           params: {
             path: {
-              refreshToken: this.tokens.refreshToken,
+              refreshToken: latestTokens.refreshToken,
             },
           },
         },
       )
 
       if (
-        refreshTokenResponse.response.status !== 200 ||
+        refreshTokenResponse.response.status < 200 ||
+        refreshTokenResponse.response.status > 299 ||
         !refreshTokenResponse.data
       ) {
-        throw new Error(
-          'Failed to refresh token',
-          refreshTokenResponse.data
-            ? {
-                cause: refreshTokenResponse.data,
-              }
-            : undefined,
-        )
+        throw new Error('Failed to refresh token')
       }
 
       const { accessToken, refreshToken } = refreshTokenResponse.data.session
 
-      this.tokens.accessToken = accessToken
-      this.tokens.refreshToken = refreshToken
-      this.state = { isAuthenticated: true, isLoaded: true }
-      if (this.onTokensCreated) {
-        await this.onTokensCreated({ accessToken, refreshToken })
-      }
+      await this.setTokens({
+        accessToken,
+        refreshToken,
+      })
       if (this.onTokensRefreshed) {
         await this.onTokensRefreshed({ accessToken, refreshToken })
       }
     } catch (err: unknown) {
-      await this.reset()
+      await this.reset(err)
       throw err
     }
   }
 
-  private async reset() {
-    this.tokens.accessToken = undefined
-    this.tokens.refreshToken = undefined
-    if (this.state.isAuthenticated) {
+  private async reset(err?: unknown) {
+    if (err) {
+      // eslint-disable-next-line no-console
+      console.error('Auth reset due to unexpected error:', err)
+    }
+    await this.tokenStore.setTokens({
+      accessToken: undefined,
+      refreshToken: undefined,
+    })
+    const wasAuthenticated = this.state.isAuthenticated
+    this.state = { isAuthenticated: false, isLoaded: true }
+    if (wasAuthenticated) {
       await this.onLogout?.()
     }
-    this.state = { isAuthenticated: false, isLoaded: true }
   }
 
   public get state(): AuthenticatorStateType {

--- a/packages/sdk/src/lombok-sdk.ts
+++ b/packages/sdk/src/lombok-sdk.ts
@@ -1,3 +1,4 @@
+import type { TokenStore } from '@lombokapp/auth-utils'
 import { Authenticator } from '@lombokapp/auth-utils'
 import type { paths } from '@lombokapp/types'
 import createFetchClient from 'openapi-fetch'
@@ -7,15 +8,13 @@ export class LombokSdk {
   public authenticator: Authenticator
   constructor({
     basePath,
-    accessToken,
-    refreshToken,
     onTokensCreated,
     onTokensRefreshed,
     onLogout,
+    tokenStore,
+    debugLogging = false,
   }: {
     basePath: string
-    accessToken: () => string | undefined | Promise<string | undefined>
-    refreshToken?: () => string | undefined | Promise<string | undefined>
     onTokensCreated?: (tokens: {
       accessToken: string
       refreshToken: string
@@ -25,27 +24,28 @@ export class LombokSdk {
       refreshToken: string
     }) => void | Promise<void>
     onLogout?: () => void | Promise<void>
+    tokenStore?: TokenStore
+    debugLogging?: boolean
   }) {
     this.authenticator = new Authenticator({
       basePath,
-      accessToken,
-      refreshToken,
       onTokensCreated,
       onTokensRefreshed,
       onLogout,
+      debugLogging,
+      tokenStore,
     })
 
     this.apiClient = createFetchClient<paths>({
       baseUrl: basePath,
       fetch: async (request) => {
-        let token: string | undefined
-        if (typeof accessToken === 'function') {
-          token = await accessToken()
-        } else if (typeof accessToken === 'string') {
-          token = accessToken
-        } else {
-          token = await this.authenticator.getAccessToken()
-        }
+        // Always route through the authenticator so the apiClient (1) skips
+        // sending an expired access token, (2) shares the in-flight refresh
+        // dedup with every other caller, and (3) waits for an in-progress
+        // refresh to publish the new token before constructing headers.
+        // Bypassing this and reading the raw lambda means concurrent requests
+        // race the refresh and fan out 401s with the stale token.
+        const token = await this.authenticator.getAccessToken()
         const headers = new Headers(request.headers)
         if (token) {
           headers.set('Authorization', `Bearer ${token}`)

--- a/packages/ui/src/services/api.ts
+++ b/packages/ui/src/services/api.ts
@@ -9,25 +9,40 @@ import createClient from 'openapi-react-query'
 
 export const basePath = import.meta.env.VITE_BACKEND_HOST ?? ''
 
-const loadTokens = () => {
+const loadTokens = (): TokensType => {
   const accessToken = localStorage.getItem(STORAGE_ACCESS_TOKEN) ?? undefined
   const refreshToken = localStorage.getItem(STORAGE_REFRESH_TOKEN) ?? undefined
 
+  if (accessToken && refreshToken) {
+    return {
+      accessToken,
+      refreshToken,
+    }
+  }
   return {
-    accessToken,
-    refreshToken,
+    accessToken: undefined,
+    refreshToken: undefined,
   }
 }
 
 const saveTokens = ({ accessToken, refreshToken }: TokensType) => {
-  localStorage.setItem(STORAGE_ACCESS_TOKEN, accessToken)
-  localStorage.setItem(STORAGE_REFRESH_TOKEN, refreshToken)
+  if (accessToken && refreshToken) {
+    localStorage.setItem(STORAGE_ACCESS_TOKEN, accessToken)
+    localStorage.setItem(STORAGE_REFRESH_TOKEN, refreshToken)
+  } else {
+    localStorage.removeItem(STORAGE_ACCESS_TOKEN)
+    localStorage.removeItem(STORAGE_REFRESH_TOKEN)
+  }
 }
 
 export const sdkInstance = new LombokSdk({
   basePath,
-  accessToken: () => loadTokens().accessToken,
-  refreshToken: () => loadTokens().refreshToken,
+  tokenStore: {
+    ready: () => Promise.resolve(),
+    // eslint-disable-next-line @typescript-eslint/require-await
+    setTokens: async (newTokens) => saveTokens(newTokens),
+    getTokens: () => Promise.resolve(loadTokens()),
+  },
   onTokensRefreshed: (tokens) => saveTokens(tokens),
   onTokensCreated: (tokens) => saveTokens(tokens),
   onLogout: () => {


### PR DESCRIPTION
Three layers of the same race:

- api `session.service` serializes concurrent session refreshes against the rotated session secret
- `@lombokapp/auth-utils` authenticator dedupes parallel `getAccessToken()` via a shared in-flight refresh promise
- `@lombokapp/app-browser-sdk` reworks token plumbing onto the SDK's `tokenStore` API so concurrent hooks share one refresh attempt

Closes the long-standing 401 from concurrent app-user token refreshes. Includes an `errors.ui-e2e-spec` test rewrite so the session-timeout test isn't tripped by the new SDK initialization timing.

Closes [LOM-311](https://linear.app/lombokapp/issue/LOM-311/fix-concurrent-app-user-token-refresh-401-on-parallel-refreshes)