### PR TITLE
feat(LOM-322): forward worker-supplied progress details in task update broadcasts

### DIFF
--- a/packages/api/src/task/services/task-update-broadcaster.service.ts
+++ b/packages/api/src/task/services/task-update-broadcaster.service.ts
@@ -1,5 +1,8 @@
 import {
   CORE_IDENTIFIER,
+  ReceivedTaskProgressReport,
+  TaskProgressDetails,
+  TaskProgressMessage,
   TaskProgressMessageLevel,
   TaskUpdateAudience,
   TaskUpdateType,
@@ -47,21 +50,36 @@ export class TaskUpdateBroadcasterService {
     private readonly appUserSocketService: AppUserSocketService,
   ) {}
 
-  handleTaskUpdate(task: Task, updateType: TaskUpdateType, _ts?: Date): void {
+  handleTaskUpdate(
+    task: Task,
+    updateType: TaskUpdateType,
+    _ts?: Date,
+    progressReport?: ReceivedTaskProgressReport,
+  ): void {
     const ts = _ts ?? new Date()
+    const reportMessage: TaskProgressMessage | undefined =
+      progressReport?.message
+    const message = reportMessage ?? {
+      level:
+        updateType === TaskUpdateType.task_failed
+          ? TaskProgressMessageLevel.error
+          : TaskProgressMessageLevel.info,
+      text: taskUpdateDescriptionForType(updateType, task),
+      audience: TASK_UPDATE_AUDIENCES_MAP[updateType],
+    }
+    // Synthesize percent: 100 on task_completed so UIs can finalize bars.
+    const progress: TaskProgressDetails | undefined =
+      progressReport?.details ??
+      (updateType === TaskUpdateType.task_completed
+        ? { percent: 100 }
+        : undefined)
     const update = {
-      message: {
-        level:
-          updateType === TaskUpdateType.task_failed
-            ? TaskProgressMessageLevel.error
-            : TaskProgressMessageLevel.info,
-        text: taskUpdateDescriptionForType(updateType, task),
-        audience: TASK_UPDATE_AUDIENCES_MAP[updateType],
-      },
+      message,
       data: {
         taskId: task.id,
         correlationKey: task.correlationKey ?? null,
       },
+      ...(progress ? { progress } : {}),
       receivedAt: ts.toISOString(),
     }
 

--- a/packages/api/src/task/services/task.service.ts
+++ b/packages/api/src/task/services/task.service.ts
@@ -1387,11 +1387,11 @@ export class TaskService {
       return null
     } // task not in running state
 
-    // Broadcast async update
     this.asyncTaskUpdateBroadcasterService.handleTaskUpdate(
       updatedTask,
       TaskUpdateType.task_progress,
       now,
+      storedProgressReport,
     )
 
     // Evaluate and dispatch onProgress handlers

--- a/packages/api/src/task/tasks.e2e-spec.ts
+++ b/packages/api/src/task/tasks.e2e-spec.ts
@@ -1385,9 +1385,31 @@ describe('Task lifecycle', () => {
       (received as { data: { correlationKey: string } }).data.correlationKey,
     ).toBe('ck-docker-update-1')
     expect((received as { data: { taskId: string } }).data.taskId).toBe(task.id)
+    // Worker's own message text is forwarded when the report supplies one,
+    // instead of the generic "Task progress: <id>" envelope label.
     expect((received as { message: { text: string } }).message.text).toBe(
-      `Task progress: ${APP_ACTION_TASK_ID}`,
+      'Halfway done',
     )
+    // Granular progress details (percent/current/total/label) must be
+    // forwarded so subscribers like codicle's clone progress UI can render
+    // per-stage updates from `gitWithProgress`.
+    expect(
+      (
+        received as {
+          progress: {
+            percent: number
+            current: number
+            total: number
+            label: string
+          }
+        }
+      ).progress,
+    ).toEqual({
+      percent: 50,
+      current: 1,
+      total: 2,
+      label: 'Processing',
+    })
     expect((received as { receivedAt: string }).receivedAt).toBeDefined()
   })
 
@@ -1481,6 +1503,15 @@ describe('Task lifecycle', () => {
       (received as { data: { correlationKey: string } }).data.correlationKey,
     ).toBe('ck-docker-folder-1')
     expect((received as { data: { taskId: string } }).data.taskId).toBe(task.id)
+    expect(
+      (received as { progress: { percent: number; label: string } }).progress,
+    ).toEqual({
+      percent: 75,
+      label: 'Almost done',
+    })
+    expect((received as { message: { text: string } }).message.text).toBe(
+      'Processing folder data',
+    )
   })
 
   it('stores task updates in the database and tracks latest progress', async () => {


### PR DESCRIPTION
Closes LOM-322. Stacks on #256 (LOM-51).

## Motivation

`TaskUpdateBroadcasterService` was emitting a generic `Task progress: <id>` envelope on every progress update, dropping both the worker-supplied message text and any structured progress details (percent / current / total / label). Subscribers — e.g. codicle's clone-progress UI — had nothing granular to render against, only the lifecycle event type.

## Changes

- `handleTaskUpdate` accepts an optional `ReceivedTaskProgressReport`. When present, its `message` is forwarded as-is and its `details` are emitted on a new `progress` field of the update payload.
- On `task_completed`, synthesize `progress: { percent: 100 }` so UIs can finalize progress bars without a separate signal.
- `task.service` threads the stored progress report through to the broadcaster on every async progress update.
- `tasks.e2e-spec.ts` extended to assert both the forwarded message text and the structured `progress` object on async docker and folder-scoped paths.

Follow-up to LOM-297.

## Test plan
- [x] `./dx check all` — prettier / tsc / eslint
- [x] api unit tests — 222 pass
- [x] `./dx e2e api` — 568 pass
- [x] `./dx e2e ui` — 18 pass