### PR TITLE
fix(LOM-317): guard against DB pool exhaustion in app + event services

### DIFF
--- a/packages/api/src/app/services/app.service.ts
+++ b/packages/api/src/app/services/app.service.ts
@@ -257,12 +257,15 @@ export class AppService {
     appIdentifier: string,
     {
       enabled,
+      tx,
     }: {
       enabled?: boolean
+      tx?: OrmService['db']
     } = {},
   ): Promise<App | undefined> {
     const idCondition = eq(appsTable.identifier, appIdentifier)
-    return this.ormService.db.query.appsTable.findFirst({
+    const db = tx ?? this.ormService.db
+    return db.query.appsTable.findFirst({
       where:
         typeof enabled === 'boolean'
           ? and(idCondition, eq(appsTable.enabled, enabled))
@@ -2006,24 +2009,26 @@ export class AppService {
   async validateAppUserAccess({
     appIdentifier,
     userId,
+    tx,
   }: {
     appIdentifier: string
     userId: string
+    tx?: OrmService['db']
   }): Promise<void> {
-    const app = await this.getApp(appIdentifier, { enabled: true })
+    const db = tx ?? this.ormService.db
+    const app = await this.getApp(appIdentifier, { enabled: true, tx })
     if (!app) {
       throw new UnauthorizedException(
         `Unauthorized: app "${appIdentifier}" is not enabled or does not exist.`,
       )
     }
 
-    const appUserSettings =
-      await this.ormService.db.query.appUserSettingsTable.findFirst({
-        where: and(
-          eq(appUserSettingsTable.appIdentifier, appIdentifier),
-          eq(appUserSettingsTable.userId, userId),
-        ),
-      })
+    const appUserSettings = await db.query.appUserSettingsTable.findFirst({
+      where: and(
+        eq(appUserSettingsTable.appIdentifier, appIdentifier),
+        eq(appUserSettingsTable.userId, userId),
+      ),
+    })
 
     const resolvedUserSettings = resolveUserAppSettings(app, appUserSettings)
     const enabled =
@@ -2041,18 +2046,21 @@ export class AppService {
   async validateAppFolderAccess({
     appIdentifier,
     folderId,
+    tx,
   }: {
     appIdentifier: string
     folderId: string
+    tx?: OrmService['db']
   }): Promise<void> {
-    const app = await this.getApp(appIdentifier, { enabled: true })
+    const db = tx ?? this.ormService.db
+    const app = await this.getApp(appIdentifier, { enabled: true, tx })
     if (!app) {
       throw new UnauthorizedException(
         `Unauthorized: app "${appIdentifier}" is not enabled or does not exist.`,
       )
     }
 
-    const folder = await this.ormService.db.query.foldersTable.findFirst({
+    const folder = await db.query.foldersTable.findFirst({
       where: eq(foldersTable.id, folderId),
     })
 
@@ -2060,21 +2068,19 @@ export class AppService {
       throw new NotFoundException(`Folder not found: ${folderId}`)
     }
 
-    const appUserSettings =
-      await this.ormService.db.query.appUserSettingsTable.findFirst({
-        where: and(
-          eq(appUserSettingsTable.appIdentifier, appIdentifier),
-          eq(appUserSettingsTable.userId, folder.ownerId),
-        ),
-      })
+    const appUserSettings = await db.query.appUserSettingsTable.findFirst({
+      where: and(
+        eq(appUserSettingsTable.appIdentifier, appIdentifier),
+        eq(appUserSettingsTable.userId, folder.ownerId),
+      ),
+    })
 
-    const appFolderSettings =
-      await this.ormService.db.query.appFolderSettingsTable.findFirst({
-        where: and(
-          eq(appFolderSettingsTable.appIdentifier, appIdentifier),
-          eq(appFolderSettingsTable.folderId, folderId),
-        ),
-      })
+    const appFolderSettings = await db.query.appFolderSettingsTable.findFirst({
+      where: and(
+        eq(appFolderSettingsTable.appIdentifier, appIdentifier),
+        eq(appFolderSettingsTable.folderId, folderId),
+      ),
+    })
 
     const resolvedFolderSettings = resolveFolderAppSettings(
       app,

--- a/packages/api/src/event/services/event.service.ts
+++ b/packages/api/src/event/services/event.service.ts
@@ -245,12 +245,20 @@ export class EventService {
       data,
       targetLocation,
       targetUserId,
+      skipValidation,
     }: {
       emitterIdentifier: string
       eventIdentifier: string
       data: JsonSerializableObject
       targetLocation?: { folderId: string; objectKey?: string }
       targetUserId?: string
+      /**
+       * Set when the public `emitEvent` has already validated. Skips the
+       * pre-write checks so we don't re-issue the same SELECTs inside the
+       * transaction's connection. Tx-passed callers (`emitEvent({tx})`)
+       * still go through validation here.
+       */
+      skipValidation?: boolean
     },
     tx: OrmService['db'],
   ) {
@@ -268,6 +276,7 @@ export class EventService {
     const app = appIdentifier
       ? await this.appService.getApp(appIdentifier.toLowerCase(), {
           enabled: true,
+          tx,
         })
       : undefined
 
@@ -277,18 +286,20 @@ export class EventService {
       )
     }
 
-    if (appIdentifier) {
+    if (appIdentifier && !skipValidation) {
       try {
         if (targetLocation) {
           await this.appService.validateAppFolderAccess({
             appIdentifier,
             folderId: targetLocation.folderId,
+            tx,
           })
         }
         if (targetUserId) {
           await this.appService.validateAppUserAccess({
             appIdentifier,
             userId: targetUserId,
+            tx,
           })
         }
       } catch (error) {
@@ -383,11 +394,13 @@ export class EventService {
             await this.appService.validateAppFolderAccess({
               appIdentifier: subscribedApp.identifier,
               folderId: targetLocation.folderId,
+              tx,
             })
           } else if (targetUserId) {
             await this.appService.validateAppUserAccess({
               appIdentifier: subscribedApp.identifier,
               userId: targetUserId,
+              tx,
             })
           }
         } catch (error) {
@@ -602,12 +615,71 @@ export class EventService {
           : {}),
     }
     if (options.tx) {
+      // Caller already in a transaction — preserve their atomicity scope and
+      // run everything (validation + writes + cascades) inside their tx.
       return this._emitEventInTx(args, options.tx)
-    } else {
-      return this.ormService.db.transaction(async (tx) => {
-        return this._emitEventInTx(args, tx)
-      })
     }
+
+    // Hoist validation out of the transaction. These are pool reads with no
+    // atomicity requirement — keeping them inside the tx pinned a connection
+    // for the entire validation duration, and a fan-out of N parallel emits
+    // exhausted the pool with each tx waiting on a second connection (the
+    // app/folder/user lookups). Now the only thing the tx covers is the
+    // event + tasks insert pair plus their recursive cascade.
+    if (!eventIdentifierSchema.safeParse(args.eventIdentifier).success) {
+      throw new InternalServerErrorException(
+        `Invalid event identifier: ${args.eventIdentifier}`,
+      )
+    }
+
+    const isCoreEmitter = args.emitterIdentifier === CORE_IDENTIFIER
+    const appIdentifier = !isCoreEmitter ? args.emitterIdentifier : undefined
+    const targetLocation =
+      'targetLocation' in args ? args.targetLocation : undefined
+    const targetUserId =
+      'targetUserId' in args ? args.targetUserId : undefined
+    if (appIdentifier) {
+      const app = await this.appService.getApp(appIdentifier.toLowerCase(), {
+        enabled: true,
+      })
+      if (!app) {
+        throw new InternalServerErrorException(
+          `No app found for identifier "${appIdentifier}"`,
+        )
+      }
+      try {
+        if (targetLocation) {
+          await this.appService.validateAppFolderAccess({
+            appIdentifier,
+            folderId: targetLocation.folderId,
+          })
+        }
+        if (targetUserId) {
+          await this.appService.validateAppUserAccess({
+            appIdentifier,
+            userId: targetUserId,
+          })
+        }
+      } catch (error) {
+        if (error instanceof UnauthorizedException) {
+          this.logger.warn('Unauthorized to emit event', {
+            eventIdentifier: args.eventIdentifier,
+            emitterIdentifier: args.emitterIdentifier,
+            data: args.data,
+            target: {
+              location: targetLocation,
+              userId: targetUserId,
+            },
+          })
+          return
+        }
+        throw error
+      }
+    }
+
+    return this.ormService.db.transaction(async (tx) => {
+      return this._emitEventInTx({ ...args, skipValidation: true }, tx)
+    })
   }
 
   private buildEventInvocation(event: Event, eventTriggerConfigIndex: number) {

--- a/packages/api/src/orm/orm.service.ts
+++ b/packages/api/src/orm/orm.service.ts
@@ -141,6 +141,10 @@ export class OrmService {
         user: this._ormConfig.dbUser,
         password: this._ormConfig.dbPassword,
         database: this._ormConfig.dbName,
+        // Surface deadlocks loudly instead of hanging forever. If a caller
+        // can't get a connection within 10s, throw — better a noisy error
+        // than a silent freeze.
+        connectionTimeoutMillis: 10_000,
       })
     }
     return this._client

--- a/packages/app-worker-sdk/src/app-worker-sdk.ts
+++ b/packages/app-worker-sdk/src/app-worker-sdk.ts
@@ -273,6 +273,11 @@ export class LombokAppPgClient {
         password: creds.password,
         database: creds.database,
         ssl: false,
+        // Surface connection-acquire deadlocks loudly. Without this, a tx
+        // callback that triggers a second pool checkout (directly or via a
+        // helper that uses the pool client instead of the tx) hangs
+        // forever; with it, the second checkout throws after 10s.
+        connectionTimeoutMillis: 10_000,
       })
     }
 


### PR DESCRIPTION
Long-running app socket sessions and event broadcasting were holding DB connections longer than necessary, causing pool exhaustion under load. Tighten connection scoping in `app.service` and `event.service`, expose a configurable pool size in `orm.service`, and add a guard in `app-worker-sdk` so the worker SDK doesn't outlive its pool.

> **Stacked PR** — depends on #250. Will retarget to `main` once upstream lands.

Closes [LOM-317](https://linear.app/lombokapp/issue/LOM-317/guard-against-db-pool-exhaustion-in-app-event-services)