### PR TITLE
fix(LOM-326): return 401 for failed app API authentication

### DIFF
--- a/packages/core-worker/src/app-workers/app-request-server.ts
+++ b/packages/core-worker/src/app-workers/app-request-server.ts
@@ -5,7 +5,7 @@ import type {
   CoreWorkerMessagePayloadTypes,
   ServerlessWorkerExecConfig,
 } from '@lombokapp/worker-utils'
-import { uniqueExecutionKey } from '@lombokapp/worker-utils'
+import { AsyncWorkError, uniqueExecutionKey } from '@lombokapp/worker-utils'
 import fs from 'fs'
 import path from 'path'
 import { runWorker } from 'src/worker-scripts/run-worker'
@@ -100,13 +100,21 @@ export const buildAppRequestServer = ({
     } catch (error: unknown) {
       const errorMessage =
         error instanceof Error ? error.message : String(error)
+      const status =
+        error instanceof AsyncWorkError &&
+        error.code === 'WORKER_REQUEST_AUTHENTICATION_FAILED'
+          ? 401
+          : 500
       return new Response(
         JSON.stringify({
-          error: 'Worker execution failed',
+          error:
+            status === 401
+              ? 'Worker request authentication failed'
+              : 'Worker execution failed',
           message: errorMessage,
         }),
         {
-          status: 500,
+          status,
           headers: { 'Content-Type': 'application/json' },
         },
       )


### PR DESCRIPTION
Closes LOM-326.

## Motivation

When an app worker rejected an incoming request because authentication failed (`AsyncWorkError` with code `WORKER_REQUEST_AUTHENTICATION_FAILED`), `app-request-server` mapped it to a generic `500 Worker execution failed`. Clients couldn't distinguish auth failure from a real server error, and SDK retry/refresh logic couldn't trigger on 401s.

## Changes

`packages/core-worker/src/app-workers/app-request-server.ts` — inspect the caught error and return:
- `401 Worker request authentication failed` when the error is an `AsyncWorkError` with code `WORKER_REQUEST_AUTHENTICATION_FAILED`
- `500 Worker execution failed` otherwise (existing behavior)

One-file change. Lets the `app-browser-sdk` `tokenStore` recognise auth failures on its existing 401 path.

## Test plan
- [x] `./dx check all`
- [x] api unit tests — 222 pass
- [x] `./dx e2e api` — 568 pass
- [ ] e2e ui skipped