### PR TITLE
fix(LOM-316): fix needsUsername property check in SSO auth flow

### DIFF
--- a/packages/auth-utils/src/contexts/auth.context.tsx
+++ b/packages/auth-utils/src/contexts/auth.context.tsx
@@ -142,7 +142,7 @@ export const AuthContextProvider = ({
         signupParams,
       )
 
-      if ('needsUsername' in handleSSOResponse) {
+      if (handleSSOResponse.needsUsername) {
         const needsUsernameResponse = handleSSOResponse as {
           needsUsername: boolean
           provider: string


### PR DESCRIPTION
`'needsUsername' in handleSSOResponse` was always true because the response type always carries the property — the SSO flow was always treating responses as "needs username" even when it wasn't required. Check the property's truthy value instead.

Closes [LOM-316](https://linear.app/lombokapp/issue/LOM-316/fix-needsusername-property-check-in-sso-auth-flow)