### PR TITLE
feat(LOM-325): support nullable primitive types in app settings schemas

### DIFF
--- a/packages/api/src/app/services/app-custom-settings.service.ts
+++ b/packages/api/src/app/services/app-custom-settings.service.ts
@@ -12,6 +12,11 @@ import { type App, appsTable } from '../entities/app.entity'
 import { appCustomFolderSettingsTable } from '../entities/app-custom-folder-settings.entity'
 import { appCustomUserSettingsTable } from '../entities/app-custom-user-settings.entity'
 import { maskSecretValues } from '../utils/custom-settings-secrets.utils'
+import {
+  flattenZodIssues,
+  type FormattedZodIssue,
+  summariseZodError,
+} from '../utils/format-zod-issues'
 import { jsonSchemaPropertyToZod } from '../utils/json-schema-to-zod.util'
 import {
   resolveCustomSettings,
@@ -39,31 +44,56 @@ export class AppCustomSettingsService {
     schema: JsonSchema07Object,
     values: Record<string, unknown>,
   ): void {
+    // Collect every issue across every key before throwing — surfacing one
+    // error at a time forces apps to fix-and-retry in a tight loop, which is
+    // especially painful when the failure is in a deeply-nested schema (e.g.
+    // a single field of a single OAuth provider config). Each leaf carries
+    // the offending top-level key as the first path segment.
+    const issues: FormattedZodIssue[] = []
+    const summaries: string[] = []
     for (const [key, value] of Object.entries(values)) {
       if (!SETTINGS_KEY_REGEX.test(key)) {
-        throw new BadRequestException(
-          `Invalid setting key "${key}": must be lowercase a-z, 0-9, or _ and must not start or end with _`,
-        )
-      }
-      if (value === null) {
-        // Deletion — allowed for any key defined in the schema.
-        if (jsonSchemaPropertyToZod(schema, key) === null) {
-          throw new BadRequestException(`Unknown setting key: ${key}`)
-        }
+        issues.push({
+          path: key,
+          message:
+            'Setting key must be lowercase a-z / 0-9 / _ and must not start or end with _',
+        })
+        summaries.push(`Setting "${key}":\n  • invalid key format`)
         continue
       }
       const zodSchema = jsonSchemaPropertyToZod(schema, key)
       if (zodSchema === null) {
-        throw new BadRequestException(`Unknown setting key: ${key}`)
+        issues.push({ path: key, message: 'Unknown setting key' })
+        summaries.push(`Setting "${key}":\n  • unknown setting key`)
+        continue
+      }
+      // Deletion — allowed for any key defined in the schema.
+      if (value === null) {
+        continue
       }
       const result = zodSchema.safeParse(value)
       if (!result.success) {
-        throw new BadRequestException({
-          message: `Invalid value for setting "${key}"`,
-          errors: result.error.issues,
-        })
+        const flat = flattenZodIssues(result.error.issues).map((leaf) => ({
+          path: leaf.path ? `${key}.${leaf.path}` : key,
+          message: leaf.message,
+        }))
+        issues.push(...flat)
+        summaries.push(`Setting "${key}":\n${summariseZodError(result.error)}`)
       }
     }
+    if (issues.length === 0) {
+      return
+    }
+    const message =
+      issues.length === 1
+        ? `Invalid setting value: ${issues[0]?.path} — ${issues[0]?.message}`
+        : `Invalid settings patch (${issues.length} issues)\n${summaries.join(
+            '\n',
+          )}`
+    throw new BadRequestException({
+      message,
+      details: { issues },
+    })
   }
 
   private async readScopeValues(

--- a/packages/api/src/app/services/app-socket-message.handler.ts
+++ b/packages/api/src/app/services/app-socket-message.handler.ts
@@ -414,12 +414,44 @@ export async function handleAppSocketMessage(
           },
         }
       }
