### PR TITLE
fix(LOM-321): prevent tunnel and app-server/api-server hostnames overlapping

### DIFF
--- a/docker/docker-bridge/src/e2e/http-api.e2e.test.ts
+++ b/docker/docker-bridge/src/e2e/http-api.e2e.test.ts
@@ -351,7 +351,7 @@ describe('Bridge HTTP API E2E', () => {
       expect(body.protocol).toBe('raw')
       expect(body.mode).toBe('ephemeral')
       expect(body.state).toBe('created')
-      expect(body.public_id).toMatch(/^[a-f0-9]{12}$/)
+      expect(body.public_id).toMatch(/^tn-[a-f0-9]{10}$/)
       expect(body.label).toBe('terminal')
       expect(body.app_id).toBe('coder')
       expect(body.agent_ready).toBe(false)

--- a/docker/docker-bridge/src/sessions/session-manager.test.ts
+++ b/docker/docker-bridge/src/sessions/session-manager.test.ts
@@ -42,7 +42,7 @@ describe('SessionManager', () => {
         '--ports',
         '3000',
       ])
-      expect(session.publicId).toMatch(/^[a-f0-9]{12}$/)
+      expect(session.publicId).toMatch(/^tn-[a-f0-9]{10}$/)
       expect(session.label).toBe('preview')
       expect(session.appIdentifier).toBe('coder')
       expect(session.agentReady).toBe(false)

--- a/docker/docker-bridge/src/sessions/session-manager.ts
+++ b/docker/docker-bridge/src/sessions/session-manager.ts
@@ -21,9 +21,13 @@ export class SessionManager {
     return 'sess_' + crypto.randomUUID().replace(/-/g, '').slice(0, 21)
   }
 
+  // The `tn-` prefix puts a hyphen inside the publicId — that hyphen
+  // partitions publicIds from app/worker identifiers (which are [a-z0-9_]+),
+  // so tunnel hostnames cannot collide with api-server--{worker}--{app}
+  // or app-server--{name} patterns.
   private generatePublicId(): string {
     for (let i = 0; i < 10; i++) {
-      const id = crypto.randomUUID().replace(/-/g, '').slice(0, 12)
+      const id = 'tn-' + crypto.randomUUID().replace(/-/g, '').slice(0, 10)
       if (!this.tunnelIndex.has(id)) {
         return id
       }

--- a/packages/api/nginx/dev-nginx.conf
+++ b/packages/api/nginx/dev-nginx.conf
@@ -35,11 +35,12 @@ server {
 
 # Tunnel traffic — route tunnel subdomains to bridge tunnel handler
 # Subdomain format: {label}--{publicId}--{appId}.{domain}
-# The tunnelId is always lowercase alphanumeric (no hyphens), ensuring
-# this 3-part pattern doesn't collide with app-server--{name} (2-part).
+# publicId is `tn-{hex}` — the embedded hyphen forbids collision with
+# api-server--{worker}--{app} (worker/app are [a-z0-9_]+, no hyphens).
+# appId charset matches the api-server constraint for symmetry.
 server {
     listen 0.0.0.0:8080;
-    server_name ~^(?<tunnel_label>.+)--(?<tunnel_public_id>[a-z0-9]+)--(?<tunnel_app>[^.]+)\.{{PLATFORM_HOST}}$;
+    server_name "~^(?<tunnel_label>[a-z0-9][a-z0-9-]{0,30}[a-z0-9])--(?<tunnel_public_id>tn-[a-f0-9]+)--(?<tunnel_app>[a-z0-9_]+)\.{{PLATFORM_HOST}}$";
 
     # Tunnel auth — route to platform API preserving full path
     # (/-/tunnel-auth, /-/tunnel-auth/landing, /-/tunnel-auth/sw.js)
@@ -84,7 +85,7 @@ server {
 # App host routing
 server {
     listen 0.0.0.0:8080;
-    server_name ~^app-server--(?<appname>.+)\.{{PLATFORM_HOST}}$;
+    server_name ~^app-server--(?<appname>[a-z0-9_]+)\.{{PLATFORM_HOST}}$;
 
     resolver 127.0.0.11 ipv6=off valid=30s;
 

--- a/packages/api/nginx/nginx.conf
+++ b/packages/api/nginx/nginx.conf
@@ -33,11 +33,12 @@ server {
 
 # Tunnel traffic — route tunnel subdomains to bridge tunnel handler
 # Subdomain format: {label}--{publicId}--{appId}.{domain}
-# The tunnelId is always lowercase alphanumeric (no hyphens), ensuring
-# this 3-part pattern doesn't collide with app-server--{name} (2-part).
+# publicId always contains a hyphen — that hyphen forbids collision with
+# api-server--{worker}--{app} (worker/app are [a-z0-9_]+, no hyphens).
+# appId charset matches the api-server constraint for symmetry.
 server {
     listen 0.0.0.0:8080;
-    server_name ~^(?<tunnel_label>.+)--(?<tunnel_public_id>[a-z0-9]+)--(?<tunnel_app>[^.]+)\.{{PLATFORM_HOST}}$;
+    server_name "~^(?<tunnel_label>[a-z0-9][a-z0-9-]{0,30}[a-z0-9])--(?<tunnel_public_id>tn-[a-f0-9]+)--(?<tunnel_app>[a-z0-9_]+)\.{{PLATFORM_HOST}}$";
 
     # Tunnel auth — route to platform API preserving full path
     # (/-/tunnel-auth, /-/tunnel-auth/landing, /-/tunnel-auth/sw.js)
@@ -84,7 +85,7 @@ server {
 # App host routing
 server {
     listen 0.0.0.0:8080;
-    server_name ~^app-server--(?<appname>.+)\.{{PLATFORM_HOST}}$;
+    server_name ~^app-server--(?<appname>[a-z0-9_]+)\.{{PLATFORM_HOST}}$;
 
     # Lombok Socket.IO connection
     location /socket.io/ {

--- a/packages/api/src/docker/controllers/tunnel-auth.controller.ts
+++ b/packages/api/src/docker/controllers/tunnel-auth.controller.ts
@@ -21,8 +21,13 @@ import { DockerBridgeService } from '../services/docker-bridge.service'
 const COOKIE_NAME = 'tunnel_auth'
 const TUNNEL_TOKEN_TTL_SECONDS = 86400 // 24 hours
 
-/** Tunnel subdomain format: {label}--{publicId}--{appIdentifier}.{platformHost} */
-const TUNNEL_DOMAIN_REGEX = /^(.+)--([a-z0-9]+)--([^.]+)\.(.+)$/
+/**
+ * Tunnel subdomain format: {label}--{publicId}--{appIdentifier}.{platformHost}
+ * publicId is `tn-{hex}` — the embedded hyphen partitions tunnel hostnames
+ * from the api-server--{worker}--{app} space (worker/app are [a-z0-9_]+).
+ */
+const TUNNEL_DOMAIN_REGEX =
+  /^([a-z0-9][a-z0-9-]{0,30}[a-z0-9])--(tn-[a-f0-9]+)--([a-z0-9_]+)\.(.+)$/
 
 interface SessionTokenPayload {
   sub: string

--- a/packages/api/src/docker/dto/create-admin-bridge-tunnel-session-request.dto.ts
+++ b/packages/api/src/docker/dto/create-admin-bridge-tunnel-session-request.dto.ts
@@ -1,11 +1,13 @@
 import { createZodDto } from 'nestjs-zod'
 import { z } from 'zod'
 
+import { tunnelLabelSchema } from './create-bridge-tunnel-session-request.dto'
+
 export const createAdminBridgeTunnelSessionRequestSchema = z.object({
   hostId: z.string().min(1),
   containerId: z.string().min(1),
   command: z.array(z.string()).min(1).optional(),
-  label: z.string().min(1).max(63).default('admin-console'),
+  label: tunnelLabelSchema.default('admin-console'),
 })
 
 export class CreateAdminBridgeTunnelSessionRequestDTO extends createZodDto(

--- a/packages/api/src/docker/dto/create-bridge-tunnel-session-request.dto.ts
+++ b/packages/api/src/docker/dto/create-bridge-tunnel-session-request.dto.ts
@@ -1,15 +1,27 @@
 import { createZodDto } from 'nestjs-zod'
 import { z } from 'zod'
 
+// DNS-label-safe charset, no '--' (which is the tunnel hostname separator).
+// Min 2 chars to satisfy the leading/trailing alphanumeric anchors.
+const tunnelLabelSchema = z
+  .string()
+  .regex(
+    /^[a-z0-9][a-z0-9-]{0,30}[a-z0-9]$/,
+    'label must be 2-32 lowercase alphanumeric/hyphen characters and start/end with alphanumeric',
+  )
+  .refine((s) => !s.includes('--'), 'label may not contain "--"')
+
 export const createBridgeTunnelSessionRequestSchema = z.object({
   hostId: z.string().min(1),
   containerId: z.string().min(1),
   command: z.array(z.string()).min(1),
-  label: z.string().min(1).max(63),
+  label: tunnelLabelSchema,
   mode: z.enum(['ephemeral', 'persistent']).default('persistent'),
   protocol: z.enum(['framed', 'raw']).default('framed'),
   public: z.boolean().default(false),
 })
+
+export { tunnelLabelSchema }
 
 export class CreateBridgeTunnelSessionRequestDTO extends createZodDto(
   createBridgeTunnelSessionRequestSchema,


### PR DESCRIPTION
## Summary

Tunnel public IDs were random lowercase hex (no hyphens), and tunnel labels were unconstrained. That meant a maliciously- or accidentally-crafted tunnel hostname could fall into the `app-server--{name}` or `api-server--{worker}--{app}` regex space and route to the wrong handler.

- Tunnel `publicId` now starts with a `tn-` prefix (`tn-{10 hex chars}`). The embedded hyphen partitions publicIds from app/worker identifiers (which are `[a-z0-9_]+`), so a tunnel hostname can't collide with `api-server--{worker}--{app}` or `app-server--{name}`.
- Tighten the `label` charset on `CreateBridgeTunnelSessionRequestDTO` (and admin variant) to a DNS-label-safe pattern (`[a-z0-9][a-z0-9-]{0,30}[a-z0-9]`, 2-32 chars) and reject `--` (the tunnel hostname separator).
- Update both nginx server_name regexes (dev + prod):
  - `app-server--(?<appname>[a-z0-9_]+)` (was `.+`)
  - `(?<tunnel_label>[a-z0-9][a-z0-9-]{0,30}[a-z0-9])--(?<tunnel_public_id>tn-[a-f0-9]+)--(?<tunnel_app>[a-z0-9_]+)`
- Update `TUNNEL_DOMAIN_REGEX` in `tunnel-auth.controller` to match.
- Update `docker-bridge` `session-manager` + tests to assert the new `tn-{hex}` pattern.

## Why

Defence in depth — the routing space is now provably non-overlapping, not just empirically. The `tn-` prefix carries a hyphen, which the api/app-server identifier charsets exclude.

Linear: [LOM-321](https://linear.app/lombokapp/issue/LOM-321/prevent-tunnel-and-app-serverapi-server-hostnames-from-overlapping)

## Test plan

- [x] `bash cmd/dev-check-all.sh` — all checks pass
- [x] `packages/api` unit tests — 222 pass / 0 fail
- [x] `bun --cwd packages/api e2e:api` — 568 pass / 0 fail
- [x] `docker-bridge` test failures (19) reproduced unchanged on `origin/main` — pre-existing, unrelated to this change