### PR TITLE
chore(LOM-320): fix prettier formatting in event.service.ts

### DIFF
--- a/packages/api/src/event/services/event.service.ts
+++ b/packages/api/src/event/services/event.service.ts
@@ -636,8 +636,7 @@ export class EventService {
     const appIdentifier = !isCoreEmitter ? args.emitterIdentifier : undefined
     const targetLocation =
       'targetLocation' in args ? args.targetLocation : undefined
-    const targetUserId =
-      'targetUserId' in args ? args.targetUserId : undefined
+    const targetUserId = 'targetUserId' in args ? args.targetUserId : undefined
     if (appIdentifier) {
       const app = await this.appService.getApp(appIdentifier.toLowerCase(), {
         enabled: true,


### PR DESCRIPTION
## Summary

A `const targetUserId = ...` assignment in `packages/api/src/event/services/event.service.ts` was wrapped over two lines but fits within prettier's line width — `bun --cwd packages/api prettier:check` flags it. Run `prettier --write` to collapse it.

Linear: [LOM-320](https://linear.app/lombokapp/issue/LOM-320/fix-prettier-formatting-in-eventservicets)

## Test plan

- [x] `bun --cwd packages/api prettier:check` — `All matched files use Prettier code style!`