### PR TITLE
feat(LOM-327): RESOLVE_APP_DOCKER_CONTAINER socket message

### DIFF
--- a/packages/api/src/app/services/app-socket-message.handler.ts
+++ b/packages/api/src/app/services/app-socket-message.handler.ts
@@ -517,5 +517,27 @@ export async function handleAppSocketMessage(
         }
       }
     }
+    case 'RESOLVE_APP_DOCKER_CONTAINER': {
+      try {
+        const result = await appService.resolveAppWorkerDockerContainer(
+          requestingAppIdentifier,
+          parsedRequest.data,
+        )
+        return { result }
+      } catch (error: unknown) {
+        return {
+          error: {
+            code:
+              error instanceof Error && 'statusCode' in error
+                ? (error as { statusCode: number }).statusCode
+                : 500,
+            message:
+              error instanceof Error
+                ? error.message
+                : 'Container resolution failed',
+          },
+        }
+      }
+    }
   }
 }

--- a/packages/api/src/app/services/app.service.ts
+++ b/packages/api/src/app/services/app.service.ts
@@ -2322,6 +2322,41 @@ export class AppService {
    * Destroy Docker containers belonging to the requesting app.
    * The hostId is always resolved from the profile configuration.
    */
+  /**
+   * Resolve the running container for `(profileIdentifier, isolationKey)` of
+   * the requesting app — used by class-isolated workflows that need to point
+   * back at a container they earlier asked the platform to spawn (e.g. the
+   * codicle OAuth login flow attaching a terminal to its dedicated login
+   * container) without caching the pointer themselves. Returns `null` if no
+   * running container matches.
+   */
+  async resolveAppWorkerDockerContainer(
+    appIdentifier: string,
+    params: {
+      profileIdentifier: string
+      userId?: string
+      isolationKey: string
+    },
+  ): Promise<{ hostId: string; containerId: string } | null> {
+    const { profileIdentifier, userId, isolationKey } = params
+    const profileKey = `${appIdentifier}:${profileIdentifier}`
+    const profileSpec = await this.dockerJobsService.getProfileSpec(
+      appIdentifier,
+      profileIdentifier,
+    )
+    const { hostId } =
+      await this.dockerJobsService.resolveDockerHostConfigForProfile(profileKey)
+    const found = await this.dockerJobsService.findRunningAppWorkerContainer({
+      hostId,
+      profileKey,
+      appIdentifier,
+      profileSpec,
+      userId,
+      isolationKey: userId ? `user:${userId}:${isolationKey}` : isolationKey,
+    })
+    return found ? { hostId, containerId: found.containerId } : null
+  }
+
   async destroyAppWorkerDockerContainers(
     appIdentifier: string,
     params:

--- a/packages/api/src/docker/services/docker-jobs.service.ts
+++ b/packages/api/src/docker/services/docker-jobs.service.ts
@@ -439,6 +439,47 @@ export class DockerJobsService {
   }
 
   /**
+   * Find the running container matching `(profileKey, isolationKey, userId?)`
+   * by docker labels. Returns `null` if nothing's running — exited / created /
+   * paused matches are filtered out so callers don't mistake a teardown-pending
+   * container for a live one. Class-isolated profiles guarantee at most one
+   * match; the first running container is returned.
+   */
+  async findRunningAppWorkerContainer(params: {
+    hostId: string
+    profileKey: string
+    appIdentifier: string
+    profileSpec: ContainerProfileConfig
+    userId?: string
+    isolationKey: string
+  }): Promise<{ containerId: string } | null> {
+    const {
+      hostId,
+      profileKey,
+      appIdentifier,
+      profileSpec,
+      userId,
+      isolationKey,
+    } = params
+    const profileHash = this.hashProfileSpec(profileSpec)
+    const containerProfileIdentifier = `lombok:profile_${profileKey}`
+    const labels = this.buildWorkerContainerLabels(
+      containerProfileIdentifier,
+      profileHash,
+      profileSpec.image,
+      appIdentifier,
+      userId,
+      isolationKey,
+    )
+    const containers = await this.dockerClientService.listContainersByLabels(
+      hostId,
+      labels,
+    )
+    const running = containers.find((c) => c.state === 'running')
+    return running ? { containerId: running.id } : null
+  }
+
+  /**
    * Resolve Docker host and resource config for a given profile key.
    * Uses the DB-backed resolution via DockerHostManagementService.
    */

--- a/packages/api/src/orm/app-database-access.e2e-spec.ts
+++ b/packages/api/src/orm/app-database-access.e2e-spec.ts
@@ -85,6 +85,9 @@ function createMockAppPlatformService(
     destroyAppDockerContainers: () => {
       throw new Error('Not implemented in test mock')
     },
+    resolveAppDockerContainer: () => {
+      throw new Error('Not implemented in test mock')
+    },
   }
 }
 

--- a/packages/app-worker-sdk/src/app-worker-sdk.ts
+++ b/packages/app-worker-sdk/src/app-worker-sdk.ts
@@ -112,6 +112,17 @@ export interface IAppPlatformService {
     params: AppSocketMessageDataMap['DESTROY_APP_DOCKER_CONTAINERS'],
     options?: PlatformApiExecuteOptions,
   ) => Promise<SocketResponse<'DESTROY_APP_DOCKER_CONTAINERS'>>
+  /**
+   * Resolve the live container running for a (profile, isolationKey) pair.
+   * Returns the running container's `{hostId, containerId}` or `null` if no
+   * matching container is currently running. Useful for class-isolated
+   * profiles where the runtime needs to reach a container it earlier asked
+   * the platform to spin up but doesn't want to cache the pointer itself.
+   */
+  resolveAppDockerContainer: (
+    params: AppSocketMessageDataMap['RESOLVE_APP_DOCKER_CONTAINER'],
+    options?: PlatformApiExecuteOptions,
+  ) => Promise<SocketResponse<'RESOLVE_APP_DOCKER_CONTAINER'>>
 }
 
 interface PlatformApiExecuteOptions {
@@ -249,6 +260,9 @@ export const buildAppClient = (
     },
     destroyAppDockerContainers(params, options) {
       return emitWithAck('DESTROY_APP_DOCKER_CONTAINERS', params, options)
+    },
+    resolveAppDockerContainer(params, options) {
+      return emitWithAck('RESOLVE_APP_DOCKER_CONTAINER', params, options)
     },
   }
 }

