### PR TITLE
chore(LOM-318): remove leftover debugLogging from auth/SDK plumbing

### DIFF
--- a/packages/api/src/auth/services/session.service.ts
+++ b/packages/api/src/auth/services/session.service.ts
@@ -211,9 +211,7 @@ export class SessionService {
     return this.jwtService.createAppUserToken({
       session,
       appIdentifier: details.app,
-      ...(typeof details.worker === 'string'
-        ? { worker: details.worker }
-        : {}),
+      ...(typeof details.worker === 'string' ? { worker: details.worker } : {}),
       ...(typeof details.platformAccess === 'boolean'
         ? { platformAccess: details.platformAccess }
         : {}),

--- a/packages/app-browser-sdk/src/app-browser-sdk.ts
+++ b/packages/app-browser-sdk/src/app-browser-sdk.ts
@@ -116,7 +116,6 @@ export class AppBrowserSdk implements AppBrowserSdkInstance {
             ),
           getTokens: () => Promise.resolve(AppBrowserSdk.tokens),
         },
-        debugLogging: this.config.debugLogging,
       })
     }
     return AppBrowserSdk.sdk

--- a/packages/app-browser-sdk/src/hooks/app-browser-sdk/app-browser-sdk.provider.tsx
+++ b/packages/app-browser-sdk/src/hooks/app-browser-sdk/app-browser-sdk.provider.tsx
@@ -65,7 +65,6 @@ export const AppBrowserSdkContextProvider = ({
             : `/${to.pathAndQuery}`,
         })
       },
-      debugLogging: true,
     })
   })
 

--- a/packages/app-browser-sdk/src/types.ts
+++ b/packages/app-browser-sdk/src/types.ts
@@ -20,7 +20,6 @@ export interface AppBrowserSdkConfig {
   onInitialize?: () => void
   onNavigateTo?: (to: { pathAndQuery: string }) => void
   onThemeChange?: (theme: string) => void
-  debugLogging?: boolean
 }
 
 export interface AppBrowserSdkInstance {

--- a/packages/auth-utils/src/authenticator.ts
+++ b/packages/auth-utils/src/authenticator.ts
@@ -59,7 +59,6 @@ export class Authenticator {
       onTokensRefreshed?: (tokens: DefinedTokensType) => void | Promise<void>
       onLogout?: () => void | Promise<void>
       tokenStore?: TokenStore
-      debugLogging?: boolean
     },
   ) {
     this.onTokensCreated = options.onTokensCreated

--- a/packages/sdk/src/lombok-sdk.ts
+++ b/packages/sdk/src/lombok-sdk.ts
@@ -12,7 +12,6 @@ export class LombokSdk {
     onTokensRefreshed,
     onLogout,
     tokenStore,
-    debugLogging = false,
   }: {
     basePath: string
     onTokensCreated?: (tokens: {
@@ -25,14 +24,12 @@ export class LombokSdk {
     }) => void | Promise<void>
     onLogout?: () => void | Promise<void>
     tokenStore?: TokenStore
-    debugLogging?: boolean
   }) {
     this.authenticator = new Authenticator({
       basePath,
       onTokensCreated,
       onTokensRefreshed,
       onLogout,
-      debugLogging,
       tokenStore,
     })
 


### PR DESCRIPTION
`debugLogging` was carried through `Authenticator`, `LombokSdk`, `AppBrowserSdkConfig`, and the app-browser-sdk provider but never actually used. The provider was hardcoding it to `true`. Pure cleanup.

Closes [LOM-318](https://linear.app/lombokapp/issue/LOM-318/remove-leftover-debuglogging-from-authsdk-plumbing)