### PR TITLE
fix(LOM-312): app db pool issues (re-targeted)

### DIFF
--- a/packages/app-worker-sdk/src/app-worker-sdk.ts
+++ b/packages/app-worker-sdk/src/app-worker-sdk.ts
@@ -318,10 +318,28 @@ export class LombokAppPgClient {
     }
   }
 
+  // Drizzle's transaction() checks `client instanceof Pool ||
+  // constructor.name.includes('Pool')` to decide whether to acquire a
+  // single connection for BEGIN/COMMIT. Without this, every query inside
+  // db.transaction() is routed through a separate pool checkout — any
+  // concurrent query (e.g. Promise.all) splits connections, the COMMIT
+  // lands on a non-tx checkout, and the in-tx connection's writes get
+  // rolled back when it idles. So we hand drizzle a real PoolClient.
+  async connect(): Promise<pg.PoolClient> {
+    const pool = await this.ensurePool()
+    return pool.connect()
+  }
+
   async end() {
     await this.pool?.end()
   }
 }
+
+// Make drizzle's `constructor.name.includes('Pool')` check pass without
+// renaming the public class — see the comment on `connect()` above.
+Object.defineProperty(LombokAppPgClient, 'name', {
+  value: 'LombokAppPgClientPool',
+})
 
 export const createLombokAppPgDatabase = <TDb extends Record<string, unknown>>(
   server: IAppPlatformService,


### PR DESCRIPTION
Re-targeting [LOM-312](https://linear.app/lombokapp/issue/LOM-312/fix-app-db-pool-issues-in-worker-sdk). The original PR (#245) was inadvertently merged into a stale stacked-PR base that did not propagate to `main`, so the changes never landed. Same content, fresh PR against `main`.

App DB pool was misbehaving on long-running workers — connections weren't being returned cleanly when an app worker exited. Add explicit pool teardown / cleanup in `@lombokapp/app-worker-sdk` so the pool drains correctly on shutdown.

Closes [LOM-312](https://linear.app/lombokapp/issue/LOM-312/fix-app-db-pool-issues-in-worker-sdk)