### PR TITLE
feat(LOM-313): support targetUserId/targetLocation on EMIT_EVENT schema

### DIFF
--- a/packages/types/src/app-socket-message-schemas.ts
+++ b/packages/types/src/app-socket-message-schemas.ts
@@ -90,6 +90,13 @@ export const dbQuerySchema = z.object({
 export const emitEventSchema = z.object({
   eventIdentifier: eventIdentifierSchema,
   data: jsonSerializableObjectSchema,
+  targetUserId: z.uuid().optional(),
+  targetLocation: z
+    .object({
+      folderId: z.string(),
+      objectKey: z.string().optional(),
+    })
+    .optional(),
 })
 
 export const dbExecSchema = z.object({


### PR DESCRIPTION
Extend the `EMIT_EVENT` socket schema with optional `targetUserId` and `targetLocation` (folder/objectKey) so apps can scope an event when emitting it. Schema-only — broadcasting logic in a follow-up.

> **Stacked PR** — depends on #245. Will retarget to `main` once upstream lands.

Closes [LOM-313](https://linear.app/lombokapp/issue/LOM-313/support-targetuserid-targetlocation-on-emit-event-schema)