### PR TITLE
feat(LOM-314): broadcast app events with target users to the app-user socket stream

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -152,6 +152,7 @@
         "@lombokapp/types": "workspace:*",
         "react": "catalog:",
         "react-dom": "catalog:",
+        "socket.io-client": "catalog:",
       },
       "devDependencies": {
         "@eslint/js": "catalog:",

--- a/packages/api/src/app/services/app-socket-message.handler.ts
+++ b/packages/api/src/app/services/app-socket-message.handler.ts
@@ -152,6 +152,11 @@ export async function handleAppSocketMessage(
           emitterIdentifier: requestingAppIdentifier,
           eventIdentifier: parsedRequest.data.eventIdentifier,
           data: parsedRequest.data.data,
+          ...(parsedRequest.data.targetLocation
+            ? { targetLocation: parsedRequest.data.targetLocation }
+            : parsedRequest.data.targetUserId
+              ? { targetUserId: parsedRequest.data.targetUserId }
+              : {}),
         })
         return { result: { success: true } }
       } catch {

--- a/packages/api/src/event/services/event.service.ts
+++ b/packages/api/src/event/services/event.service.ts
@@ -38,6 +38,7 @@ import { getCoreEventAggregationConfig } from 'src/notification/config/notificat
 import { buildAggregationKey } from 'src/notification/util/aggregation-key.util'
 import { OrmService } from 'src/orm/orm.service'
 import { getUtcTimestampBucket } from 'src/shared/utils/timestamp.util'
+import { AppUserSocketService } from 'src/socket/app-user/app-user-socket.service'
 import { UserSocketService } from 'src/socket/user/user-socket.service'
 import {
   CORE_EVENT_TRIGGERS_TO_TASKS_MAP,
@@ -76,6 +77,9 @@ export class EventService {
   get userSocketService(): UserSocketService {
     return this._userSocketService as UserSocketService
   }
+  get appUserSocketService(): AppUserSocketService {
+    return this._appUserSocketService as AppUserSocketService
+  }
 
   get appService(): AppService {
     return this._appService as AppService
@@ -91,6 +95,8 @@ export class EventService {
     private readonly _coreTaskService,
     @Inject(forwardRef(() => UserSocketService))
     private readonly _userSocketService,
+    @Inject(forwardRef(() => AppUserSocketService))
+    private readonly _appUserSocketService,
     @Inject(forwardRef(() => FolderService)) private readonly _folderService,
     @Inject(forwardRef(() => AppService)) private readonly _appService,
   ) {}
@@ -496,6 +502,30 @@ export class EventService {
         FolderPushMessage.EVENT_CREATED as FolderPushMessage,
         { event },
       )
+    }
+
+    // Broadcast app-emitted, user-targeted events on the app-user socket channel.
+    if (appIdentifier && targetUserId) {
+      this.appUserSocketService.emitUpdate({
+        update: {
+          code: `app:${appIdentifier}:${eventIdentifier}`,
+          data: {
+            eventId: event.id,
+            eventIdentifier,
+            emitterIdentifier: appIdentifier,
+            targetUserId,
+            targetLocationFolderId: targetLocation?.folderId ?? null,
+            targetLocationObjectKey: targetLocation?.objectKey ?? null,
+            data,
+            createdAt: now.toISOString(),
+          },
+        },
+        scope: {
+          targetUserId,
+          targetAppIdentifier: appIdentifier,
+          targetLocationFolderId: targetLocation?.folderId ?? null,
+        },
+      })
     }
 
     void this.coreTaskService.startDrainCoreTasks()

--- a/packages/app-browser-sdk/package.json
+++ b/packages/app-browser-sdk/package.json
@@ -10,7 +10,7 @@
     }
   },
   "scripts": {
-    "build": "rm -rf ./dist && NODE_ENV=production tsup src/index.ts --format esm,cjs --dts --external bun,@lombokapp/auth-utils,@lombokapp/types,@lombokapp/sdk",
+    "build": "rm -rf ./dist && NODE_ENV=production tsup src/index.ts --format esm,cjs --dts --external bun,@lombokapp/auth-utils,@lombokapp/types,@lombokapp/sdk,socket.io-client",
     "dev": "bun --watch src/index.ts",
     "lint:check": "eslint .",
     "lint:fix": "eslint --fix .",
@@ -23,7 +23,8 @@
     "@lombokapp/types": "workspace:*",
     "@lombokapp/auth-utils": "workspace:*",
     "react": "catalog:",
-    "react-dom": "catalog:"
+    "react-dom": "catalog:",
+    "socket.io-client": "catalog:"
   },
   "devDependencies": {
     "@types/bun": "catalog:",

--- a/packages/app-browser-sdk/src/hooks/app-user-socket/app-user-socket.context.ts
+++ b/packages/app-browser-sdk/src/hooks/app-user-socket/app-user-socket.context.ts
@@ -1,0 +1,15 @@
+import React from 'react'
+import type { Socket } from 'socket.io-client'
+
+export interface AppUserSocketContextValue {
+  socket: Socket | null
+  connected: boolean
+  reconnectCount: number
+  subscribe: (
+    eventName: string,
+    handler: (payload: unknown) => void,
+  ) => () => void
+}
+
+export const AppUserSocketContext =
+  React.createContext<AppUserSocketContextValue | null>(null)

--- a/packages/app-browser-sdk/src/hooks/app-user-socket/app-user-socket.hook.ts
+++ b/packages/app-browser-sdk/src/hooks/app-user-socket/app-user-socket.hook.ts
@@ -1,0 +1,74 @@
+import React from 'react'
+
+import {
+  AppUserSocketContext,
+  type AppUserSocketContextValue,
+} from './app-user-socket.context'
+
+export function useAppUserSocket(): AppUserSocketContextValue {
+  const ctx = React.useContext(AppUserSocketContext)
+  if (!ctx) {
+    throw new Error(
+      'useAppUserSocket must be used within an AppUserSocketProvider',
+    )
+  }
+  return ctx
+}
+
+/**
+ * Subscribe to a single raw socket.io event on the `/app-user` namespace.
+ * The latest `handler` is always invoked, so callers don't need to memoize.
+ */
+export function useAppUserSocketEvent<T = unknown>(
+  eventName: string | null,
+  handler: (payload: T) => void,
+): void {
+  const { subscribe } = useAppUserSocket()
+  const handlerRef = React.useRef(handler)
+  handlerRef.current = handler
+
+  React.useEffect(() => {
+    if (!eventName) {
+      return
+    }
+    return subscribe(eventName, (payload) => handlerRef.current(payload as T))
+  }, [eventName, subscribe])
+}
+
+/**
+ * Payload shape emitted by the platform when an app emits a custom,
+ * user-targeted event via `serverClient.emitEvent`. The socket event name
+ * is `app:<emitterIdentifier>:<eventIdentifier>`.
+ */
+export interface AppEventPayload<TData = Record<string, unknown>> {
+  eventId: string
+  eventIdentifier: string
+  emitterIdentifier: string
+  targetUserId: string
+  targetLocationFolderId: string | null
+  targetLocationObjectKey: string | null
+  data: TData
+  createdAt: string
+}
+
+/**
+ * Subscribe to a custom app event broadcast on the `/app-user` socket.
+ *
+ * The platform fans out events emitted via `serverClient.emitEvent({
+ * targetUserId, ... })` to every open browser tab of that user.
+ *
+ * @param appIdentifier - The emitting app's identifier (e.g. "codicle").
+ * @param eventIdentifier - The event name from the worker (e.g. "repo_updated").
+ * @param handler - Called with the event payload.
+ */
+export function useAppEvent<TData = Record<string, unknown>>(
+  appIdentifier: string | null,
+  eventIdentifier: string | null,
+  handler: (payload: AppEventPayload<TData>) => void,
+): void {
+  const eventName =
+    appIdentifier && eventIdentifier
+      ? `app:${appIdentifier}:${eventIdentifier}`
+      : null
+  useAppUserSocketEvent<AppEventPayload<TData>>(eventName, handler)
+}

--- a/packages/app-browser-sdk/src/hooks/app-user-socket/app-user-socket.provider.tsx
+++ b/packages/app-browser-sdk/src/hooks/app-user-socket/app-user-socket.provider.tsx
@@ -1,0 +1,118 @@
+import React from 'react'
+import { io, type Socket } from 'socket.io-client'
+
+import { useAppBrowserSdk } from '../app-browser-sdk'
+import { AppUserSocketContext } from './app-user-socket.context'
+
+/**
+ * Opens an authenticated `/app-user` socket.io connection for the current
+ * app + user pair, scoped to the platform host. Provides a single shared
+ * connection that all app event hooks subscribe through, so we avoid
+ * duplicate sockets per consumer.
+ */
+export const AppUserSocketProvider = ({
+  children,
+}: {
+  children: React.ReactNode
+}) => {
+  const { isInitialized, authState, getAccessToken } = useAppBrowserSdk()
+  const socketRef = React.useRef<Socket | null>(null)
+  const listenersRef = React.useRef<
+    Map<string, Set<(payload: unknown) => void>>
+  >(new Map())
+  const [socket, setSocket] = React.useState<Socket | null>(null)
+  const [connected, setConnected] = React.useState(false)
+  const [reconnectCount, setReconnectCount] = React.useState(0)
+
+  React.useEffect(() => {
+    if (!isInitialized || !authState.isAuthenticated) {
+      return
+    }
+
+    let cancelled = false
+    void (async () => {
+      const token = await getAccessToken()
+      // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition -- set in cleanup
+      if (cancelled) {
+        return
+      }
+
+      const s = io('/app-user', {
+        auth: { token },
+        transports: ['websocket'],
+        reconnection: true,
+      })
+
+      s.on('connect', () => {
+        setConnected(true)
+        setReconnectCount((c) => c + 1)
+      })
+      s.on('disconnect', () => setConnected(false))
+
+      // Re-attach existing handlers (in case any subscribed before connect).
+      for (const [name, handlers] of listenersRef.current) {
+        s.on(name, (payload: unknown) => {
+          for (const h of handlers) {
+            h(payload)
+          }
+        })
+      }
+
+      socketRef.current = s
+      setSocket(s)
+    })()
+
+    return () => {
+      cancelled = true
+      socketRef.current?.disconnect()
+      socketRef.current = null
+      setSocket(null)
+      setConnected(false)
+    }
+  }, [isInitialized, authState.isAuthenticated, getAccessToken])
+
+  const subscribe = React.useCallback(
+    (eventName: string, handler: (payload: unknown) => void) => {
+      const map = listenersRef.current
+      let handlers = map.get(eventName)
+      if (!handlers) {
+        handlers = new Set()
+        map.set(eventName, handlers)
+        // First subscriber for this event — bind the socket listener.
+        socketRef.current?.on(eventName, (payload: unknown) => {
+          const set = listenersRef.current.get(eventName)
+          if (!set) {
+            return
+          }
+          for (const h of set) {
+            h(payload)
+          }
+        })
+      }
+      handlers.add(handler)
+      return () => {
+        const set = listenersRef.current.get(eventName)
+        if (!set) {
+          return
+        }
+        set.delete(handler)
+        if (set.size === 0) {
+          listenersRef.current.delete(eventName)
+          socketRef.current?.off(eventName)
+        }
+      }
+    },
+    [],
+  )
+
+  const value = React.useMemo(
+    () => ({ socket, connected, reconnectCount, subscribe }),
+    [socket, connected, reconnectCount, subscribe],
+  )
+
+  return (
+    <AppUserSocketContext.Provider value={value}>
+      {children}
+    </AppUserSocketContext.Provider>
+  )
+}

--- a/packages/app-browser-sdk/src/hooks/app-user-socket/index.ts
+++ b/packages/app-browser-sdk/src/hooks/app-user-socket/index.ts
@@ -1,0 +1,3 @@
+export * from './app-user-socket.context'
+export * from './app-user-socket.hook'
+export * from './app-user-socket.provider'

--- a/packages/app-browser-sdk/src/index.ts
+++ b/packages/app-browser-sdk/src/index.ts
@@ -1,6 +1,7 @@
 export { Link } from './components'
 export type { IframeMessage, InitialData as TokenData } from './types'
 export * from './hooks/app-browser-sdk'
+export * from './hooks/app-user-socket'
 export {
   createBridgeConnection,
   type BridgeConnection,


### PR DESCRIPTION
Deliver app-emitted events with `targetUserId` / `targetLocation` to the matching app-user socket stream, rather than the app-wide channel.

- `app-socket-message.handler` plumbs target fields into dispatch
- `event.service` routes targeted events to app-user socket rooms
- `app-browser-sdk` exposes `useAppUserSocket` hook + provider

> **Stacked PR** — depends on #246. Will retarget to `main` once upstream lands.

Closes [LOM-314](https://linear.app/lombokapp/issue/LOM-314/broadcast-app-events-with-target-users-to-the-app-user-socket-stream)