### PR TITLE
fix(LOM-329): propagate bridge 404 and map controller validation to HTTP exceptions

### DIFF
--- a/packages/api/src/docker/controllers/bridge-session.controller.ts
+++ b/packages/api/src/docker/controllers/bridge-session.controller.ts
@@ -1,9 +1,11 @@
 import {
   Body,
   Controller,
+  ForbiddenException,
   HttpCode,
   HttpStatus,
   Logger,
+  NotFoundException,
   Post,
   Req,
   UnauthorizedException,
@@ -76,19 +78,19 @@ export class BridgeSessionController {
     )
 
     if (!container) {
-      throw new Error(
+      throw new NotFoundException(
         `No running container found for instance "${containerId}"`,
       )
     }
 
     const containerAppId = container.labels[DOCKER_LABELS.APP_ID]
     if (!containerAppId || containerAppId !== appIdentifier) {
-      throw new Error('Container not owned by this app')
+      throw new ForbiddenException('Container not owned by this app')
     }
 
     const containerUserId = container.labels[DOCKER_LABELS.USER_ID]
     if (!containerUserId || containerUserId !== userId) {
-      throw new Error('Container not owned by this user')
+      throw new ForbiddenException('Container not owned by this user')
     }
 
     return container

--- a/packages/api/src/docker/services/client/docker-client.service.ts
+++ b/packages/api/src/docker/services/client/docker-client.service.ts
@@ -19,6 +19,7 @@ import { DockerBridgeService } from '../docker-bridge.service'
 import { DockerHostManagementService } from '../docker-host-management.service'
 import { DOCKER_CONTAINER_TYPES, DOCKER_LABELS } from '../docker-jobs.service'
 import {
+  BridgeHttpError,
   type ConnectionTestResult,
   type ContainerInfo,
   type DockerContainerGpuInfo,
@@ -128,8 +129,9 @@ export class DockerClientService {
       const error = (await response.json().catch(() => ({
         error: response.statusText,
       }))) as { error?: string }
-      throw new Error(
+      throw new BridgeHttpError(
         `Bridge ${method} ${path} failed (${response.status}): ${error.error ?? response.statusText}`,
+        response.status,
       )
     }
 
@@ -620,38 +622,42 @@ export class DockerClientService {
     containerId: string,
     options?: { start?: boolean },
   ): Promise<ContainerInfo | undefined> {
-    const container = await this.withErrorGuard(
-      async () => this.getContainerInspect(hostId, containerId),
-      (error) =>
-        convertErrorToAsyncWorkError(
-          error instanceof Error ? error : new Error(String(error)),
-          {
-            name: 'DockerClientError',
-            message: `Failed to find container by id "${containerId}": ${error instanceof Error ? error.message : String(error)}`,
-            code: 'FIND_CONTAINER_BY_ID_FAILED',
-            stack: new Error().stack,
-            details: { containerId },
-          },
-        ),
-    ).then((containerInspect) => {
-      const state: ContainerInfo['state'] = containerInspect.State.Running
-        ? 'running'
-        : containerInspect.State.Paused
-          ? 'paused'
-          : containerInspect.State.Status === 'exited'
-            ? 'exited'
-            : containerInspect.State.Status === 'created'
-              ? 'created'
-              : 'unknown'
-      return {
-        id: containerInspect.Id,
-        image: containerInspect.Config.Image,
-        labels: containerInspect.Config.Labels,
-        state,
-        reusable: !containerInspect.State.Dead,
-        createdAt: containerInspect.Created,
+    let containerInspect: ContainerInspectInfo
+    try {
+      containerInspect = await this.getContainerInspect(hostId, containerId)
+    } catch (error: unknown) {
+      if (error instanceof BridgeHttpError && error.statusCode === 404) {
+        return undefined
       }
-    })
+      throw convertErrorToAsyncWorkError(
+        error instanceof Error ? error : new Error(String(error)),
+        {
+          name: 'DockerClientError',
+          message: `Failed to find container by id "${containerId}": ${error instanceof Error ? error.message : String(error)}`,
+          code: 'FIND_CONTAINER_BY_ID_FAILED',
+          stack: new Error().stack,
+          details: { containerId },
+        },
+      )
+    }
+
+    const state: ContainerInfo['state'] = containerInspect.State.Running
+      ? 'running'
+      : containerInspect.State.Paused
+        ? 'paused'
+        : containerInspect.State.Status === 'exited'
+          ? 'exited'
+          : containerInspect.State.Status === 'created'
+            ? 'created'
+            : 'unknown'
+    const container: ContainerInfo = {
+      id: containerInspect.Id,
+      image: containerInspect.Config.Image,
+      labels: containerInspect.Config.Labels,
+      state,
+      reusable: !containerInspect.State.Dead,
+      createdAt: containerInspect.Created,
+    }
 
     if (options?.start) {
       return this.ensureContainerRunning(hostId, container)

--- a/packages/api/src/docker/services/client/docker-client.types.ts
+++ b/packages/api/src/docker/services/client/docker-client.types.ts
@@ -170,6 +170,16 @@ export class DockerError extends Error {
   }
 }
 
+export class BridgeHttpError extends Error {
+  constructor(
+    message: string,
+    public readonly statusCode: number,
+  ) {
+    super(message)
+    this.name = 'BridgeHttpError'
+  }
+}
+
 export class DockerLogAccessError extends DockerError {
   constructor(code: string, message: string) {
     super(code, message)


### PR DESCRIPTION
## Summary

- `bridgeRequest` now throws a typed `BridgeHttpError` that carries the bridge's HTTP `statusCode`, so callers can branch on the response status instead of regex-matching the message.
- `findContainerById` catches `BridgeHttpError(404)` and returns `undefined`, matching its declared signature. End result for `destroyAppDockerContainers`: when the container is already gone, the destroy now reports `{ destroyedCount: 0 }` (success) instead of a generic 500.
- `BridgeSessionController.validateContainerAccess` was throwing plain `Error`s — NestJS turned all three into 500s. Now: missing container → `NotFoundException` (404), wrong app/user → `ForbiddenException` (403). The codicle UI tunnel-create path now sees correct status codes.

Linear: [LOM-329](https://linear.app/lombokapp/issue/LOM-329/propagate-bridge-http-404-so-callers-can-handle-missing-containers)

## Out of scope

The frontend's direct tunnel traffic path (`/-/tunnel/...` on the docker bridge) does not flow through `bridgeRequest`. If that returns 500 for missing containers, it's a separate bridge-side fix — the bridge's `http-server.ts` catch block falls back to 500 whenever the underlying dockerode error doesn't expose `statusCode`. Can be tracked separately if needed.

## Test plan

- [x] `./dx check all` → all green
- [x] `./dx e2e api` → 568 pass, 0 fail
- [ ] Manually destroy a workspace whose docker container is already gone; confirm the task finishes as success rather than surfacing a 500
- [ ] Hit `POST /api/v1/docker/bridge-sessions/tunnel` with a stale `containerId`; confirm 404 (not 500)
- [ ] Hit it with a `containerId` owned by a different app/user; confirm 403 (not 500)