### PR TITLE
fix(LOM-323): structure per-worker log files with timestamp prefix (incl. LOM-322)

### DIFF
--- a/docker/worker-agent/cmd/worker_supervisor.go
+++ b/docker/worker-agent/cmd/worker_supervisor.go
@@ -330,7 +330,11 @@ func (w *persistentWorkerLogInterceptor) processLine(line string) {
 	workerLogFile := w.workerLogFile
 	w.mu.Unlock()
 	if workerLogFile != nil {
-		_, _ = io.WriteString(workerLogFile, line+"\n")
+		// Emit the same structured timestamp|WORKER_<port>|LEVEL|JSON
+		// shape used by the unified log so consumers (e.g. worker.ts
+		// /diagnostics/logs) can dedupe by timestamp cursor.
+		formatted := logs.FormatStructuredWorkerLogLine(w.port, line, w.defaultLevel)
+		_, _ = io.WriteString(workerLogFile, formatted)
 	}
 
 	logs.WriteUnifiedWorkerLog(w.port, line, w.defaultLevel)

--- a/docker/worker-agent/internal/logs/writer.go
+++ b/docker/worker-agent/internal/logs/writer.go
@@ -347,18 +347,12 @@ func WriteJobLog(jobLogFile *os.File, jobID string, level LogLevel, message stri
 	return nil
 }
 
-// WriteUnifiedWorkerLog writes a worker log line to the unified log file with timestamp|WORKER_<port>| prefix.
-// All lines are converted to structured format: timestamp|WORKER_<port>|LEVEL|["message",{data}]
-// If the line is unstructured, defaultLevel is used.
-func WriteUnifiedWorkerLog(port int, line string, defaultLevel LogLevel) {
-	logMutex.Lock()
-	defer logMutex.Unlock()
-
-	if unifiedLogFile == nil {
-		return
-	}
-
-	// Get timestamp
+// FormatStructuredWorkerLogLine converts a raw worker log line into the
+// canonical timestamp|WORKER_<port>|LEVEL|["message",{data}] format. The
+// returned string includes a trailing newline. Used for both the unified
+// log and per-worker log files so consumers (e.g. the worker.ts diagnostics
+// log viewer) can rely on a stable, parseable format with timestamps.
+func FormatStructuredWorkerLogLine(port int, line string, defaultLevel LogLevel) string {
 	timestamp := formatLogTimestamp()
 
 	// Try to parse as job-specific structured log first
@@ -380,16 +374,7 @@ func WriteUnifiedWorkerLog(port int, line string, defaultLevel LogLevel) {
 			levelStr := strings.TrimSpace(parts[1])
 			jsonPart := strings.TrimSpace(parts[2])
 			level = LogLevel(levelStr)
-			// Validate level
-			validLevels := []LogLevel{LogLevelTrace, LogLevelDebug, LogLevelInfo, LogLevelWarn, LogLevelError, LogLevelFatal}
-			valid := false
-			for _, validLevel := range validLevels {
-				if level == validLevel {
-					valid = true
-					break
-				}
-			}
-			if valid {
+			if isValidLogLevel(level) {
 				// Parse the JSON array: ["message",{optional_data}]
 				var logArray []any
 				if err := json.Unmarshal([]byte(jsonPart), &logArray); err == nil && len(logArray) > 0 {
@@ -400,6 +385,8 @@ func WriteUnifiedWorkerLog(port int, line string, defaultLevel LogLevel) {
 						}
 					}
 				}
+			} else {
+				level = ""
 			}
 		}
 	}
@@ -432,8 +419,21 @@ func WriteUnifiedWorkerLog(port int, line string, defaultLevel LogLevel) {
 		logEntryJSON = []byte(fmt.Sprintf(`["%s"]`, message))
 	}
 
-	// Format: timestamp|WORKER_<port>|LEVEL|["message",{data}]
-	unifiedLine := fmt.Sprintf("%s|WORKER_%d|%s|%s\n", timestamp, port, level, string(logEntryJSON))
+	return fmt.Sprintf("%s|WORKER_%d|%s|%s\n", timestamp, port, level, string(logEntryJSON))
+}
+
+// WriteUnifiedWorkerLog writes a worker log line to the unified log file with timestamp|WORKER_<port>| prefix.
+// All lines are converted to structured format: timestamp|WORKER_<port>|LEVEL|["message",{data}]
+// If the line is unstructured, defaultLevel is used.
+func WriteUnifiedWorkerLog(port int, line string, defaultLevel LogLevel) {
+	logMutex.Lock()
+	defer logMutex.Unlock()
+
+	if unifiedLogFile == nil {
+		return
+	}
+
+	unifiedLine := FormatStructuredWorkerLogLine(port, line, defaultLevel)
 	_, _ = io.WriteString(unifiedLogFile, unifiedLine)
 	_ = unifiedLogFile.Sync()
 }

--- a/packages/api/src/task/services/task-update-broadcaster.service.ts
+++ b/packages/api/src/task/services/task-update-broadcaster.service.ts
@@ -1,5 +1,8 @@
 import {
   CORE_IDENTIFIER,
+  ReceivedTaskProgressReport,
+  TaskProgressDetails,
+  TaskProgressMessage,
   TaskProgressMessageLevel,
   TaskUpdateAudience,
   TaskUpdateType,
@@ -47,21 +50,36 @@ export class TaskUpdateBroadcasterService {
     private readonly appUserSocketService: AppUserSocketService,
   ) {}
 
-  handleTaskUpdate(task: Task, updateType: TaskUpdateType, _ts?: Date): void {
+  handleTaskUpdate(
+    task: Task,
+    updateType: TaskUpdateType,
+    _ts?: Date,
+    progressReport?: ReceivedTaskProgressReport,
+  ): void {
     const ts = _ts ?? new Date()
+    const reportMessage: TaskProgressMessage | undefined =
+      progressReport?.message
+    const message = reportMessage ?? {
+      level:
+        updateType === TaskUpdateType.task_failed
+          ? TaskProgressMessageLevel.error
+          : TaskProgressMessageLevel.info,
+      text: taskUpdateDescriptionForType(updateType, task),
+      audience: TASK_UPDATE_AUDIENCES_MAP[updateType],
+    }
+    // Synthesize percent: 100 on task_completed so UIs can finalize bars.
+    const progress: TaskProgressDetails | undefined =
+      progressReport?.details ??
+      (updateType === TaskUpdateType.task_completed
+        ? { percent: 100 }
+        : undefined)
     const update = {
-      message: {
-        level:
-          updateType === TaskUpdateType.task_failed
-            ? TaskProgressMessageLevel.error
-            : TaskProgressMessageLevel.info,
-        text: taskUpdateDescriptionForType(updateType, task),
-        audience: TASK_UPDATE_AUDIENCES_MAP[updateType],
-      },
+      message,
       data: {
         taskId: task.id,
         correlationKey: task.correlationKey ?? null,
       },
+      ...(progress ? { progress } : {}),
       receivedAt: ts.toISOString(),
     }
 

--- a/packages/api/src/task/services/task.service.ts
+++ b/packages/api/src/task/services/task.service.ts
@@ -1387,11 +1387,11 @@ export class TaskService {
       return null
     } // task not in running state
 
-    // Broadcast async update
     this.asyncTaskUpdateBroadcasterService.handleTaskUpdate(
       updatedTask,
       TaskUpdateType.task_progress,
       now,
+      storedProgressReport,
     )
 
     // Evaluate and dispatch onProgress handlers

--- a/packages/api/src/task/tasks.e2e-spec.ts
+++ b/packages/api/src/task/tasks.e2e-spec.ts
@@ -1385,9 +1385,31 @@ describe('Task lifecycle', () => {
       (received as { data: { correlationKey: string } }).data.correlationKey,
     ).toBe('ck-docker-update-1')
     expect((received as { data: { taskId: string } }).data.taskId).toBe(task.id)
+    // Worker's own message text is forwarded when the report supplies one,
+    // instead of the generic "Task progress: <id>" envelope label.
     expect((received as { message: { text: string } }).message.text).toBe(
-      `Task progress: ${APP_ACTION_TASK_ID}`,
+      'Halfway done',
     )
+    // Granular progress details (percent/current/total/label) must be
+    // forwarded so subscribers like codicle's clone progress UI can render
+    // per-stage updates from `gitWithProgress`.
+    expect(
+      (
+        received as {
+          progress: {
+            percent: number
+            current: number
+            total: number
+            label: string
+          }
+        }
+      ).progress,
+    ).toEqual({
+      percent: 50,
+      current: 1,
+      total: 2,
+      label: 'Processing',
+    })
     expect((received as { receivedAt: string }).receivedAt).toBeDefined()
   })
 
@@ -1481,6 +1503,15 @@ describe('Task lifecycle', () => {
       (received as { data: { correlationKey: string } }).data.correlationKey,
     ).toBe('ck-docker-folder-1')
     expect((received as { data: { taskId: string } }).data.taskId).toBe(task.id)
+    expect(
+      (received as { progress: { percent: number; label: string } }).progress,
+    ).toEqual({
+      percent: 75,
+      label: 'Almost done',
+    })
+    expect((received as { message: { text: string } }).message.text).toBe(
+      'Processing folder data',
+    )
   })
 
   it('stores task updates in the database and tracks latest progress', async () => {


### PR DESCRIPTION
Closes LOM-323. Also carries LOM-322 (the previous stacked PR #257 was merged into the wrong base and never reached main).

## LOM-323 — per-worker log files

The persistent-worker log file (e.g. `workers/http_9000.log`) was getting raw worker stdout (`LEVEL|JSON`) with no timestamp, while the unified log got the structured `timestamp|WORKER_<port>|LEVEL|JSON` shape. Tailing consumers like `worker.ts /diagnostics/logs` advance an `after=...` cursor based on the timestamp prefix — on the per-worker file there was no cursor to advance, so every poll re-rendered the same tail.

- Extracted the unified-log formatter into `FormatStructuredWorkerLogLine` in `docker/worker-agent/internal/logs/writer.go`.
- Per-worker file now uses the same formatter, sharing the `timestamp|WORKER_<port>|LEVEL|JSON` shape.
- `cmd/worker_supervisor.go` updated to wire the formatter through.

## LOM-322 — task update progress details (re-included)

`TaskUpdateBroadcasterService` was emitting a generic `Task progress: <id>` envelope on every progress update, dropping both the worker-supplied message text and any structured progress details (percent / current / total / label).

- `handleTaskUpdate` accepts an optional `ReceivedTaskProgressReport`; its `message` is forwarded as-is and `details` are emitted on a new `progress` field.
- On `task_completed`, synthesize `progress: { percent: 100 }` so UIs can finalize bars without a separate signal.
- `task.service` threads the stored progress report through to the broadcaster on every async progress update.
- `tasks.e2e-spec.ts` extended to assert both the forwarded message text and the structured `progress` object on async docker and folder-scoped paths.

## Test plan
- [x] `./dx check all`
- [x] api unit tests — 222 pass
- [x] `./dx e2e api` — 568 pass
- [x] `go vet ./...` + `go test ./...` (only the pre-existing `TestRotateTargetRespectsRetention` retention flake fails on origin/main)
- [ ] e2e ui skipped per request