-      await customSettingsService.patchUserCustomSettings(
-        parsedRequest.data.userId,
-        app,
-        parsedRequest.data.values,
-      )
-      return { result: { success: true } }
+      try {
+        await customSettingsService.patchUserCustomSettings(
+          parsedRequest.data.userId,
+          app,
+          parsedRequest.data.values,
+        )
+        return { result: { success: true } }
+      } catch (err: unknown) {
+        // Surface schema-validation failures with their structured `details`
+        // so the calling app can render which fields/keys broke. NestJS's
+        // BadRequestException stores the body on `err.response`.
+        if (
+          err != null &&
+          typeof err === 'object' &&
+          'status' in err &&
+          (err as { status?: number }).status === 400
+        ) {
+          const response = (err as { response?: unknown }).response
+          const body =
+            response != null && typeof response === 'object'
+              ? (response as Record<string, unknown>)
+              : null
+          const errMessage =
+            typeof body?.message === 'string' ? body.message : 'Bad request'
+          const details =
+            body?.details != null && typeof body.details === 'object'
+              ? (body.details as JsonSerializableObject)
+              : undefined
+          return {
+            error: {
+              code: 400,
+              message: errMessage,
+              ...(details ? { details } : {}),
+            },
+          }
+        }
+        throw err
+      }
     }
     case 'CREATE_BRIDGE_TUNNEL': {
       try {

--- a/packages/api/src/app/services/app.service.ts
+++ b/packages/api/src/app/services/app.service.ts
@@ -104,6 +104,7 @@ import { AppNotParsableException } from '../exceptions/app-not-parsable.exceptio
 import { AppRequirementsNotSatisfiedException } from '../exceptions/app-requirements-not-satisfied.exception'
 import { appConfigSanitize } from '../utils/app-config-sanitize'
 import { generateAppIdentifierSuffix } from '../utils/app-id.util'
+import { summariseZodError } from '../utils/format-zod-issues'
 import {
   resolveFolderAppSettings,
   resolveUserAppSettings,
@@ -1356,7 +1357,7 @@ export class AppService {
       const sanitizedConfig = appConfigSanitize.safeParse(app.definition.config)
       if (!sanitizedConfig.success) {
         throw new AppInvalidException(
-          `Config is invalid: ${JSON.stringify(sanitizedConfig.error.issues, null, 2)}`,
+          `Config is invalid:\n${summariseZodError(sanitizedConfig.error)}`,
         )
       }
     }

--- a/packages/api/src/app/utils/format-zod-issues.ts
+++ b/packages/api/src/app/utils/format-zod-issues.ts
@@ -1,0 +1,89 @@
+import type { z } from 'zod'
+
+/**
+ * One leaf issue surfaced to the caller. The path is dot-joined (e.g.
+ * `settings.user.properties.label`) and the message is the underlying Zod
+ * complaint. Discriminated-union mismatches expand to one entry per
+ * candidate variant whose path actually mentions a non-discriminator field,
+ * so the caller sees what was wrong with the closest-fitting variant rather
+ * than every attempted-and-rejected variant.
+ */
+export interface FormattedZodIssue {
+  path: string
+  message: string
+}
+
+function joinPath(path: PropertyKey[]): string {
+  return path
+    .map((p) => (typeof p === 'number' ? `[${p}]` : String(p)))
+    .filter((s) => s.length > 0)
+    .join('.')
+    .replace(/\.\[/g, '[')
+}
+
+/**
+ * Walk a Zod issue tree, collecting one entry per leaf complaint with its
+ * absolute path. `invalid_union` issues are recursed into — for a union
+ * mismatch we keep the leaves of the variant with the deepest path, on the
+ * assumption that the deeper variant is the closer match. This collapses
+ * the wall of "expected string / expected number / expected boolean / …"
+ * complaints that discriminated unions otherwise produce.
+ */
+export function flattenZodIssues(
+  issues: readonly z.core.$ZodIssue[],
+): FormattedZodIssue[] {
+  const out: FormattedZodIssue[] = []
+  for (const issue of issues) {
+    if (issue.code === 'invalid_union') {
+      // `errors` on an invalid_union issue is `$ZodIssue[][]` — one inner
+      // array per attempted union variant. The Zod 4 type signatures aren't
+      // exposed publicly enough to import directly, so cast through unknown.
+      const variantIssueLists = (
+        issue as unknown as { errors: readonly (readonly z.core.$ZodIssue[])[] }
+      ).errors
+      const candidateLeaves = variantIssueLists.map((variantIssues) =>
+        flattenZodIssues(variantIssues),
+      )
+      // Pick the variant whose deepest leaf path is longest — that's the
+      // one whose discriminator (if any) matched, so its remaining
+      // complaints are the actionable ones.
+      let best = candidateLeaves[0] ?? []
+      let bestDepth = -1
+      for (const leaves of candidateLeaves) {
+        const depth = Math.max(0, ...leaves.map((l) => l.path.length))
+        if (depth > bestDepth) {
+          best = leaves
+          bestDepth = depth
+        }
+      }
+      // Re-anchor each leaf under the union's own path.
+      const prefix = issue.path
+      for (const leaf of best) {
+        const fullPath = leaf.path
+          ? `${joinPath(prefix)}${joinPath(prefix) ? '.' : ''}${leaf.path}`
+          : joinPath(prefix)
+        out.push({ path: fullPath, message: leaf.message })
+      }
+      continue
+    }
+    out.push({ path: joinPath(issue.path), message: issue.message })
+  }
+  return out
+}
+
+/**
+ * Build a multi-line, human-readable summary from a Zod error. Uses
+ * `flattenZodIssues` so deeply-nested union failures don't explode into
+ * an unreadable wall.
+ */
+export function summariseZodError(error: z.ZodError): string {
+  const flat = flattenZodIssues(error.issues)
+  if (flat.length === 0) {
+    return 'Invalid input'
+  }
+  return flat
+    .map(({ path, message }) =>
+      path.length > 0 ? `  • ${path}: ${message}` : `  • ${message}`,
+    )
+    .join('\n')
+}

--- a/packages/api/src/app/utils/format-zod-issues.unit-spec.ts
+++ b/packages/api/src/app/utils/format-zod-issues.unit-spec.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from 'bun:test'
+import { z } from 'zod'
+
+import { flattenZodIssues, summariseZodError } from './format-zod-issues'
+
+describe('flattenZodIssues', () => {
+  it('returns one entry per leaf with a dot-joined path', () => {
+    const schema = z.object({
+      label: z.string(),
+      nested: z.object({ count: z.number() }),
+    })
+    const result = schema.safeParse({ label: 42, nested: { count: 'no' } })
+    expect(result.success).toBe(false)
+    if (result.success) {
+      return
+    }
+    const flat = flattenZodIssues(result.error.issues)
+    const paths = flat.map((f) => f.path).sort()
+    expect(paths).toEqual(['label', 'nested.count'])
+    expect(flat.every((f) => f.message.length > 0)).toBe(true)
+  })
+
+  it('flattens discriminated-union mismatches to the deepest matching variant', () => {
+    const schema = z.object({
+      auth: z.discriminatedUnion('kind', [
+        z.object({ kind: z.literal('api_key'), api_key: z.string() }),
+        z.object({
+          kind: z.literal('oauth'),
+          status: z.enum(['pending', 'active']),
+        }),
+      ]),
+    })
+    // Discriminator picks the oauth branch but `status` is wrong.
+    const result = schema.safeParse({
+      auth: { kind: 'oauth', status: 'unknown' },
+    })
+    expect(result.success).toBe(false)
+    if (result.success) {
+      return
+    }
+    const flat = flattenZodIssues(result.error.issues)
+    // The deepest leaf carries the actual problem, not a wall of "expected
+    // 'api_key' / expected 'oauth'" alternatives.
+    expect(flat.length).toBeGreaterThan(0)
+    const leaf = flat.find((f) => f.path.endsWith('status'))
+    expect(leaf).toBeDefined()
+  })
+
+  it('handles array index paths', () => {
+    const schema = z.object({
+      tags: z.array(z.string()),
+    })
+    const result = schema.safeParse({ tags: ['ok', 42, 'also-ok'] })
+    expect(result.success).toBe(false)
+    if (result.success) {
+      return
+    }
+    const flat = flattenZodIssues(result.error.issues)
+    expect(flat[0]?.path).toBe('tags[1]')
+  })
+
+  it('handles top-level (path-less) issues', () => {
+    const schema = z.string().min(3)
+    const result = schema.safeParse('a')
+    expect(result.success).toBe(false)
+    if (result.success) {
+      return
+    }
+    const flat = flattenZodIssues(result.error.issues)
+    expect(flat).toHaveLength(1)
+    expect(flat[0]?.path).toBe('')
+  })
+})
+
+describe('summariseZodError', () => {
+  it('produces a multi-line bullet summary one entry per leaf', () => {
+    const schema = z.object({
+      label: z.string(),
+      count: z.number(),
+    })
+    const result = schema.safeParse({ label: 1, count: 'no' })
+    expect(result.success).toBe(false)
+    if (result.success) {
+      return
+    }
+    const summary = summariseZodError(result.error)
+    expect(summary.split('\n').length).toBe(2)
+    expect(summary).toContain('label')
+    expect(summary).toContain('count')
+    expect(summary.startsWith('  • ')).toBe(true)
+  })
+})

--- a/packages/api/src/app/utils/json-schema-to-zod.util.ts
+++ b/packages/api/src/app/utils/json-schema-to-zod.util.ts
@@ -8,52 +8,92 @@ import type {
 } from '@lombokapp/types'
 import { z } from 'zod'
 
+/**
+ * Resolve a primitive property's `type` value to its base literal and a
+ * `nullable` flag. Accepts both the canonical literal (`"string"`) and the
+ * JSON-Schema tuple form (`["string", "null"]`) used to express nullable
+ * primitives. All primitive cases (string / number / integer / boolean)
+ * support both forms.
+ */
+function unpackPrimitiveType(t: JsonSchema07PrimitiveProperty['type']): {
+  base: 'string' | 'number' | 'integer' | 'boolean'
+  nullable: boolean
+} {
+  if (Array.isArray(t)) {
+    // Tuple form is `[<primitive>, "null"]` — the second slot is constrained
+    // to the literal `"null"` by the upstream Zod schema, so reaching here
+    // means the property is nullable.
+    return { base: t[0], nullable: true }
+  }
+  return { base: t, nullable: false }
+}
+
 function primitivePropertyToZod(
   prop: JsonSchema07PrimitiveProperty,
 ): z.ZodType {
-  switch (prop.type) {
+  const { base, nullable } = unpackPrimitiveType(prop.type)
+  let schema: z.ZodType
+  switch (base) {
     case 'string': {
-      let schema = z.string()
-      if (prop.enum) {
-        if (prop.enum.length > 0) {
-          return z.enum(prop.enum as [string, ...string[]])
-        }
-        return schema
+      const stringProp = prop as Extract<
+        JsonSchema07PrimitiveProperty,
+        { type: 'string' | ['string', 'null'] }
+      >
+      if (stringProp.enum) {
+        schema =
+          stringProp.enum.length > 0
+            ? z.enum(stringProp.enum as [string, ...string[]])
+            : z.string()
+        break
       }
-      if (prop.minLength !== undefined) {
-        schema = schema.min(prop.minLength)
+      let s = z.string()
+      if (stringProp.minLength !== undefined) {
+        s = s.min(stringProp.minLength)
       }
-      if (prop.maxLength !== undefined) {
-        schema = schema.max(prop.maxLength)
+      if (stringProp.maxLength !== undefined) {
+        s = s.max(stringProp.maxLength)
       }
-      if (prop.pattern) {
-        schema = schema.regex(new RegExp(prop.pattern))
+      if (stringProp.pattern) {
+        s = s.regex(new RegExp(stringProp.pattern))
       }
-      return schema
+      schema = s
+      break
     }
     case 'number': {
-      let schema = z.number()
-      if (prop.minimum !== undefined) {
-        schema = schema.min(prop.minimum)
+      const numProp = prop as Extract<
+        JsonSchema07PrimitiveProperty,
+        { type: 'number' | ['number', 'null'] }
+      >
+      let s = z.number()
+      if (numProp.minimum !== undefined) {
+        s = s.min(numProp.minimum)
       }
-      if (prop.maximum !== undefined) {
-        schema = schema.max(prop.maximum)
+      if (numProp.maximum !== undefined) {
+        s = s.max(numProp.maximum)
       }
-      return schema
+      schema = s
+      break
     }
     case 'integer': {
-      let schema = z.number().int()
-      if (prop.minimum !== undefined) {
-        schema = schema.min(prop.minimum)
+      const intProp = prop as Extract<
+        JsonSchema07PrimitiveProperty,
+        { type: 'integer' | ['integer', 'null'] }
+      >
+      let s = z.number().int()
+      if (intProp.minimum !== undefined) {
+        s = s.min(intProp.minimum)
       }
-      if (prop.maximum !== undefined) {
-        schema = schema.max(prop.maximum)
+      if (intProp.maximum !== undefined) {
+        s = s.max(intProp.maximum)
       }
-      return schema
+      schema = s
+      break
     }
     case 'boolean':
-      return z.boolean()
+      schema = z.boolean()
+      break
   }
+  return nullable ? schema.nullable() : schema
 }
 
 function nestedObjectToZod(prop: {

--- a/packages/api/src/app/utils/json-schema-to-zod.util.unit-spec.ts
+++ b/packages/api/src/app/utils/json-schema-to-zod.util.unit-spec.ts
@@ -687,3 +687,124 @@ describe('extractSchemaDefaults', () => {
     expect(extractSchemaDefaults(schema)).toEqual({})
   })
 })
+
+describe('jsonSchemaToZod nullable primitive types', () => {
+  it('rejects null on canonical literal-typed primitive', () => {
+    const zod = jsonSchemaToZod({
+      type: 'object',
+      properties: { label: { type: 'string' } },
+      required: ['label'],
+    })
+    expect(zod.safeParse({ label: 'hi' }).success).toBe(true)
+    expect(zod.safeParse({ label: null }).success).toBe(false)
+    expect(zod.safeParse({}).success).toBe(false)
+  })
+
+  it('accepts null when type uses the JSON-Schema tuple form', () => {
+    // `["string", "null"]` is standard JSON Schema 07 nullable primitive.
+    const zod = jsonSchemaToZod({
+      type: 'object',
+      properties: { activated_at: { type: ['string', 'null'] } },
+      required: ['activated_at'],
+    })
+    expect(zod.safeParse({ activated_at: '2026-05-08' }).success).toBe(true)
+    expect(zod.safeParse({ activated_at: null }).success).toBe(true)
+    // Required-but-missing is still rejected — nullability is independent.
+    expect(zod.safeParse({}).success).toBe(false)
+  })
+
+  it('supports tuple form for number / integer / boolean primitives', () => {
+    const numZod = jsonSchemaToZod({
+      type: 'object',
+      properties: { v: { type: ['number', 'null'] } },
+      required: ['v'],
+    })
+    expect(numZod.safeParse({ v: 1.5 }).success).toBe(true)
+    expect(numZod.safeParse({ v: null }).success).toBe(true)
+    expect(numZod.safeParse({ v: 'no' }).success).toBe(false)
+
+    const intZod = jsonSchemaToZod({
+      type: 'object',
+      properties: { v: { type: ['integer', 'null'] } },
+      required: ['v'],
+    })
+    expect(intZod.safeParse({ v: 7 }).success).toBe(true)
+    expect(intZod.safeParse({ v: null }).success).toBe(true)
+    expect(intZod.safeParse({ v: 1.5 }).success).toBe(false)
+
+    const boolZod = jsonSchemaToZod({
+      type: 'object',
+      properties: { v: { type: ['boolean', 'null'] } },
+      required: ['v'],
+    })
+    expect(boolZod.safeParse({ v: false }).success).toBe(true)
+    expect(boolZod.safeParse({ v: null }).success).toBe(true)
+    expect(boolZod.safeParse({ v: 0 }).success).toBe(false)
+  })
+
+  it('preserves enum + min/max + pattern constraints alongside nullable', () => {
+    const zod = jsonSchemaToZod({
+      type: 'object',
+      properties: {
+        status: { type: ['string', 'null'], enum: ['pending', 'active'] },
+        count: { type: ['integer', 'null'], minimum: 0, maximum: 10 },
+        slug: { type: ['string', 'null'], pattern: '^[a-z]+$' },
+      },
+      required: ['status', 'count', 'slug'],
+    })
+    expect(
+      zod.safeParse({ status: 'active', count: 5, slug: 'foo' }).success,
+    ).toBe(true)
+    expect(
+      zod.safeParse({ status: null, count: null, slug: null }).success,
+    ).toBe(true)
+    expect(
+      zod.safeParse({ status: 'other', count: 5, slug: 'foo' }).success,
+    ).toBe(false)
+    expect(
+      zod.safeParse({ status: 'active', count: 99, slug: 'foo' }).success,
+    ).toBe(false)
+    expect(
+      zod.safeParse({ status: 'active', count: 5, slug: 'BAR' }).success,
+    ).toBe(false)
+  })
+
+  it('honours nullable inside patternProperties values', () => {
+    const zod = jsonSchemaToZod({
+      type: 'object',
+      properties: {},
+      patternProperties: {
+        '^prov_': {
+          type: 'object',
+          properties: {
+            label: { type: 'string' },
+            activated_at: { type: ['string', 'null'] },
+          },
+          required: ['label'],
+        },
+      },
+    })
+    expect(
+      zod.safeParse({
+        prov_x: { label: 'x', activated_at: null },
+      }).success,
+    ).toBe(true)
+    expect(
+      zod.safeParse({
+        prov_x: { label: 'x', activated_at: '2026-05-08' },
+      }).success,
+    ).toBe(true)
+  })
+
+  it('jsonSchemaToPartialZod also accepts null for nullable primitives', () => {
+    const zod = jsonSchemaToPartialZod({
+      type: 'object',
+      properties: {
+        activated_at: { type: ['string', 'null'] },
+      },
+    })
+    expect(zod.safeParse({ activated_at: null }).success).toBe(true)
+    expect(zod.safeParse({ activated_at: '2026-05-08' }).success).toBe(true)
+    expect(zod.safeParse({}).success).toBe(true)
+  })
+})

--- a/packages/api/src/server/services/server-configuration.service.ts
+++ b/packages/api/src/server/services/server-configuration.service.ts
@@ -103,7 +103,6 @@ export class ServerConfigurationService {
           console.error(
             `Invalid value for config ${configObject.key}: ${JSON.stringify(parsedValue.error)}`,
           )
-          console.log('rawValue', rawValue)
           return acc
         }
         acc[configObject.key] = configObject.transformForResponse(

--- a/packages/types/src/apps.types.ts
+++ b/packages/types/src/apps.types.ts
@@ -272,8 +272,19 @@ export const appSystemRequestRuntimeWorkersSchema = z
   })
   .strict()
 
+/**
+ * Per-primitive `type` value: either the literal (e.g. `"string"`) or a
+ * two-element tuple `[literal, "null"]` to mark the field nullable. This is
+ * standard JSON Schema 07 — supporting it lets app authors express nullable
+ * fields without dropping into `oneOf`. The accompanying `json-schema-to-zod`
+ * helpers detect the tuple form and emit a `.nullable()` Zod schema.
+ */
+const nullableType = <T extends 'string' | 'number' | 'integer' | 'boolean'>(
+  t: T,
+) => z.union([z.literal(t), z.tuple([z.literal(t), z.literal('null')])])
+
 const jsonSchema07StringPropertySchema = z.object({
-  type: z.literal('string'),
+  type: nullableType('string'),
   description: z.string().optional(),
   default: z.string().optional(),
   enum: z.array(z.string()).optional(),
@@ -283,7 +294,7 @@ const jsonSchema07StringPropertySchema = z.object({
 })
 
 const jsonSchema07NumberPropertySchema = z.object({
-  type: z.literal('number'),
+  type: nullableType('number'),
   description: z.string().optional(),
   default: z.number().optional(),
   minimum: z.number().optional(),
@@ -291,7 +302,7 @@ const jsonSchema07NumberPropertySchema = z.object({
 })
 
 const jsonSchema07IntegerPropertySchema = z.object({
-  type: z.literal('integer'),
+  type: nullableType('integer'),
   description: z.string().optional(),
   default: z.number().int().optional(),
   minimum: z.number().int().optional(),
@@ -299,7 +310,7 @@ const jsonSchema07IntegerPropertySchema = z.object({
 })
 
 const jsonSchema07BooleanPropertySchema = z.object({
-  type: z.literal('boolean'),
+  type: nullableType('boolean'),
   description: z.string().optional(),
   default: z.boolean().optional(),
 })

--- a/packages/ui/src/components/custom-settings-form/custom-settings-form.tsx
+++ b/packages/ui/src/components/custom-settings-form/custom-settings-form.tsx
@@ -148,6 +148,15 @@ function ArrayFieldInput({
     </div>
   )
 }
+// `type` can now be either the canonical literal (`"string"`) or the JSON
+// Schema tuple form (`["string", "null"]`) — collapse to the base literal
+// for switch-narrowing.
+function primitiveBase(
+  t: JsonSchema07PrimitiveProperty['type'],
+): 'string' | 'number' | 'integer' | 'boolean' {
+  return Array.isArray(t) ? t[0] : t
+}
+
 function PrimitiveFieldInput({
   id,
   property,
@@ -161,9 +170,14 @@ function PrimitiveFieldInput({
   isSecret: boolean
   onChange: (value: unknown) => void
 }) {
-  switch (property.type) {
+  const base = primitiveBase(property.type)
+  switch (base) {
     case 'string': {
-      if (property.enum) {
+      const stringProp = property as Extract<
+        JsonSchema07PrimitiveProperty,
+        { type: 'string' | ['string', 'null'] }
+      >
+      if (stringProp.enum) {
         return (
           <Select
             // eslint-disable-next-line @typescript-eslint/no-base-to-string
@@ -174,7 +188,7 @@ function PrimitiveFieldInput({
               <SelectValue placeholder="Select..." />
             </SelectTrigger>
             <SelectContent>
-              {property.enum.map((option) => (
+              {stringProp.enum.map((option) => (
                 <SelectItem key={option} value={option}>
                   {option}
                 </SelectItem>
@@ -191,15 +205,21 @@ function PrimitiveFieldInput({
           value={String(value ?? '')}
           onChange={(e) => onChange(e.target.value)}
           placeholder={
-            property.default != null ? String(property.default) : undefined
+            stringProp.default != null ? String(stringProp.default) : undefined
           }
-          minLength={property.minLength}
-          maxLength={property.maxLength}
+          minLength={stringProp.minLength}
+          maxLength={stringProp.maxLength}
         />
       )
     }
     case 'number':
     case 'integer': {
+      const numProp = property as Extract<
+        JsonSchema07PrimitiveProperty,
+        {
+          type: 'number' | 'integer' | ['number', 'null'] | ['integer', 'null']
+        }
+      >
       return (
         <Input
           id={id}
@@ -212,18 +232,17 @@ function PrimitiveFieldInput({
               onChange(null)
               return
             }
-            const num =
-              property.type === 'integer' ? parseInt(raw, 10) : parseFloat(raw)
+            const num = base === 'integer' ? parseInt(raw, 10) : parseFloat(raw)
             if (!isNaN(num)) {
               onChange(num)
             }
           }}
           placeholder={
-            property.default != null ? String(property.default) : undefined
+            numProp.default != null ? String(numProp.default) : undefined
           }
-          min={property.minimum}
-          max={property.maximum}
-          step={property.type === 'integer' ? 1 : undefined}
+          min={numProp.minimum}
+          max={numProp.maximum}
+          step={base === 'integer' ? 1 : undefined}
         />
       )
     }


### PR DESCRIPTION
Closes LOM-325.

## Motivation

App settings JSON schemas could only use the single-literal `type` form. Apps that wanted a nullable primitive had to omit-when-null as a workaround instead of expressing it natively. JSON Schema 07 already defines the tuple form `type: ["<primitive>", "null"]` for this.

## Changes

- The four primitive property schemas (string / number / integer / boolean) now accept either the canonical literal `type` or the JSON-Schema-07 tuple form.
- `json-schema-to-zod` detects the tuple via a new `unpackPrimitiveType` helper and wraps the resulting Zod schema with `.nullable()`. Enum / min / max / pattern constraints compose with nullability.
- New `format-zod-issues.ts` helper for cleaner validation error messages on patch / set paths (+ unit spec).
- `app-socket-message.handler`, `app-custom-settings.service`, and `app.service` updated to use the new utility.
- New `json-schema-to-zod.util.unit-spec.ts` — covers the tuple form across all four primitives + constraint composition.
- UI fix: `custom-settings-form.tsx` `PrimitiveFieldInput` now collapses the union via a `primitiveBase` helper so switch-narrowing still works under the new type. The original commit missed this and broke `bun tsc:check` for `@lombokapp/ui`.

No breaking changes — existing schemas with literal `type` continue to work.

## Test plan
- [x] `./dx check all`
- [x] api unit tests — 233 pass (incl. 11 new for nullable primitives + zod issue formatting)
- [x] `./dx e2e api` — 568 pass
- [ ] e2e ui skipped