### PR TITLE
fix(LOM-330): forward DELETE request bodies to runtime worker handlers

### DIFF
--- a/packages/core-worker/src/worker-scripts/run-worker.ts
+++ b/packages/core-worker/src/worker-scripts/run-worker.ts
@@ -1010,8 +1010,11 @@ async function ensureLinkedNodeModulesMirror(): Promise<string> {
 
 // Helper function to parse request body based on Content-Type and HTTP method
 async function parseRequestBody(request: Request): Promise<unknown> {
-  // Methods that typically don't have request bodies
-  const methodsWithoutBody = ['GET', 'HEAD', 'DELETE', 'OPTIONS']
+  // Methods that never have request bodies. DELETE is allowed to carry a body
+  // (RFC 9110 §9.3.5) — handlers may use it to convey delete options, so we
+  // must forward it. The Content-Length / Content-Type checks below short-
+  // circuit when there's nothing to parse.
+  const methodsWithoutBody = ['GET', 'HEAD', 'OPTIONS']
 
   if (methodsWithoutBody.includes(request.method)) {
     return undefined


### PR DESCRIPTION
## Summary

`parseRequestBody` in `packages/core-worker/src/worker-scripts/run-worker.ts` short-circuited on `DELETE`, so any DELETE request reached the handler with an empty-string body and Zod object validation rejected it with `expected object, received string`. RFC 9110 §9.3.5 allows DELETE bodies; we want to forward them so endpoints like codicle's `deleteAgent` (`{ deleteChats: boolean }`) work.

This drops `DELETE` from `methodsWithoutBody`. The downstream `Content-Length` / `Content-Type` guards still skip parsing for bodyless DELETEs, so existing DELETE endpoints (`body: null`) are unaffected.

## Trace

1. Browser SDK fetches with JSON body
2. `parseRequestBody` returns `undefined` (DELETE in skip list)
3. `bodyString = JSON.stringify(undefined ?? '')` → `'""'`
4. Worker daemon reconstructs Request with body `'""'` + `Content-Type: application/json`
5. Handler does `request.json()` → `""` (empty string)
6. Zod fails: `expected object, received string`

## Test plan

- [ ] Bun unit tests pass on `packages/core-worker`
- [ ] Manually verified codicle delete-agent flow no longer 400s after upgrade
- [ ] Existing DELETE endpoints (workspace/worktree/repo/etc., all `body: null`) still work

Linear: [LOM-330](https://linear.app/lombokapp/issue/LOM-330/core-worker-strips-request-bodies-from-delete-requests)