--- a/packages/core-worker/src/test/test-server-client.mock.ts
+++ b/packages/core-worker/src/test/test-server-client.mock.ts
@@ -74,6 +74,9 @@ export function buildTestServerClient(
     destroyAppDockerContainers: () => {
       throw new Error('Not implemented in test mock')
     },
+    resolveAppDockerContainer: () => {
+      throw new Error('Not implemented in test mock')
+    },
   }
 
   return { ...base, ...overrides }

--- a/packages/types/src/app-socket-message-schemas.ts
+++ b/packages/types/src/app-socket-message-schemas.ts
@@ -203,6 +203,19 @@ export const destroyAppDockerContainersSchema = z.union([
   }),
 ])
 
+/**
+ * Resolve the live container running for a (profile, isolationKey) pair.
+ * Class-isolated container profiles spin up at most one container per
+ * isolation key per user — this returns the one currently in `running`
+ * state, or null if no live container matches. The platform filters out
+ * exited / dead matches so callers don't get a zombie pointer.
+ */
+export const resolveAppDockerContainerSchema = z.object({
+  profileIdentifier: z.string(),
+  userId: z.string().optional(),
+  isolationKey: z.string(),
+})
+
 export const AppSocketMessageSchemaMap = {
   EMIT_EVENT: emitEventSchema,
   SAVE_LOG_ENTRY: logEntrySchema,
@@ -222,6 +235,7 @@ export const AppSocketMessageSchemaMap = {
   CREATE_BRIDGE_TUNNEL: createBridgeTunnelSchema,
   DELETE_BRIDGE_TUNNEL: deleteBridgeTunnelSchema,
   DESTROY_APP_DOCKER_CONTAINERS: destroyAppDockerContainersSchema,
+  RESOLVE_APP_DOCKER_CONTAINER: resolveAppDockerContainerSchema,
 } as const satisfies Record<z.infer<typeof AppSocketMessage>, z.ZodType>
 
 export type AppSocketMessageDataMap = {
@@ -359,6 +373,9 @@ export const AppSocketMessageResponseSchemaMap = {
   ),
   DESTROY_APP_DOCKER_CONTAINERS: createResponseSchema(
     z.object({ destroyedCount: z.number() }),
+  ),
+  RESOLVE_APP_DOCKER_CONTAINER: createResponseSchema(
+    z.object({ hostId: z.string(), containerId: z.string() }).nullable(),
   ),
 } as const satisfies Record<z.infer<typeof AppSocketMessage>, z.ZodType>
 

--- a/packages/types/src/apps.types.ts
+++ b/packages/types/src/apps.types.ts
@@ -33,6 +33,7 @@ export const AppSocketMessage = z.enum([
   'CREATE_BRIDGE_TUNNEL',
   'DELETE_BRIDGE_TUNNEL',
   'DESTROY_APP_DOCKER_CONTAINERS',
+  'RESOLVE_APP_DOCKER_CONTAINER',
 ])
 
 export const appMessageErrorSchema = z.object({


### PR DESCRIPTION
Closes LOM-327.

## Motivation

Class-isolated app workflows (e.g. the codicle OAuth login flow) need to talk to a container they earlier asked the platform to spawn for a given `(profile, isolationKey)` pair. There was no platform API to look that container up — apps had to either model the host/container pair as their own durable state, or cache the pointer in memory and risk a stale value after restart / failover. The platform already knows the mapping via the labels it puts on the container at create time.

## Changes

- New `AppSocketMessage` — `RESOLVE_APP_DOCKER_CONTAINER` — with input `{ profileIdentifier, userId?, isolationKey }` and output `{ hostId, containerId } | null`.
- `AppService.resolveAppWorkerDockerContainer` applies the same `userId` prefixing the destroy path uses.
- `DockerJobsService.findRunningAppWorkerContainer` wraps `listContainersByLabels` and filters to `state === 'running'` — exited/dead matches are dropped so callers don't get a zombie pointer.
- Wired into `IAppPlatformService` + `buildAppClient` in `@lombokapp/app-worker-sdk`.
- Test mocks (`app-database-access.e2e-spec`, `test-server-client.mock`) updated.

Returns `null` when no live container matches; the contract is "tell me about the running one or nothing."

## Test plan
- [x] `./dx check all`
- [x] api unit tests — 233 pass
- [x] `./dx e2e api` — 568 pass
- [ ] e2e ui skipped