### PR TITLE
chore(LOM-319): improve platform vs app error handling

### DIFF
--- a/docker/worker-agent/internal/runner/cancel.go
+++ b/docker/worker-agent/internal/runner/cancel.go
@@ -143,7 +143,9 @@ func CancelJob(config CancelJobConfig, errorCode string, errorMessage string, er
 		"worker_startup_time_seconds": workerStartupDuration.Seconds(),
 	}
 
-	// Signal completion to platform if available
+	// Signal completion to platform if available.
+	// Cancellations are agent-initiated (e.g., we couldn't signal start to the
+	// platform) — they're internal mechanics failures by definition.
 	if config.PlatformClient != nil {
 		ctx := context.Background()
 		completionReq := &types.CompletionRequest{
@@ -151,6 +153,7 @@ func CancelJob(config CancelJobConfig, errorCode string, errorMessage string, er
 			Error: &types.JobError{
 				Code:    errorCode,
 				Message: errorMessage,
+				Origin:  types.ErrorOriginPlatform,
 				Details: errorDetails,
 			},
 		}
@@ -165,6 +168,7 @@ func CancelJob(config CancelJobConfig, errorCode string, errorMessage string, er
 	errMap := map[string]interface{}{
 		"code":    errorCode,
 		"message": errorMessage,
+		"origin":  types.ErrorOriginPlatform,
 	}
 	if len(errorDetails) > 0 {
 		errMap["details"] = errorDetails
@@ -191,6 +195,7 @@ func CancelJob(config CancelJobConfig, errorCode string, errorMessage string, er
 		Error: &types.JobError{
 			Code:    errorCode,
 			Message: errorMessage,
+			Origin:  types.ErrorOriginPlatform,
 			Details: errorDetails,
 		},
 	}

--- a/docker/worker-agent/internal/runner/exec.go
+++ b/docker/worker-agent/internal/runner/exec.go
@@ -149,6 +149,7 @@ func RunExecPerJob(payload *types.JobPayload, jobStartTime time.Time) error {
 				Error: &types.JobError{
 					Code:    "WORKER_START_ERROR",
 					Message: startErrorMessage,
+					Origin:  types.ErrorOriginPlatform,
 					Details: startErrorDetails,
 				},
 			}
@@ -167,6 +168,7 @@ func RunExecPerJob(payload *types.JobPayload, jobStartTime time.Time) error {
 			"error": map[string]interface{}{
 				"code":    "WORKER_START_ERROR",
 				"message": startErrorMessage,
+				"origin":  types.ErrorOriginPlatform,
 				"details": startErrorDetails,
 			},
 		}
@@ -184,6 +186,7 @@ func RunExecPerJob(payload *types.JobPayload, jobStartTime time.Time) error {
 			Error: &types.JobError{
 				Code:    "WORKER_START_ERROR",
 				Message: startErrorMessage,
+				Origin:  types.ErrorOriginPlatform,
 				Details: startErrorDetails,
 			},
 		}
@@ -346,9 +349,12 @@ func RunExecPerJob(payload *types.JobPayload, jobStartTime time.Time) error {
 				// Prefer the worker's own structured error when available.
 				completionReq.Error = workerSuppliedError
 			} else {
+				// Worker process is user-controlled code; a non-zero exit
+				// without a structured envelope is an app-side crash.
 				completionReq.Error = &types.JobError{
 					Code:    "WORKER_EXIT_ERROR",
 					Message: fmt.Sprintf("worker exited with code %d: %s", exitCode, exitError),
+					Origin:  types.ErrorOriginApp,
 					Details: map[string]any{
 						"exit_code": exitCode,
 					},
@@ -362,6 +368,7 @@ func RunExecPerJob(payload *types.JobPayload, jobStartTime time.Time) error {
 			completionReq.Error = &types.JobError{
 				Code:    "FILE_UPLOAD_ERROR",
 				Message: fmt.Sprintf("failed to upload output files: %v", uploadError),
+				Origin:  types.ErrorOriginPlatform,
 				Details: map[string]any{
 					"underlying_error": uploadError.Error(),
 				},
@@ -413,6 +420,7 @@ func RunExecPerJob(payload *types.JobPayload, jobStartTime time.Time) error {
 			finalError = &types.JobError{
 				Code:    "WORKER_EXIT_ERROR",
 				Message: fmt.Sprintf("worker exited with code %d: %s", exitCode, exitError),
+				Origin:  types.ErrorOriginApp,
 				Details: map[string]any{
 					"exit_code": exitCode,
 				},
@@ -424,6 +432,7 @@ func RunExecPerJob(payload *types.JobPayload, jobStartTime time.Time) error {
 		finalError = &types.JobError{
 			Code:    "FILE_UPLOAD_ERROR",
 			Message: fmt.Sprintf("failed to upload output files: %v", uploadError),
+			Origin:  types.ErrorOriginPlatform,
 			Details: map[string]any{
 				"underlying_error": uploadError.Error(),
 			},
@@ -434,6 +443,7 @@ func RunExecPerJob(payload *types.JobPayload, jobStartTime time.Time) error {
 		errMap := map[string]interface{}{
 			"code":    finalError.Code,
 			"message": finalError.Message,
+			"origin":  finalError.Origin,
 		}
 		if len(finalError.Details) > 0 {
 			errMap["details"] = finalError.Details

--- a/docker/worker-agent/internal/runner/http.go
+++ b/docker/worker-agent/internal/runner/http.go
@@ -129,6 +129,7 @@ func RunPersistentHTTP(payload *types.JobPayload, jobStartTime time.Time) error 
 				Error: &types.JobError{
 					Code:    "WORKER_NOT_READY",
 					Message: err.Error(),
+					Origin:  types.ErrorOriginPlatform,
 					Details: errorDetails,
 				},
 			}
@@ -143,6 +144,7 @@ func RunPersistentHTTP(payload *types.JobPayload, jobStartTime time.Time) error 
 			"error": map[string]interface{}{
 				"code":    "WORKER_NOT_READY",
 				"message": err.Error(),
+				"origin":  types.ErrorOriginPlatform,
 				"details": errorDetails,
 			},
 			"timing": map[string]interface{}{
@@ -231,6 +233,7 @@ func RunPersistentHTTP(payload *types.JobPayload, jobStartTime time.Time) error 
 			"error": map[string]interface{}{
 				"code":    "JOB_SUBMIT_FAILED",
 				"message": err.Error(),
+				"origin":  types.ErrorOriginPlatform,
 				"details": errorDetails,
 			},
 			"timing": map[string]interface{}{
@@ -282,7 +285,9 @@ func RunPersistentHTTP(payload *types.JobPayload, jobStartTime time.Time) error 
 			}
 		}
 
-		// Signal completion to platform if available
+		// Signal completion to platform if available.
+		// JOB_NOT_ACCEPTED is the worker rejecting the job — that's an app
+		// concern (the worker decided this job isn't valid for it).
 		if platformClient != nil {
 			ctx := context.Background()
 			completionReq := &types.CompletionRequest{
@@ -290,6 +295,7 @@ func RunPersistentHTTP(payload *types.JobPayload, jobStartTime time.Time) error 
 				Error: &types.JobError{
 					Code:    "JOB_NOT_ACCEPTED",
 					Message: errMsg,
+					Origin:  types.ErrorOriginApp,
 					Details: errorDetails,
 				},
 			}
@@ -304,6 +310,7 @@ func RunPersistentHTTP(payload *types.JobPayload, jobStartTime time.Time) error 
 			"error": map[string]interface{}{
 				"code":    "JOB_NOT_ACCEPTED",
 				"message": errMsg,
+				"origin":  types.ErrorOriginApp,
 				"details": errorDetails,
 			},
 			"timing": map[string]interface{}{
@@ -378,7 +385,10 @@ func RunPersistentHTTP(payload *types.JobPayload, jobStartTime time.Time) error 
 			"timeout_seconds": jobPollTimeout.Seconds(),
 		}
 
-		// Signal completion to platform if available
+		// Signal completion to platform if available.
+		// JOB_POLL_TIMEOUT means the worker never finished its job — the worker
+		// is user code, so this is treated as an app-side hang rather than a
+		// platform mechanics failure.
 		if platformClient != nil {
 			ctx := context.Background()
 			completionReq := &types.CompletionRequest{
@@ -386,6 +396,7 @@ func RunPersistentHTTP(payload *types.JobPayload, jobStartTime time.Time) error 
 				Error: &types.JobError{
 					Code:    "JOB_POLL_TIMEOUT",
 					Message: jobState.Error,
+					Origin:  types.ErrorOriginApp,
 					Details: errorDetails,
 				},
 			}
@@ -400,6 +411,7 @@ func RunPersistentHTTP(payload *types.JobPayload, jobStartTime time.Time) error 
 			"error": map[string]interface{}{
 				"code":    "JOB_POLL_TIMEOUT",
 				"message": jobState.Error,
+				"origin":  types.ErrorOriginApp,
 				"details": errorDetails,
 			},
 			"timing": map[string]interface{}{

--- a/docker/worker-agent/internal/types/payload.go
+++ b/docker/worker-agent/internal/types/payload.go
@@ -99,6 +99,15 @@ type HTTPJobResponse struct {
 	Error   *JobError       `json:"error,omitempty"`
 }
 
+// Error origin classification. "app" means the failure came from the worker's
+// (user-controlled) code; "platform" means the failure came from the agent or
+// platform mechanics. The platform uses this to decide whether the runner task
+// itself should fail or whether only the inner task should.
+const (
+	ErrorOriginApp      = "app"
+	ErrorOriginPlatform = "platform"
+)
+
 // JobError represents an error from a job execution.
 // Supports both structured {"code":"...","message":"...","details":{...}} and plain string
 // formats during JSON unmarshaling, so that validation errors from workers
@@ -106,19 +115,25 @@ type HTTPJobResponse struct {
 type JobError struct {
 	Code    string         `json:"code"`
 	Message string         `json:"message"`
+	Origin  string         `json:"origin"`
 	Details map[string]any `json:"details,omitempty"`
 }
 
 // UnmarshalJSON handles both string and object error formats from workers.
 //
-//	String:  "some error"           → JobError{Code: "UNKNOWN", Message: "some error"}
-//	Object:  {"code":"X","message":"Y"} → JobError{Code: "X", Message: "Y"}
+//	String:  "some error"           → JobError{Code: "UNKNOWN", Message: "some error", Origin: "app"}
+//	Object:  {"code":"X","message":"Y"} → JobError{Code: "X", Message: "Y", Origin: "app"}
+//
+// Anything that arrives via worker output is by definition worker-supplied, so
+// origin defaults to "app" when omitted. Agent-generated errors set Origin
+// explicitly at construction.
 func (e *JobError) UnmarshalJSON(data []byte) error {
 	// Try plain string first (the common mismatch case)
 	var s string
 	if err := json.Unmarshal(data, &s); err == nil {
 		e.Code = "UNKNOWN"
 		e.Message = s
+		e.Origin = ErrorOriginApp
 		return nil
 	}
 	// Fall back to structured object
@@ -128,6 +143,9 @@ func (e *JobError) UnmarshalJSON(data []byte) error {
 		return err
 	}
 	*e = JobError(a)
+	if e.Origin == "" {
+		e.Origin = ErrorOriginApp
+	}
 	return nil
 }
 

--- a/docker/worker-agent/internal/types/payload_test.go
+++ b/docker/worker-agent/internal/types/payload_test.go
@@ -18,6 +18,9 @@ func TestJobError_UnmarshalJSON_PlainString(t *testing.T) {
 	if got.Message != "boom" {
 		t.Errorf("Message = %q, want %q", got.Message, "boom")
 	}
+	if got.Origin != ErrorOriginApp {
+		t.Errorf("Origin = %q, want %q", got.Origin, ErrorOriginApp)
+	}
 	if got.Details != nil {
 		t.Errorf("Details = %v, want nil", got.Details)
 	}
@@ -35,8 +38,21 @@ func TestJobError_UnmarshalJSON_StructuredWithoutDetails(t *testing.T) {
 	if got.Message != "Y" {
 		t.Errorf("Message = %q, want %q", got.Message, "Y")
 	}
+	if got.Origin != ErrorOriginApp {
+		t.Errorf("Origin = %q, want %q (default when omitted)", got.Origin, ErrorOriginApp)
+	}
 	if got.Details != nil {
 		t.Errorf("Details = %v, want nil", got.Details)
+	}
+}
+
+func TestJobError_UnmarshalJSON_StructuredWithExplicitOrigin(t *testing.T) {
+	var got JobError
+	if err := json.Unmarshal([]byte(`{"code":"X","message":"Y","origin":"platform"}`), &got); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.Origin != ErrorOriginPlatform {
+		t.Errorf("Origin = %q, want %q", got.Origin, ErrorOriginPlatform)
 	}
 }
 
@@ -67,6 +83,7 @@ func TestJobError_MarshalJSON_RoundTrip(t *testing.T) {
 	original := JobError{
 		Code:    "X",
 		Message: "Y",
+		Origin:  ErrorOriginPlatform,
 		Details: map[string]any{"foo": "bar"},
 	}
 
@@ -80,7 +97,7 @@ func TestJobError_MarshalJSON_RoundTrip(t *testing.T) {
 		t.Fatalf("unmarshal failed: %v", err)
 	}
 
-	if decoded.Code != original.Code || decoded.Message != original.Message {
+	if decoded.Code != original.Code || decoded.Message != original.Message || decoded.Origin != original.Origin {
 		t.Errorf("round-trip mismatch: got %+v, want %+v", decoded, original)
 	}
 	if !reflect.DeepEqual(map[string]any(decoded.Details), original.Details) {
@@ -89,7 +106,7 @@ func TestJobError_MarshalJSON_RoundTrip(t *testing.T) {
 }
 
 func TestJobError_MarshalJSON_OmitsEmptyDetails(t *testing.T) {
-	original := JobError{Code: "X", Message: "Y"}
+	original := JobError{Code: "X", Message: "Y", Origin: ErrorOriginApp}
 
 	encoded, err := json.Marshal(original)
 	if err != nil {
@@ -97,7 +114,8 @@ func TestJobError_MarshalJSON_OmitsEmptyDetails(t *testing.T) {
 	}
 
 	// `details` should be omitted when nil/empty thanks to the `omitempty` tag.
-	wantJSON := `{"code":"X","message":"Y"}`
+	// `origin` is required, never omitted.
+	wantJSON := `{"code":"X","message":"Y","origin":"app"}`
 	if string(encoded) != wantJSON {
 		t.Errorf("encoded = %s, want %s", string(encoded), wantJSON)
 	}

--- a/packages/api/src/core-worker/processors/run-serverless-worker-task.processor.ts
+++ b/packages/api/src/core-worker/processors/run-serverless-worker-task.processor.ts
@@ -8,6 +8,7 @@ import { tasksTable } from 'src/task/entities/task.entity'
 import { TaskService } from 'src/task/services/task.service'
 import { CoreTaskName } from 'src/task/task.constants'
 import { transformTaskToDTO } from 'src/task/transforms/task.transforms'
+import { buildTaskCompletions } from 'src/task/util/build-task-completions.util'
 
 import { CoreWorkerService } from '../core-worker.service'
 
@@ -80,46 +81,13 @@ export class RunServerlessWorkerTaskProcessor extends BaseCoreTaskProcessor<Core
                 error,
               })
 
-        const highestLevelAppError =
-          normalizedError.resolveHighestLevelAppError()
-        const runnerSuccess = !!highestLevelAppError
-        innerTaskCompletion = {
-          success: false,
-          requeueDelayMs: highestLevelAppError?.requeueDelayMs,
-          executorMetadata: runtimeExecutorMetadata,
-          error: {
-            code: highestLevelAppError?.code ?? 'EXECUTION_ERROR',
-            name: highestLevelAppError?.name ?? 'ExecutionError',
-            message:
-              highestLevelAppError?.message ??
-              `There was an error executing the task (${typeof highestLevelAppError?.requeueDelayMs !== 'undefined' ? 'requeued' : 'see admin logs for details'})`,
-            ...(highestLevelAppError
-              ? {
-                  name: highestLevelAppError.name,
-                  message: highestLevelAppError.message,
-                  stack: highestLevelAppError.stack,
-                  details: highestLevelAppError.toEnvelope(),
-                }
-              : {}), // TODO: add some details for an internal (non-app) error
-          },
-        }
-
-        runnerTaskCompletion = {
-          success: runnerSuccess,
-          ...(!runnerSuccess
-            ? {
-                error: {
-                  code: normalizedError.code,
-                  name: normalizedError.name,
-                  message: normalizedError.message,
-                  details: normalizedError.toEnvelope(),
-                },
-              }
-            : {
-                result: {},
-              }),
-          executorMetadata: { type: 'system', metadata: {} },
-        } as TaskCompletion
+        const built = buildTaskCompletions({
+          normalizedError,
+          innerExecutorMetadata: runtimeExecutorMetadata,
+          runnerExecutorMetadata: { type: 'system', metadata: {} },
+        })
+        innerTaskCompletion = built.innerTaskCompletion
+        runnerTaskCompletion = built.runnerTaskCompletion
       }
 
       // Update the inner and runner tasks in a transaction

--- a/packages/api/src/docker/dto/docker-job-complete-request.dto.ts
+++ b/packages/api/src/docker/dto/docker-job-complete-request.dto.ts
@@ -1,4 +1,5 @@
 import { jsonSerializableObjectSchema, requeueSchema } from '@lombokapp/types'
+import { errorOriginSchema } from '@lombokapp/worker-utils'
 import { createZodDto } from 'nestjs-zod'
 import { z } from 'zod'
 
@@ -21,6 +22,7 @@ export const errorResponseSchema = z
       name: z.string().optional(),
       code: z.string(),
       message: z.string(),
+      origin: errorOriginSchema,
       details: jsonSerializableObjectSchema.optional(),
     }),
   })

--- a/packages/api/src/docker/processors/run-docker-worker.task-processor.ts
+++ b/packages/api/src/docker/processors/run-docker-worker.task-processor.ts
@@ -1,4 +1,4 @@
-import { deterministicJobId, TaskCompletion } from '@lombokapp/types'
+import { deterministicJobId } from '@lombokapp/types'
 import { AsyncWorkError, buildUnexpectedError } from '@lombokapp/worker-utils'
 import {
   forwardRef,
@@ -13,6 +13,7 @@ import { BaseCoreTaskProcessor } from 'src/task/base.processor'
 import { tasksTable } from 'src/task/entities/task.entity'
 import { TaskService } from 'src/task/services/task.service'
 import { CoreTaskName } from 'src/task/task.constants'
+import { buildTaskCompletions } from 'src/task/util/build-task-completions.util'
 
 import { DockerJobsService } from '../services/docker-jobs.service'
 
@@ -88,55 +89,21 @@ export class RunDockerWorkerTaskProcessor extends BaseCoreTaskProcessor<CoreTask
             : buildUnexpectedError({
                 code: 'UNEXPECTED_DOCKER_EXECUTION_ERROR',
                 message:
-                  'Unexpected error during in run serverless worker core task processor (run-docker-worker-task.processor.ts)',
-
+                  'Unexpected error during in run docker worker core task processor (run-docker-worker-task.processor.ts)',
                 error,
               })
-        const highestLevelAppError =
-          normalizedError.resolveHighestLevelAppError()
-        const runnerSuccess = !!highestLevelAppError
 
-        const innerTaskCompletion = {
-          success: false,
-          requeueDelayMs: highestLevelAppError?.requeueDelayMs,
-          executorMetadata: {
-            type: 'docker',
-            metadata: executorMetadata,
-          },
-          error: {
-            code: highestLevelAppError?.code ?? 'EXECUTION_ERROR',
-            name: highestLevelAppError?.name ?? 'ExecutionError',
-            message:
-              highestLevelAppError?.message ??
-              `There was an error executing the task (${typeof highestLevelAppError?.requeueDelayMs !== 'undefined' ? 'requeued' : 'see admin logs for details'})`,
-            ...(highestLevelAppError
-              ? {
-                  name: highestLevelAppError.name,
-                  message: highestLevelAppError.message,
-                  stack: highestLevelAppError.stack,
-                  details: highestLevelAppError.toEnvelope(),
-                }
-              : {}), // TODO: add some details for an internal (non-app) error
-          },
-        } as const
-
-        const runnerTaskCompletion = {
-          success: runnerSuccess,
-          ...(!runnerSuccess
-            ? {
-                error: {
-                  code: normalizedError.code,
-                  name: normalizedError.name,
-                  message: normalizedError.message,
-                  details: normalizedError.toEnvelope(),
-                },
-              }
-            : {}),
-          executorMetadata: {
-            type: 'docker' as const,
-            metadata: executorMetadata,
-          },
+        const dockerExecutorMetadata = {
+          type: 'docker' as const,
+          metadata: executorMetadata,
         }
+
+        const { innerTaskCompletion, runnerTaskCompletion } =
+          buildTaskCompletions({
+            normalizedError,
+            innerExecutorMetadata: dockerExecutorMetadata,
+            runnerExecutorMetadata: dockerExecutorMetadata,
+          })
 
         await this.ormService.db.transaction(async (tx) => {
           await this.taskService.registerTaskCompleted(
@@ -147,7 +114,7 @@ export class RunDockerWorkerTaskProcessor extends BaseCoreTaskProcessor<CoreTask
 
           await this.taskService.registerTaskCompleted(
             task.id,
-            runnerTaskCompletion as TaskCompletion,
+            runnerTaskCompletion,
             { tx },
           )
         })

--- a/packages/api/src/docker/services/client/docker-client.service.ts
+++ b/packages/api/src/docker/services/client/docker-client.service.ts
@@ -671,7 +671,7 @@ export class DockerClientService {
           error instanceof Error ? error : new Error(String(error)),
           {
             name: 'DockerClientError',
-            origin: 'internal',
+            origin: 'platform',
             message: `Failed to list containers by labels: ${error instanceof Error ? error.message : String(error)}`,
             code: 'LIST_CONTAINERS_BY_LABELS_FAILED',
             stack: new Error().stack,

--- a/packages/api/src/docker/services/docker-jobs.service.ts
+++ b/packages/api/src/docker/services/docker-jobs.service.ts
@@ -449,7 +449,7 @@ export class DockerJobsService {
     if (!appIdentifier || !profileName) {
       throw new AsyncWorkError({
         name: 'DockerClientError',
-        origin: 'internal',
+        origin: 'platform',
         code: 'DOCKER_NOT_CONFIGURED',
         message: `Invalid profile key "${profileKey}" — expected "appIdentifier:profileName"`,
       })
@@ -496,7 +496,7 @@ export class DockerJobsService {
       if (!host?.enabled) {
         throw new AsyncWorkError({
           name: 'DockerClientError',
-          origin: 'internal',
+          origin: 'platform',
           code: 'DOCKER_NOT_CONFIGURED',
           message: `Unrecognized Docker host "${hostId}" for container "${refContainerId}"`,
         })
@@ -510,7 +510,7 @@ export class DockerJobsService {
       if (!container) {
         throw new AsyncWorkError({
           name: 'DockerClientError',
-          origin: 'internal',
+          origin: 'platform',
           code: 'CONTAINER_NOT_FOUND',
           message: `Container "${refContainerId}" not found on host "${hostId}"`,
         })
@@ -558,7 +558,7 @@ export class DockerJobsService {
     if (!container) {
       throw new AsyncWorkError({
         name: 'DockerClientError',
-        origin: 'internal',
+        origin: 'platform',
         code: 'CONTAINER_NOT_FOUND',
         message: 'Container not found after findOrCreateContainer call',
       })
@@ -608,7 +608,7 @@ export class DockerJobsService {
       if (provisionExec.exitCode !== 0) {
         throw new AsyncWorkError({
           name: 'ProvisionError',
-          origin: 'internal',
+          origin: 'platform',
           message: `Failed to provision container: exit=${provisionExec.exitCode} stdout=${provisionExec.stdout} stderr=${provisionExec.stderr}`,
           code: 'PROVISION_FAILED',
           stack: new Error().stack,
@@ -667,7 +667,7 @@ export class DockerJobsService {
         if (!resolvedContainerId || typeof resolvedContainerId !== 'string') {
           throw new AsyncWorkError({
             name: 'DockerClientError',
-            origin: 'internal',
+            origin: 'platform',
             code: 'INVALID_CONTAINER_TARGET',
             message:
               'containerIdTemplate did not resolve to a valid container ID',
@@ -689,7 +689,7 @@ export class DockerJobsService {
           ) {
             throw new AsyncWorkError({
               name: 'DockerClientError',
-              origin: 'internal',
+              origin: 'platform',
               code: 'CONTAINER_USER_MISMATCH',
               message: `Container "${resolvedContainerId}" does not belong to user "${userId}"`,
             })
@@ -859,7 +859,7 @@ export class DockerJobsService {
         )
         throw new AsyncWorkError({
           name: 'DockerJobSubmissionError',
-          origin: 'internal',
+          origin: 'platform',
           code: 'JOB_SUBMISSION_FAILED',
           message: startJobExec.stderr || `Job ${jobId} submission failed`,
           stack: new Error().stack,
@@ -956,7 +956,7 @@ export class DockerJobsService {
     }
     throw new AsyncWorkError({
       name: 'DockerWorkerCompletionError',
-      origin: 'internal',
+      origin: 'platform',
       code: 'COMPLETION_TIMEOUT',
       message: `Job is not completed after approximately ${maxRetries * retryPeriodMs}ms`,
     })
@@ -1008,7 +1008,7 @@ export class DockerJobsService {
     if (exec.exitCode !== 0) {
       throw new AsyncWorkError({
         name: 'DockerWorkerStateError',
-        origin: 'internal',
+        origin: 'platform',
         code: 'GET_JOB_STATE_FAILED',
         message: 'Failed to get job state: ' + exec.stderr,
       })
@@ -1017,7 +1017,7 @@ export class DockerJobsService {
     if (exec.stdout.length === 0) {
       throw new AsyncWorkError({
         name: 'DockerWorkerStateError',
-        origin: 'internal',
+        origin: 'platform',
         code: 'JOB_STATE_NOT_FOUND',
         message:
           'Job state not found\nError: ' + exec.stderr + '\n' + exec.stderr,
@@ -1184,7 +1184,7 @@ export class DockerJobsService {
     if (exec.exitCode !== 0) {
       throw new AsyncWorkError({
         name: 'DockerWorkerStateError',
-        origin: 'internal',
+        origin: 'platform',
         code: 'GET_WORKER_STATE_FAILED',
         message: 'Failed to get worker state: ' + exec.stderr,
       })
@@ -1193,7 +1193,7 @@ export class DockerJobsService {
     if (exec.stdout.length === 0) {
       throw new AsyncWorkError({
         name: 'DockerWorkerStateError',
-        origin: 'internal',
+        origin: 'platform',
         code: 'WORKER_STATE_NOT_FOUND',
         message:
           'Worker state not found\nError: ' + exec.stderr + '\n' + exec.stderr,
@@ -1257,7 +1257,7 @@ export class DockerJobsService {
     if (exec.exitCode !== 0) {
       throw new AsyncWorkError({
         name: 'DockerWorkerError',
-        origin: 'internal',
+        origin: 'platform',
         code: 'PURGE_JOBS_FAILED',
         message: 'Failed to purge jobs: ' + exec.stderr,
       })
@@ -1280,7 +1280,7 @@ export class DockerJobsService {
     if (!normalized.startsWith('http_')) {
       throw new AsyncWorkError({
         name: 'DockerWorkerStateError',
-        origin: 'internal',
+        origin: 'platform',
         code: 'WORKER_STATE_NOT_FOUND',
         message: `Worker ID must start with "http_": ${workerId}`,
       })
@@ -1289,7 +1289,7 @@ export class DockerJobsService {
     if (!Number.isFinite(port) || port <= 0) {
       throw new AsyncWorkError({
         name: 'DockerWorkerStateError',
-        origin: 'internal',
+        origin: 'platform',
         code: 'WORKER_STATE_NOT_FOUND',
         message: `Invalid worker port in worker ID: ${workerId}`,
       })

--- a/packages/api/src/docker/services/docker-worker-hook.service.ts
+++ b/packages/api/src/docker/services/docker-worker-hook.service.ts
@@ -457,39 +457,74 @@ export class DockerWorkerHookService {
         throw new NotFoundException(`Inner task not found: ${innerTask}`)
       }
 
-      const innerTaskCompletion: TaskCompletion = completeJobRequest.success
-        ? {
-            success: true,
-            result: completeJobRequest.result,
-            executorMetadata: {
-              type: 'docker',
-              metadata: claims.executorMetadata,
-            },
-          }
-        : {
-            success: false,
-            executorMetadata: {
-              type: 'docker',
-              metadata: claims.executorMetadata,
-            },
-            error: {
-              name: completeJobRequest.error.name ?? 'Error',
-              code: completeJobRequest.error.code,
-              message: completeJobRequest.error.message,
-              ...(completeJobRequest.error.details
-                ? { details: completeJobRequest.error.details }
-                : {}),
-            },
-          }
+      const dockerExecutorMetadata = {
+        type: 'docker' as const,
+        metadata: claims.executorMetadata,
+      }
 
-      // Trigger completion of the docker handler task
+      let innerTaskCompletion: TaskCompletion
+      let runnerTaskCompletion: TaskCompletion
+
+      if (completeJobRequest.success) {
+        innerTaskCompletion = {
+          success: true,
+          result: completeJobRequest.result,
+          executorMetadata: dockerExecutorMetadata,
+        }
+        runnerTaskCompletion = {
+          success: true,
+          result: {},
+          executorMetadata: dockerExecutorMetadata,
+        }
+      } else {
+        const { name, code, message, origin, details } =
+          completeJobRequest.error
+        // Persist origin alongside any worker-supplied details so it's
+        // queryable for diagnostics. The task error schema has no top-level
+        // origin field today.
+        const innerErrorDetails = { ...(details ?? {}), origin }
+
+        innerTaskCompletion = {
+          success: false,
+          executorMetadata: dockerExecutorMetadata,
+          error: {
+            name: name ?? 'Error',
+            code,
+            message,
+            details: innerErrorDetails,
+          },
+        }
+
+        // Runner mechanics succeed when the inner failure was caused by app
+        // code; the runner did its job and faithfully reported the outcome.
+        // Only origin: 'platform' (Docker provisioning, agent failures, etc.)
+        // counts as a runner-level failure.
+        if (origin === 'app') {
+          runnerTaskCompletion = {
+            success: true,
+            result: {},
+            executorMetadata: dockerExecutorMetadata,
+          }
+        } else {
+          runnerTaskCompletion = {
+            success: false,
+            executorMetadata: dockerExecutorMetadata,
+            error: {
+              name: name ?? 'Error',
+              code,
+              message,
+              details: innerErrorDetails,
+            },
+          }
+        }
+      }
+
       await this.taskService.registerTaskCompleted(
         dockerTask.id,
-        innerTaskCompletion,
+        runnerTaskCompletion,
         { tx },
       )
 
-      // Trigger completion of the inner task
       await this.taskService.registerTaskCompleted(
         innerTask.id,
         innerTaskCompletion,

--- a/packages/api/src/docker/tests/docker.e2e-spec.ts
+++ b/packages/api/src/docker/tests/docker.e2e-spec.ts
@@ -2112,6 +2112,8 @@ describe('Docker Jobs', () => {
 
     expect(completedDockerTask?.completedAt).toBeDefined()
     expect(completedDockerTask?.systemLog.length).toEqual(2)
+    // The runner (docker) task itself has no result of its own — that's the
+    // inner task's domain. The runner just orchestrated the docker job.
     expect(completedDockerTask?.systemLog).toEqual([
       {
         at: expect.any(Date),
@@ -2129,9 +2131,7 @@ describe('Docker Jobs', () => {
         logType: 'success',
         message: 'Task completed successfully',
         payload: {
-          result: {
-            message: 'done',
-          },
+          result: {},
           executorMetadata: {
             metadata: {
               containerId: '1',
@@ -2148,7 +2148,7 @@ describe('Docker Jobs', () => {
     ])
   })
 
-  it('should persist error.details from the worker on a failure completion', async () => {
+  it('should fail inner task and succeed runner task when worker reports an app-origin failure', async () => {
     await createTestUser(testModule!, {
       username: 'testuser',
       password: '123',
@@ -2201,6 +2201,7 @@ describe('Docker Jobs', () => {
           error: {
             code: 'CUSTOM_WORKER_ERROR',
             message: 'simulated structured failure',
+            origin: 'app',
             details: errorDetails,
           },
         },
@@ -2219,7 +2220,7 @@ describe('Docker Jobs', () => {
       code: 'CUSTOM_WORKER_ERROR',
       name: 'Error',
       message: 'simulated structured failure',
-      details: errorDetails,
+      details: { ...errorDetails, origin: 'app' },
     })
 
     // The error system log entry should also carry the structured details
@@ -2231,19 +2232,20 @@ describe('Docker Jobs', () => {
       code: 'CUSTOM_WORKER_ERROR',
       name: 'Error',
       message: 'simulated structured failure',
-      details: errorDetails,
+      details: { ...errorDetails, origin: 'app' },
     })
 
-    // The docker-run task should also reflect the failure with details.
+    // The docker-run (runner) task should succeed: the runner faithfully
+    // reported an app-origin failure, so the runner mechanics did their job.
     const completedDockerTask =
       await testModule!.services.ormService.db.query.tasksTable.findFirst({
         where: eq(tasksTable.id, dockerRunTask.id),
       })
-    expect(completedDockerTask?.success).toBe(false)
-    expect(completedDockerTask?.error?.details).toEqual(errorDetails)
+    expect(completedDockerTask?.success).toBe(true)
+    expect(completedDockerTask?.error).toBeNull()
   })
 
-  it('should accept a failure completion without error.details (backwards compatible)', async () => {
+  it('should accept a failure completion without error.details', async () => {
     await createTestUser(testModule!, {
       username: 'testuser',
       password: '123',
@@ -2285,6 +2287,7 @@ describe('Docker Jobs', () => {
           error: {
             code: 'WORKER_EXIT_ERROR',
             message: 'worker exited with code 1',
+            origin: 'app',
           },
         },
       },
@@ -2297,9 +2300,76 @@ describe('Docker Jobs', () => {
       })
 
     expect(completedInnerTask?.error?.code).toBe('WORKER_EXIT_ERROR')
-    // Without `details` being supplied, it must not appear on the persisted
-    // error or the agent will spuriously light up the details panel.
-    expect(completedInnerTask?.error?.details).toBeUndefined()
+    // Without `details` being supplied, only the synthesized origin should
+    // appear under details — no other free-form fields.
+    expect(completedInnerTask?.error?.details).toEqual({ origin: 'app' })
+  })
+
+  it('should fail both inner and runner tasks when agent reports a platform-origin failure', async () => {
+    await createTestUser(testModule!, {
+      username: 'testuser',
+      password: '123',
+    })
+
+    execSpy.mockImplementation((_hostId, _containerId, command, _options?) => {
+      return Promise.resolve({
+        exitCode: 0,
+        stdout:
+          command[1] === 'job-state'
+            ? `{"job_id": "${command.at(-1)}", "job_class": "test_job", "status": "complete", "success": true, "started_at": "${new Date().toISOString()}"}`
+            : '',
+        stderr: '',
+      })
+    })
+
+    const { innerTask, dockerRunTask } = await triggerAppDockerHandledTask(
+      testModule!,
+      {
+        appIdentifier: TEST_APP_SLUG,
+        taskIdentifier: 'non_triggered_docker_worker_task',
+        taskData: { myTaskData: 'test' },
+      },
+    )
+
+    const parsedPayload = parseJobPayload(
+      execSpy.mock.calls[1]![2].at(-1) ?? '',
+    )
+    const jobToken = parsedPayload.jobToken
+    const jobId = parsedPayload.jobId
+
+    await _apiClient(jobToken).POST(`/api/v1/docker/jobs/{jobId}/start`, {
+      params: { path: { jobId } },
+    })
+
+    const completeResponse = await _apiClient(jobToken).POST(
+      `/api/v1/docker/jobs/{jobId}/complete`,
+      {
+        params: { path: { jobId } },
+        body: {
+          success: false,
+          error: {
+            code: 'WORKER_START_ERROR',
+            message: 'failed to spawn worker process',
+            origin: 'platform',
+          },
+        },
+      },
+    )
+    expect(responseStatus(completeResponse)).toBe(200)
+
+    const completedInnerTask =
+      await testModule!.services.ormService.db.query.tasksTable.findFirst({
+        where: eq(tasksTable.id, innerTask.id),
+      })
+    const completedDockerTask =
+      await testModule!.services.ormService.db.query.tasksTable.findFirst({
+        where: eq(tasksTable.id, dockerRunTask.id),
+      })
+
+    expect(completedInnerTask?.success).toBe(false)
+    expect(completedInnerTask?.error?.code).toBe('WORKER_START_ERROR')
+    expect(completedDockerTask?.success).toBe(false)
+    expect(completedDockerTask?.error?.code).toBe('WORKER_START_ERROR')
   })
 
   it('should return unauthorized when lifecycle endpoints are called with an invalid token', async () => {

--- a/packages/api/src/openapi.json
+++ b/packages/api/src/openapi.json
@@ -31876,6 +31876,13 @@
                   "message": {
                     "type": "string"
                   },
+                  "origin": {
+                    "type": "string",
+                    "enum": [
+                      "platform",
+                      "app"
+                    ]
+                  },
                   "details": {
                     "type": "object",
                     "propertyNames": {
@@ -31888,7 +31895,8 @@
                 },
                 "required": [
                   "code",
-                  "message"
+                  "message",
+                  "origin"
                 ]
               },
               "outputFiles": {

--- a/packages/api/src/task/util/build-task-completions.util.ts
+++ b/packages/api/src/task/util/build-task-completions.util.ts
@@ -1,0 +1,82 @@
+import type {
+  ExecutorMetadata,
+  ExecutorStartMetadata,
+  TaskCompletion,
+} from '@lombokapp/types'
+import type { AsyncWorkError } from '@lombokapp/worker-utils'
+
+/**
+ * Build the (innerTaskCompletion, runnerTaskCompletion) pair for a runner
+ * processor catch block. The runner task succeeds when the cause chain
+ * contains an `origin: 'app'` error (the runner did its job and faithfully
+ * reported an app-level failure); it fails when the cause is purely
+ * `origin: 'platform'` (provisioning, dispatch, polling, etc.).
+ */
+export const buildTaskCompletions = ({
+  normalizedError,
+  innerExecutorMetadata,
+  runnerExecutorMetadata,
+}: {
+  normalizedError: AsyncWorkError
+  innerExecutorMetadata: ExecutorMetadata | ExecutorStartMetadata
+  runnerExecutorMetadata: ExecutorMetadata | ExecutorStartMetadata
+}): {
+  innerTaskCompletion: TaskCompletion
+  runnerTaskCompletion: TaskCompletion
+} => {
+  const highestLevelAppError = normalizedError.resolveHighestLevelAppError()
+  const runnerSuccess = !!highestLevelAppError
+
+  // Inner-task error policy:
+  //  - app-origin failure: surface the app error verbatim (code/name/message/
+  //    stack/details) so the app developer sees their own error
+  //  - internal-origin failure: keep the inner error generic so we don't
+  //    leak platform internals to the app. The full envelope is recorded on
+  //    the runner task instead, where admins can inspect it.
+  const innerErrorBase = highestLevelAppError
+    ? {
+        code: highestLevelAppError.code,
+        name: highestLevelAppError.name,
+        message: highestLevelAppError.message,
+        stack: highestLevelAppError.stack,
+        details: highestLevelAppError.toEnvelope(),
+      }
+    : {
+        code: 'EXECUTION_ERROR',
+        name: 'ExecutionError',
+        message:
+          'There was an error executing the task (see admin logs for details)',
+      }
+
+  const innerTaskCompletion: TaskCompletion = {
+    success: false,
+    ...(typeof highestLevelAppError?.requeueDelayMs !== 'undefined'
+      ? { requeueDelayMs: highestLevelAppError.requeueDelayMs }
+      : {}),
+    executorMetadata: innerExecutorMetadata,
+    error: innerErrorBase,
+  }
+
+  const runnerTaskCompletion: TaskCompletion = runnerSuccess
+    ? // The runner-success path is only reached when the cause chain contains
+      // an origin:'app' error, which means the executor actually ran and
+      // populated full ExecutorMetadata (start-only metadata implies the
+      // executor never produced an app error).
+      ({
+        success: true,
+        result: {},
+        executorMetadata: runnerExecutorMetadata as ExecutorMetadata,
+      } satisfies TaskCompletion)
+    : {
+        success: false,
+        executorMetadata: runnerExecutorMetadata,
+        error: {
+          code: normalizedError.code,
+          name: normalizedError.name,
+          message: normalizedError.message,
+          details: normalizedError.toEnvelope(),
+        },
+      }
+
+  return { innerTaskCompletion, runnerTaskCompletion }
+}

--- a/packages/core-worker/src/worker-scripts/run-worker.ts
+++ b/packages/core-worker/src/worker-scripts/run-worker.ts
@@ -1717,7 +1717,7 @@ export async function runWorker(
       if (!error) {
         throw new AsyncWorkError({
           name: 'InvalidWorkerError',
-          origin: 'internal',
+          origin: 'platform',
           code: 'NO_ERROR_PROVIDED',
           message: 'Response marked as failed but no error provided',
           stack: new Error().stack,
@@ -1738,7 +1738,7 @@ export async function runWorker(
     if (!pipeResponse.response) {
       throw new AsyncWorkError({
         name: 'InvalidWorkerResponse',
-        origin: 'internal',
+        origin: 'platform',
         code: 'NO_RESPONSE_DATA_RECEIVED',
         message: 'No response data received for request',
         stack: new Error().stack,

--- a/packages/core-worker/src/worker-scripts/worker-daemon/app-error-utils.ts
+++ b/packages/core-worker/src/worker-scripts/worker-daemon/app-error-utils.ts
@@ -67,7 +67,7 @@ export const getAsyncWorkErrorFromAppTaskError = (
   if (appTaskErrorValidationSuccess) {
     return new AsyncWorkError({
       name: 'Error',
-      origin: 'internal',
+      origin: 'platform',
       message: 'App threw an AppTaskError',
       code: 'APP_TASK_ERROR',
       stack,
@@ -96,7 +96,7 @@ export const getAsyncWorkErrorFromAppTaskError = (
 
   return new AsyncWorkError({
     name: 'Error',
-    origin: 'internal',
+    origin: 'platform',
     message: 'App threw an AppTaskError which was invalid',
     code: 'APP_THREW_INVALID_APP_TASK_ERROR',
     stack: new Error().stack,

--- a/packages/core-worker/src/worker-scripts/worker-daemon/worker-daemon.ts
+++ b/packages/core-worker/src/worker-scripts/worker-daemon/worker-daemon.ts
@@ -372,7 +372,7 @@ void (async () => {
                 if (!publicKeyPem) {
                   throw new AsyncWorkError({
                     name: 'AuthenticationFailed',
-                    origin: 'internal',
+                    origin: 'platform',
                     message:
                       'LOMBOK_APP_JWT_PUBLIC_KEY env var not set; cannot verify app tokens',
                     code: 'WORKER_REQUEST_AUTHENTICATION_FAILED',
@@ -396,7 +396,7 @@ void (async () => {
                   })
                   throw new AsyncWorkError({
                     name: 'AuthenticationFailed',
-                    origin: 'internal',
+                    origin: 'platform',
                     message: errorMessage,
                     code: 'WORKER_REQUEST_AUTHENTICATION_FAILED',
                     stack: new Error().stack,
@@ -415,7 +415,7 @@ void (async () => {
                 if (claims.actorType !== 'app_user') {
                   throw new AsyncWorkError({
                     name: 'AuthenticationFailed',
-                    origin: 'internal',
+                    origin: 'platform',
                     message: `Token actor "${claims.actorType}" is not allowed for worker requests`,
                     code: 'WORKER_REQUEST_AUTHENTICATION_FAILED',
                     stack: new Error().stack,
@@ -428,7 +428,7 @@ void (async () => {
                 if (claims.appIdentifier !== pipeRequest.appIdentifier) {
                   throw new AsyncWorkError({
                     name: 'AuthenticationFailed',
-                    origin: 'internal',
+                    origin: 'platform',
                     message: 'Token app identifier mismatch',
                     code: 'WORKER_REQUEST_AUTHENTICATION_FAILED',
                     stack: new Error().stack,
@@ -489,7 +489,7 @@ void (async () => {
             const error = err instanceof Error ? err : new Error(String(err))
 
             throw new AsyncWorkError({
-              origin: 'internal',
+              origin: 'platform',
               name: 'UnknownAuthenticationError',
               message: 'Unknown authentication error',
               code: 'WORKER_REQUEST_AUTHENTICATION_FAILED',
@@ -504,7 +504,7 @@ void (async () => {
                 isSystemRequest: pipeRequest.isSystemRequest,
               },
               cause: new AsyncWorkError({
-                origin: 'internal',
+                origin: 'platform',
                 name: 'UnknownAuthenticationError',
                 code: 'UNKNOWN_AUTHENTICATION_ERROR',
                 message: 'Unknown authentication error',
@@ -820,7 +820,7 @@ void (async () => {
                   message: 'Error dispatching request',
                   cause: {
                     name: 'AsyncWorkDispatchError',
-                    origin: 'internal',
+                    origin: 'platform',
                     code: 'DISPATCH_ERROR',
                     message:
                       error instanceof Error ? error.message : String(error),
@@ -912,14 +912,14 @@ void (async () => {
         ? err.toEnvelope()
         : new AsyncWorkError({
             name: 'UnexpectedError',
-            origin: 'internal',
+            origin: 'platform',
             code: 'UNEXPECTED_ERROR_DURING_WORKER_EXECUTION',
             message: 'Unexpected error during worker execution',
             stack: new Error().stack,
             cause:
               err instanceof Error
                 ? {
-                    origin: 'internal',
+                    origin: 'platform',
                     name: 'UnexpectedError',
                     code: 'UNKNOWN_ERROR',
                     message: 'Unknown error',
@@ -931,7 +931,7 @@ void (async () => {
                     },
                   }
                 : {
-                    origin: 'internal',
+                    origin: 'platform',
                     name: 'UnexpectedError',
                     code: 'THROWN_NON_ERROR',
                     message: 'Non-error object thrown',

--- a/packages/types/src/api-paths.d.ts
+++ b/packages/types/src/api-paths.d.ts
@@ -7169,6 +7169,8 @@ export interface components {
                 name?: string;
                 code: string;
                 message: string;
+                /** @enum {string} */
+                origin: "platform" | "app";
                 details?: {
                     [key: string]: components["schemas"]["DockerJobCompleteRequestDTO__schema0"];
                 };

--- a/packages/worker-utils/src/errors/work-errors.types.ts
+++ b/packages/worker-utils/src/errors/work-errors.types.ts
@@ -1,13 +1,13 @@
 import { jsonSerializableObjectSchema, requeueSchema } from '@lombokapp/types'
 import { z } from 'zod'
 
-export const errorOriginSchema = z.enum(['internal', 'app'])
+export const errorOriginSchema = z.enum(['platform', 'app'])
 
 export type ErrorOrigin = z.infer<typeof errorOriginSchema>
 
 // {
 //   "type": "work_error",
-//   "origin": "internal | app",
+//   "origin": "platform | app",
 //   "requeueDelayMs": number,
 //   "message": "human-readable summary",
 //   "code": "stable_machine_code",

--- a/packages/worker-utils/src/errors/worker-errors.ts
+++ b/packages/worker-utils/src/errors/worker-errors.ts
@@ -76,7 +76,7 @@ export class NotReadyAsyncWorkError extends AsyncWorkError {
   constructor(args: Omit<AsyncWorkErrorConstructorArg, 'origin' | 'class'>) {
     super({
       ...args,
-      origin: 'internal',
+      origin: 'platform',
       requeueDelayMs: args.requeueDelayMs,
       code: args.code,
       message: args.message,
@@ -95,7 +95,7 @@ export class AsyncWorkDispatchError extends AsyncWorkError {
   ) {
     super({
       ...args,
-      origin: 'internal',
+      origin: 'platform',
       ...(args.requeueDelayMs ? { requeueDelayMs: args.requeueDelayMs } : {}),
       code: args.code ?? 'DISPATCH_ERROR',
       message: args.message,
@@ -183,14 +183,14 @@ export const convertErrorToAsyncWorkError = (
       ? new AsyncWorkError({
           ...error,
           ...wrapper,
-          origin: wrapper.origin ?? 'internal',
+          origin: wrapper.origin ?? 'platform',
           details: wrapper.details,
           cause: convertErrorToAsyncWorkError(error),
         })
       : error
   }
   const errorRepr = {
-    origin: 'internal' as const,
+    origin: 'platform' as const,
     code: 'code' in error ? String(error.code) : 'ERROR',
     name: error.name,
     message: error.message,
@@ -204,7 +204,7 @@ export const convertErrorToAsyncWorkError = (
   return wrapper
     ? new AsyncWorkError({
         ...wrapper,
-        origin: wrapper.origin ?? 'internal',
+        origin: wrapper.origin ?? 'platform',
         cause: new AsyncWorkError(errorRepr),
       })
     : new AsyncWorkError(errorRepr)
@@ -227,7 +227,7 @@ export const buildUnexpectedError = ({
     error instanceof Error ? error : new Error(String(error))
 
   return new AsyncWorkError({
-    origin: 'internal',
+    origin: 'platform',
     code,
     message,
     name: 'UnexpectedError',
@@ -235,7 +235,7 @@ export const buildUnexpectedError = ({
     cause:
       error instanceof Error
         ? {
-            origin: isAppError ? 'app' : 'internal',
+            origin: isAppError ? 'app' : 'platform',
             code: 'UNEXPECTED_ERROR',
             name: normalizedError.name,
             message: normalizedError.message,
@@ -251,7 +251,7 @@ export const buildUnexpectedError = ({
               : {}),
           }
         : {
-            origin: 'internal',
+            origin: 'platform',
             code: 'THROWN_NON_ERROR',
             name: 'UnexpectedError',
             message: 'Non-error object thrown',


### PR DESCRIPTION
## Summary

Distinguish "platform" errors (agent / dispatcher / runner mechanics) from "app" errors (worker-supplied) end-to-end, so a runner task's own success/failure can be decided independently of the inner task it dispatched.

- Rename `internal` error origin → `platform` across `worker-utils` and the runtime workers — the new name better matches what it represents (failures coming from the platform side, not user code).
- Add an `origin` field to the worker-agent `JobError` Go type. Worker-supplied errors default to `"app"` on JSON unmarshal; agent-generated errors set `"platform"` explicitly.
- Add a shared `buildTaskCompletions` util in `packages/api/src/task/util/` that derives the (innerTaskCompletion, runnerTaskCompletion) pair from a normalized `AsyncWorkError`:
  - The runner task succeeds when the cause chain contains an `origin: "app"` error (the runner did its job and faithfully reported an app-level failure).
  - The runner task fails only when the cause is purely `origin: "platform"` (provisioning / dispatch / polling).
  - Inner-task errors are surfaced verbatim for app origins; for platform origins the inner task gets a generic `EXECUTION_ERROR` and the full envelope is kept on the runner task for admins.
- Refactor `run-serverless-worker-task.processor.ts` and `run-docker-worker.task-processor.ts` to use the new util — removes duplicated catch-block logic.
- Update `docker-worker-hook.service` and `docker-jobs.service` to plumb the new `origin` field through job complete payloads.
- Update worker-agent runners (`exec`, `http`, `cancel`) and payload tests for the new field.

## Why

Previously, an app-side worker error would fail the runner task itself, masking whether the runner succeeded at executing the work. With explicit origin classification, an app-level failure no longer marks the platform's runner task as failed — only platform-side failures do.

Linear: [LOM-319](https://linear.app/lombokapp/issue/LOM-319/improve-platform-vs-app-error-handling-in-worker-pipeline)

## Test plan

- [x] `bash cmd/dev-check-all.sh` — passes (one pre-existing prettier issue on `event.service.ts`, unrelated to this change)
- [x] `packages/api` unit tests — 222 pass / 0 fail
- [x] `packages/types|utils|worker-utils` unit tests — pass
- [x] `bun --cwd packages/api e2e:api` — 568 pass / 0 fail, includes 3 new tests:
  - `Docker Jobs > should fail inner task and succeed runner task when worker reports an app-origin failure`
  - `Docker Jobs > should accept a failure completion without error.details`
  - `Docker Jobs > should fail both inner and runner tasks when agent reports a platform-origin failure`
- [x] `go test ./internal/runner/... ./internal/types/...` in `docker/worker-agent` — pass