### PR TITLE
feat(LOM-331): runtime registerable task triggers

### DIFF
--- a/packages/api/src/app/app.module.ts
+++ b/packages/api/src/app/app.module.ts
@@ -17,6 +17,7 @@ import { AppsController } from './controllers/apps.controller'
 import { UserAppsController } from './controllers/user-apps.controller'
 import { AppService } from './services/app.service'
 import { AppCustomSettingsService } from './services/app-custom-settings.service'
+import { AppRuntimeTriggerService } from './services/app-runtime-trigger.service'
 
 @Module({
   imports: [
@@ -35,10 +36,11 @@ import { AppCustomSettingsService } from './services/app-custom-settings.service
   providers: [
     AppService,
     AppCustomSettingsService,
+    AppRuntimeTriggerService,
     S3Service,
     ServerConfigurationService,
   ],
-  exports: [AppService, AppCustomSettingsService],
+  exports: [AppService, AppCustomSettingsService, AppRuntimeTriggerService],
 })
 // eslint-disable-next-line @typescript-eslint/no-extraneous-class
 export class AppModule {}

--- a/packages/api/src/app/entities/app-runtime-trigger.entity.ts
+++ b/packages/api/src/app/entities/app-runtime-trigger.entity.ts
@@ -1,0 +1,59 @@
+import type { RegisterableTriggerConfig } from '@lombokapp/types'
+import { sql } from 'drizzle-orm'
+import {
+  index,
+  jsonb,
+  pgTable,
+  text,
+  timestamp,
+  uniqueIndex,
+  uuid,
+} from 'drizzle-orm/pg-core'
+
+import { appsTable } from './app.entity'
+
+/**
+ * Triggers an app registers at runtime via the worker socket
+ * (REGISTER_APP_TRIGGER), parallel to the config.json-declared triggers in
+ * `apps.config.triggers`. Both sources are read by EventService on every
+ * event emit and schedule tick.
+ *
+ * The trigger shape is stored as a single `definition` jsonb (same shape as a
+ * config.json triggers[] entry). Lookup hot paths use Postgres expression
+ * indexes on JSONB fields so there's no denormalized column to keep in sync.
+ *
+ * ON DELETE CASCADE lets AppService.uninstallApp's single DELETE of the apps
+ * row clean these up without an extra step.
+ */
+export const appRuntimeTriggersTable = pgTable(
+  'app_runtime_triggers',
+  {
+    id: uuid('id').primaryKey(),
+    appId: text('app_id')
+      .references(() => appsTable.id, { onDelete: 'cascade' })
+      .notNull(),
+    definition: jsonb('definition')
+      .$type<RegisterableTriggerConfig>()
+      .notNull(),
+    createdAt: timestamp('created_at').notNull(),
+    updatedAt: timestamp('updated_at').notNull(),
+  },
+  (table) => [
+    index('app_runtime_triggers_app_id_idx').on(table.appId),
+    // Event-emit hot path: `WHERE definition->>'eventIdentifier' = ?` resolves
+    // via this index (the same expression is required at query time for
+    // Postgres to pick it up).
+    index('app_runtime_triggers_event_identifier_idx')
+      .on(sql`(${table.definition} ->> 'eventIdentifier')`)
+      .where(sql`(${table.definition} ->> 'kind') = 'event'`),
+    // App-supplied triggerKey is unique per app across both kinds when set.
+    // Schedules require it; events opt in. NULL keys (events that didn't
+    // supply one) are excluded so multiple anonymous event rows coexist.
+    uniqueIndex('app_runtime_triggers_app_trigger_key_unique')
+      .on(table.appId, sql`(${table.definition} ->> 'triggerKey')`)
+      .where(sql`(${table.definition} ->> 'triggerKey') IS NOT NULL`),
+  ],
+)
+
+export type AppRuntimeTrigger = typeof appRuntimeTriggersTable.$inferSelect
+export type NewAppRuntimeTrigger = typeof appRuntimeTriggersTable.$inferInsert

--- a/packages/api/src/app/services/app-runtime-trigger.service.ts
+++ b/packages/api/src/app/services/app-runtime-trigger.service.ts
@@ -1,0 +1,162 @@
+import type { RegisterableTriggerConfig } from '@lombokapp/types'
+import {
+  BadRequestException,
+  ConflictException,
+  Injectable,
+  NotFoundException,
+} from '@nestjs/common'
+import { and, eq, sql } from 'drizzle-orm'
+import { OrmService } from 'src/orm/orm.service'
+import { v4 as uuidV4 } from 'uuid'
+
+import { appsTable } from '../entities/app.entity'
+import {
+  AppRuntimeTrigger,
+  appRuntimeTriggersTable,
+} from '../entities/app-runtime-trigger.entity'
+
+export interface ListedAppRuntimeTrigger {
+  id: string
+  kind: 'event' | 'schedule'
+  definition: RegisterableTriggerConfig
+}
+
+@Injectable()
+export class AppRuntimeTriggerService {
+  constructor(private readonly ormService: OrmService) {}
+
+  private async resolveApp(requestingAppIdentifier: string) {
+    // Inlined to avoid an AppService dep — AppService imports back into this
+    // module for the socket handler, and a Nest forwardRef pair around the
+    // decorator metadata trips on circular module init.
+    const app = await this.ormService.db.query.appsTable.findFirst({
+      where: eq(appsTable.identifier, requestingAppIdentifier),
+    })
+    if (!app) {
+      throw new NotFoundException(`App not found: ${requestingAppIdentifier}`)
+    }
+    return app
+  }
+
+  async register(
+    requestingAppIdentifier: string,
+    trigger: RegisterableTriggerConfig,
+  ): Promise<{ triggerId: string }> {
+    const app = await this.resolveApp(requestingAppIdentifier)
+
+    // Mirror the cross-field rules appConfigSchema.superRefine enforces for
+    // config triggers (packages/types/src/apps.types.ts:719-751).
+    const taskExists = (app.config.tasks ?? []).some(
+      (t) => t.identifier === trigger.taskIdentifier,
+    )
+    if (!taskExists) {
+      throw new BadRequestException({
+        code: 'UNKNOWN_TASK',
+        message: `Unknown task "${trigger.taskIdentifier}". Must be one of the app's declared tasks.`,
+      })
+    }
+
+    if (trigger.kind === 'event') {
+      const isCoreEvent = trigger.eventIdentifier.startsWith('core:')
+      if (
+        isCoreEvent &&
+        !app.subscribedCoreEvents.includes(trigger.eventIdentifier)
+      ) {
+        throw new BadRequestException({
+          code: 'EVENT_NOT_SUBSCRIBED',
+          message: `Platform event "${trigger.eventIdentifier}" is not in the app's subscribedCoreEvents.`,
+        })
+      }
+    }
+
+    // Cross-source triggerKey uniqueness: the DB unique index covers
+    // runtime-vs-runtime, but config-declared triggers live in
+    // apps.config.triggers (JSONB) and aren't in this table. Schedule
+    // triggers always have a key; event triggers may opt in.
+    if (trigger.triggerKey) {
+      const configCollision = (app.config.triggers ?? []).some(
+        (t) =>
+          (t.kind === 'schedule' || t.kind === 'event') &&
+          t.triggerKey === trigger.triggerKey,
+      )
+      if (configCollision) {
+        throw new ConflictException({
+          code: 'TRIGGER_KEY_TAKEN',
+          message: `triggerKey "${trigger.triggerKey}" already used by a config-declared trigger.`,
+        })
+      }
+    }
+
+    const now = new Date()
+    const triggerId = uuidV4()
+    try {
+      await this.ormService.db.insert(appRuntimeTriggersTable).values({
+        id: triggerId,
+        appId: app.id,
+        definition: trigger,
+        createdAt: now,
+        updatedAt: now,
+      })
+    } catch (error) {
+      // Drizzle wraps pg errors: the SQLSTATE lives on `error.cause.code`.
+      const pgCode =
+        (error as { code?: string } | null | undefined)?.code ??
+        (error as { cause?: { code?: string } } | null | undefined)?.cause?.code
+      if (pgCode === '23505') {
+        throw new ConflictException({
+          code: 'TRIGGER_KEY_TAKEN',
+          message: `triggerKey already registered for this app.`,
+        })
+      }
+      throw error
+    }
+
+    return { triggerId }
+  }
+
+  async unregister(
+    requestingAppIdentifier: string,
+    triggerId: string,
+  ): Promise<{ success: boolean }> {
+    const app = await this.resolveApp(requestingAppIdentifier)
+
+    const result = await this.ormService.db
+      .delete(appRuntimeTriggersTable)
+      .where(
+        and(
+          eq(appRuntimeTriggersTable.id, triggerId),
+          eq(appRuntimeTriggersTable.appId, app.id),
+        ),
+      )
+      .returning({ id: appRuntimeTriggersTable.id })
+
+    if (result.length === 0) {
+      throw new NotFoundException(`Trigger not found: ${triggerId}`)
+    }
+
+    return { success: true }
+  }
+
+  async list(
+    requestingAppIdentifier: string,
+    options: { kind?: 'event' | 'schedule' } = {},
+  ): Promise<ListedAppRuntimeTrigger[]> {
+    const app = await this.resolveApp(requestingAppIdentifier)
+
+    const where = options.kind
+      ? and(
+          eq(appRuntimeTriggersTable.appId, app.id),
+          sql`(${appRuntimeTriggersTable.definition} ->> 'kind') = ${options.kind}`,
+        )
+      : eq(appRuntimeTriggersTable.appId, app.id)
+
+    const rows =
+      await this.ormService.db.query.appRuntimeTriggersTable.findMany({ where })
+
+    return rows.map((row: AppRuntimeTrigger) => ({
+      id: row.id,
+      kind: row.definition.kind,
+      definition: row.definition,
+    }))
+  }
+}

--- a/packages/api/src/app/services/app-socket-message.handler.ts
+++ b/packages/api/src/app/services/app-socket-message.handler.ts
@@ -19,6 +19,7 @@ import { z } from 'zod'
 
 import type { AppService } from './app.service'
 import type { AppCustomSettingsService } from './app-custom-settings.service'
+import type { AppRuntimeTriggerService } from './app-runtime-trigger.service'
 
 export type AppSocketMessageName = z.infer<typeof AppSocketMessage>
 
@@ -70,6 +71,45 @@ export function parseAppSocketRequest(
   }
 }
 
+function appExceptionToError(
+  error: unknown,
+  fallbackMessage: string,
+): {
+  code: number | string
+  message: string
+  details?: JsonSerializableObject
+} {
+  if (
+    error instanceof Error &&
+    'getResponse' in error &&
+    'getStatus' in error
+  ) {
+    const status = (error as { getStatus: () => number }).getStatus()
+    const response = (error as { getResponse: () => unknown }).getResponse()
+    // NestJS exceptions thrown with a structured body surface it via
+    // getResponse(); we preserve the app-facing string code in `details` and
+    // the HTTP status in `code` so existing SDK callers keep working.
+    if (
+      response &&
+      typeof response === 'object' &&
+      'code' in response &&
+      typeof (response as { code: unknown }).code === 'string'
+    ) {
+      const body = response as { code: string; message?: string }
+      return {
+        code: status,
+        message: body.message ?? error.message,
+        details: { code: body.code },
+      }
+    }
+    return { code: status, message: error.message }
+  }
+  return {
+    code: 500,
+    message: error instanceof Error ? error.message : fallbackMessage,
+  }
+}
+
 export async function handleAppSocketMessage(
   handlerInstanceId: string,
   requestingAppIdentifier: string,
@@ -82,6 +122,7 @@ export async function handleAppSocketMessage(
     folderService,
     appService,
     customSettingsService,
+    runtimeTriggerService,
   }: {
     eventService: EventService
     ormService: OrmService
@@ -90,6 +131,7 @@ export async function handleAppSocketMessage(
     taskService: TaskService
     appService: AppService
     customSettingsService: AppCustomSettingsService
+    runtimeTriggerService: AppRuntimeTriggerService
   },
 ): Promise<AppSocketResponse<AppSocketMessageName>> {
   const parsedRequest = parseAppSocketRequest(message)
@@ -537,6 +579,47 @@ export async function handleAppSocketMessage(
                 : 'Container resolution failed',
           },
         }
+      }
+    }
+    case 'REGISTER_APP_TRIGGER': {
+      try {
+        const result = await runtimeTriggerService.register(
+          requestingAppIdentifier,
+          parsedRequest.data.trigger,
+        )
+        return { result }
+      } catch (error: unknown) {
+        return {
+          error: appExceptionToError(error, 'Failed to register trigger'),
+        }
+      }
+    }
+    case 'UNREGISTER_APP_TRIGGER': {
+      try {
+        const result = await runtimeTriggerService.unregister(
+          requestingAppIdentifier,
+          parsedRequest.data.triggerId,
+        )
+        return { result }
+      } catch (error: unknown) {
+        return {
+          error: appExceptionToError(error, 'Failed to unregister trigger'),
+        }
+      }
+    }
+    case 'LIST_APP_TRIGGERS': {
+      try {
+        const triggers = await runtimeTriggerService.list(
+          requestingAppIdentifier,
+          {
+            ...(parsedRequest.data.kind
+              ? { kind: parsedRequest.data.kind }
+              : {}),
+          },
+        )
+        return { result: { triggers } }
+      } catch (error: unknown) {
+        return { error: appExceptionToError(error, 'Failed to list triggers') }
       }
     }
   }

--- a/packages/api/src/app/services/app.service.ts
+++ b/packages/api/src/app/services/app.service.ts
@@ -110,6 +110,7 @@ import {
   resolveUserAppSettings,
 } from '../utils/resolve-app-settings.utils'
 import { AppCustomSettingsService } from './app-custom-settings.service'
+import { AppRuntimeTriggerService } from './app-runtime-trigger.service'
 import { handleAppSocketMessage } from './app-socket-message.handler'
 
 const MAX_APP_FILE_SIZE = 1024 * 1024 * 16
@@ -162,6 +163,7 @@ export class AppService {
     @Inject(forwardRef(() => CoreWorkerService))
     _coreWorkerService,
     private readonly customSettingsService: AppCustomSettingsService,
+    private readonly runtimeTriggerService: AppRuntimeTriggerService,
     private readonly dockerClientService: DockerClientService,
   ) {
     this.coreTaskService = _coreTaskService as CoreTaskService
@@ -366,6 +368,7 @@ export class AppService {
         taskService: this.taskService,
         appService: this,
         customSettingsService: this.customSettingsService,
+        runtimeTriggerService: this.runtimeTriggerService,
       },
     )
   }

--- a/packages/api/src/app/tests/app-runtime-triggers.e2e-spec.ts
+++ b/packages/api/src/app/tests/app-runtime-triggers.e2e-spec.ts
@@ -1,0 +1,323 @@
+import type { RegisterableTriggerConfig } from '@lombokapp/types'
+import {
+  afterAll,
+  afterEach,
+  beforeAll,
+  beforeEach,
+  describe,
+  expect,
+  it,
+} from 'bun:test'
+import { and, eq } from 'drizzle-orm'
+import { io, type Socket } from 'socket.io-client'
+import { appsTable } from 'src/app/entities/app.entity'
+import { appRuntimeTriggersTable } from 'src/app/entities/app-runtime-trigger.entity'
+import { tasksTable } from 'src/task/entities/task.entity'
+import type { TestModule } from 'src/test/test.types'
+import { buildTestModule } from 'src/test/test.util'
+
+import { buildAppClient } from '../../../../app-worker-sdk'
+
+const TEST_MODULE_KEY = 'app_runtime_triggers'
+const SOCKET_TEST_APP_SLUG = 'sockettestapp'
+
+describe('App Runtime Triggers', () => {
+  let testModule: TestModule | undefined
+  let socket: Socket | undefined
+  let serverBaseUrl: string
+  const startServerOnPort = 7032
+
+  const createAppToken = (appIdentifier: string): Promise<string> =>
+    testModule!.services.jwtService.mintAppToken(appIdentifier)
+
+  const connectSocket = async (instanceId: string): Promise<Socket> => {
+    const appIdentifier =
+      testModule!.getInstalledAppIdentifier(SOCKET_TEST_APP_SLUG)
+    const token = await createAppToken(appIdentifier)
+    const socketUrl = `${serverBaseUrl}/apps`
+
+    return new Promise((resolve, reject) => {
+      const newSocket = io(socketUrl, {
+        auth: { instanceId, token },
+        reconnection: false,
+        transports: ['websocket'],
+      })
+      const timeout = setTimeout(() => {
+        newSocket.disconnect()
+        reject(new Error('Socket connection timeout'))
+      }, 10000)
+      newSocket.on('connect', () => {
+        clearTimeout(timeout)
+        resolve(newSocket)
+      })
+      newSocket.on('connect_error', (error) => {
+        clearTimeout(timeout)
+        reject(error)
+      })
+    })
+  }
+
+  beforeAll(async () => {
+    testModule = await buildTestModule({
+      testModuleKey: TEST_MODULE_KEY,
+      startServerOnPort,
+    })
+    serverBaseUrl = `http://localhost:${startServerOnPort}`
+    await testModule.installLocalAppBundles([SOCKET_TEST_APP_SLUG])
+  })
+
+  beforeEach(async () => {
+    await testModule!.installLocalAppBundles([SOCKET_TEST_APP_SLUG])
+    socket = await connectSocket('test-instance-runtime-triggers')
+  })
+
+  afterEach(async () => {
+    if (socket) {
+      socket.disconnect()
+      socket = undefined
+    }
+    await testModule!.resetAppState()
+  })
+
+  afterAll(async () => {
+    await testModule?.shutdown()
+  })
+
+  const scheduleTriggerOnce = (overrides?: {
+    triggerKey?: string
+    taskIdentifier?: string
+  }): RegisterableTriggerConfig => ({
+    kind: 'schedule',
+    triggerKey: overrides?.triggerKey ?? 'runtime-schedule-1',
+    config: { interval: 1, unit: 'minutes' },
+    taskIdentifier: overrides?.taskIdentifier ?? 'socket_test_task',
+  })
+
+  const eventTriggerOnce = (overrides?: {
+    eventIdentifier?: string
+    taskIdentifier?: string
+    triggerKey?: string
+  }): RegisterableTriggerConfig => ({
+    kind: 'event',
+    eventIdentifier: overrides?.eventIdentifier ?? 'dummy_event',
+    taskIdentifier: overrides?.taskIdentifier ?? 'socket_test_task',
+    ...(overrides?.triggerKey ? { triggerKey: overrides.triggerKey } : {}),
+  })
+
+  it('registers, lists, and unregisters a schedule trigger', async () => {
+    const client = buildAppClient(socket!, serverBaseUrl)
+
+    const registerResp = await client.registerAppTrigger({
+      trigger: scheduleTriggerOnce(),
+    })
+    if (!('result' in registerResp)) {
+      throw new Error('register failed')
+    }
+    const triggerId = registerResp.result.triggerId
+    expect(triggerId).toBeDefined()
+
+    const listResp = await client.listAppTriggers({})
+    if (!('result' in listResp)) {
+      throw new Error('list failed')
+    }
+    expect(listResp.result.triggers).toHaveLength(1)
+    expect(listResp.result.triggers[0]?.id).toBe(triggerId)
+    expect(listResp.result.triggers[0]?.kind).toBe('schedule')
+
+    const unregisterResp = await client.unregisterAppTrigger({ triggerId })
+    if (!('result' in unregisterResp)) {
+      throw new Error('unregister failed')
+    }
+    expect(unregisterResp.result.success).toBe(true)
+
+    const listAfter = await client.listAppTriggers({})
+    if (!('result' in listAfter)) {
+      throw new Error('list-after failed')
+    }
+    expect(listAfter.result.triggers).toHaveLength(0)
+  })
+
+  it('rejects registration with unknown taskIdentifier', async () => {
+    const client = buildAppClient(socket!, serverBaseUrl)
+    const resp = await client.registerAppTrigger({
+      trigger: scheduleTriggerOnce({ taskIdentifier: 'no_such_task' }),
+    })
+    if (!('error' in resp)) {
+      throw new Error('expected error')
+    }
+    expect(resp.error.code).toBe(400)
+    expect((resp.error.details as { code?: string } | undefined)?.code).toBe(
+      'UNKNOWN_TASK',
+    )
+  })
+
+  it('rejects core: event subscription not in subscribedCoreEvents', async () => {
+    const client = buildAppClient(socket!, serverBaseUrl)
+    const resp = await client.registerAppTrigger({
+      trigger: eventTriggerOnce({ eventIdentifier: 'core:object_added' }),
+    })
+    if (!('error' in resp)) {
+      throw new Error('expected error')
+    }
+    expect(resp.error.code).toBe(400)
+    expect((resp.error.details as { code?: string } | undefined)?.code).toBe(
+      'EVENT_NOT_SUBSCRIBED',
+    )
+  })
+
+  it('rejects duplicate schedule names', async () => {
+    const client = buildAppClient(socket!, serverBaseUrl)
+    const first = await client.registerAppTrigger({
+      trigger: scheduleTriggerOnce({ triggerKey: 'dup-schedule' }),
+    })
+    if (!('result' in first)) {
+      throw new Error('first register failed')
+    }
+
+    const second = await client.registerAppTrigger({
+      trigger: scheduleTriggerOnce({ triggerKey: 'dup-schedule' }),
+    })
+    if (!('error' in second)) {
+      throw new Error('expected conflict')
+    }
+    expect(second.error.code).toBe(409)
+  })
+
+  it('fires a task when its runtime schedule trigger ticks', async () => {
+    const client = buildAppClient(socket!, serverBaseUrl)
+    const registered = await client.registerAppTrigger({
+      trigger: scheduleTriggerOnce({ triggerKey: 'fire-schedule' }),
+    })
+    if (!('result' in registered)) {
+      throw new Error('register failed')
+    }
+    const triggerId = registered.result.triggerId
+
+    await testModule!.services.eventService.processScheduledTaskTriggers()
+
+    const appIdentifier =
+      testModule!.getInstalledAppIdentifier(SOCKET_TEST_APP_SLUG)
+    const tasks = await testModule!.services.ormService.db
+      .select()
+      .from(tasksTable)
+      .where(
+        and(
+          eq(tasksTable.ownerId, appIdentifier),
+          eq(tasksTable.taskIdentifier, 'socket_test_task'),
+        ),
+      )
+
+    const fired = tasks.find(
+      (task) =>
+        task.invocation.kind === 'schedule' &&
+        task.invocation.invokeContext.runtimeTriggerId === triggerId,
+    )
+    expect(fired).toBeDefined()
+  })
+
+  it('fires a task when its runtime event trigger matches an emitted event', async () => {
+    const client = buildAppClient(socket!, serverBaseUrl)
+    const registered = await client.registerAppTrigger({
+      trigger: eventTriggerOnce({ eventIdentifier: 'dummy_event' }),
+    })
+    if (!('result' in registered)) {
+      throw new Error('register failed')
+    }
+    const triggerId = registered.result.triggerId
+
+    const appIdentifier =
+      testModule!.getInstalledAppIdentifier(SOCKET_TEST_APP_SLUG)
+    await testModule!.services.eventService.emitEvent({
+      emitterIdentifier: appIdentifier,
+      eventIdentifier: 'dummy_event',
+      data: { fromTest: true },
+    })
+
+    const tasks = await testModule!.services.ormService.db
+      .select()
+      .from(tasksTable)
+      .where(
+        and(
+          eq(tasksTable.ownerId, appIdentifier),
+          eq(tasksTable.taskIdentifier, 'socket_test_task'),
+        ),
+      )
+
+    const fired = tasks.find(
+      (task) =>
+        task.invocation.kind === 'event' &&
+        task.invocation.invokeContext.runtimeTriggerId === triggerId,
+    )
+    expect(fired).toBeDefined()
+  })
+
+  it('stops firing after the trigger is unregistered', async () => {
+    const client = buildAppClient(socket!, serverBaseUrl)
+    const registered = await client.registerAppTrigger({
+      trigger: eventTriggerOnce({ eventIdentifier: 'dummy_event' }),
+    })
+    if (!('result' in registered)) {
+      throw new Error('register failed')
+    }
+    const triggerId = registered.result.triggerId
+
+    await client.unregisterAppTrigger({ triggerId })
+
+    const appIdentifier =
+      testModule!.getInstalledAppIdentifier(SOCKET_TEST_APP_SLUG)
+    await testModule!.services.eventService.emitEvent({
+      emitterIdentifier: appIdentifier,
+      eventIdentifier: 'dummy_event',
+      data: { fromTest: true },
+    })
+
+    const tasks = await testModule!.services.ormService.db
+      .select()
+      .from(tasksTable)
+      .where(
+        and(
+          eq(tasksTable.ownerId, appIdentifier),
+          eq(tasksTable.taskIdentifier, 'socket_test_task'),
+        ),
+      )
+
+    const fired = tasks.find(
+      (task) =>
+        task.invocation.kind === 'event' &&
+        task.invocation.invokeContext.runtimeTriggerId === triggerId,
+    )
+    expect(fired).toBeUndefined()
+  })
+
+  it('cascade-deletes triggers when the app is uninstalled', async () => {
+    const client = buildAppClient(socket!, serverBaseUrl)
+    const registered = await client.registerAppTrigger({
+      trigger: scheduleTriggerOnce({ triggerKey: 'uninstall-cascade' }),
+    })
+    if (!('result' in registered)) {
+      throw new Error('register failed')
+    }
+
+    const appIdentifier =
+      testModule!.getInstalledAppIdentifier(SOCKET_TEST_APP_SLUG)
+    const app =
+      await testModule!.services.ormService.db.query.appsTable.findFirst({
+        where: eq(appsTable.identifier, appIdentifier),
+      })
+    if (!app) {
+      throw new Error('test app missing')
+    }
+    // Disconnect first so uninstall's disconnect step doesn't race the socket
+    // we still hold from beforeEach.
+    socket?.disconnect()
+    socket = undefined
+
+    await testModule!.services.appService.uninstallApp(app)
+
+    const remaining = await testModule!.services.ormService.db
+      .select()
+      .from(appRuntimeTriggersTable)
+      .where(eq(appRuntimeTriggersTable.appId, app.id))
+    expect(remaining).toHaveLength(0)
+  })
+})

--- a/packages/api/src/event/services/event.service.ts
+++ b/packages/api/src/event/services/event.service.ts
@@ -1,4 +1,5 @@
 import {
+  AppConfig,
   AppTaskConfig,
   CORE_IDENTIFIER,
   CoreEvent,
@@ -27,8 +28,10 @@ import {
   ilike,
   or,
   SQL,
+  sql,
 } from 'drizzle-orm'
 import { appsTable } from 'src/app/entities/app.entity'
+import { appRuntimeTriggersTable } from 'src/app/entities/app-runtime-trigger.entity'
 import { AppService } from 'src/app/services/app.service'
 import { normalizeSortParam, parseSort } from 'src/core/utils/sort.util'
 import { evalTriggerHandlerCondition } from 'src/event/util/eval-trigger-condition.util'
@@ -143,76 +146,118 @@ export class EventService {
 
       const tasksToInsert: NewTask[] = []
 
+      const tryEnqueueScheduleTask = async (input: {
+        appConfig: AppConfig
+        appIdentifier: string
+        scheduleTrigger: ScheduleTaskTriggerConfig
+        runtimeTriggerId?: string
+      }) => {
+        const { appConfig, appIdentifier, scheduleTrigger, runtimeTriggerId } =
+          input
+        const intervalMs = this.getScheduleIntervalMs(scheduleTrigger)
+        const earliestAllowed = new Date(nowMs - intervalMs)
+
+        const taskDefinition = appConfig.tasks?.find(
+          (task) => task.identifier === scheduleTrigger.taskIdentifier,
+        )
+
+        if (!taskDefinition) {
+          this.logger.error(
+            `Task definition not found: ${scheduleTrigger.taskIdentifier}`,
+          )
+          return
+        }
+
+        const { handlerType, handlerIdentifier } =
+          this.resolveTaskHandler(taskDefinition)
+
+        const newTask = withTaskIdempotencyKey({
+          id: uuidV4(),
+          invocation: {
+            kind: 'schedule',
+            invokeContext: {
+              timestampBucket: getUtcScheduleBucket(
+                scheduleTrigger.config,
+                now,
+              ).bucketStart.toISOString(),
+              triggerKey: scheduleTrigger.triggerKey,
+              config: {
+                interval: scheduleTrigger.config.interval,
+                unit: scheduleTrigger.config.unit,
+              },
+              ...(runtimeTriggerId ? { runtimeTriggerId } : {}),
+            },
+          },
+          taskIdentifier: taskDefinition.identifier,
+          taskDescription: taskDefinition.description,
+          data: {},
+          ownerId: appIdentifier,
+          createdAt: now,
+          updatedAt: now,
+          handlerType,
+          handlerIdentifier,
+        })
+
+        const existingTask =
+          await this.ormService.db.query.tasksTable.findFirst({
+            columns: { id: true, createdAt: true },
+            where: and(
+              eq(tasksTable.ownerId, appIdentifier),
+              eq(tasksTable.taskIdentifier, newTask.taskIdentifier),
+              eq(tasksTable.idempotencyKey, newTask.idempotencyKey),
+              gte(tasksTable.createdAt, earliestAllowed),
+            ),
+            orderBy: desc(tasksTable.createdAt),
+          })
+
+        if (existingTask) {
+          return
+        }
+        tasksToInsert.push(newTask)
+      }
+
       for (const app of enabledApps) {
         const scheduleTriggers = (app.config.triggers ?? []).filter(
           (trigger) => trigger.kind === 'schedule',
         )
+        for (const scheduleTrigger of scheduleTriggers) {
+          await tryEnqueueScheduleTask({
+            appConfig: app.config,
+            appIdentifier: app.identifier,
+            scheduleTrigger,
+          })
+        }
+      }
 
-        if (!scheduleTriggers.length) {
+      // Runtime-registered schedule triggers live in app_runtime_triggers
+      // (not app.config.triggers) but follow the same firing semantics. Join
+      // to apps so we get config (to resolve the task definition) and filter
+      // on enabled status in one query.
+      const runtimeScheduleRows = await this.ormService.db
+        .select({
+          trigger: appRuntimeTriggersTable,
+          identifier: appsTable.identifier,
+          config: appsTable.config,
+        })
+        .from(appRuntimeTriggersTable)
+        .innerJoin(appsTable, eq(appRuntimeTriggersTable.appId, appsTable.id))
+        .where(
+          and(
+            sql`(${appRuntimeTriggersTable.definition} ->> 'kind') = 'schedule'`,
+            eq(appsTable.enabled, true),
+          ),
+        )
+
+      for (const row of runtimeScheduleRows) {
+        if (row.trigger.definition.kind !== 'schedule') {
           continue
         }
-
-        for (const scheduleTrigger of scheduleTriggers) {
-          const intervalMs = this.getScheduleIntervalMs(scheduleTrigger)
-          const earliestAllowed = new Date(nowMs - intervalMs)
-
-          const taskDefinition = app.config.tasks?.find(
-            (task) => task.identifier === scheduleTrigger.taskIdentifier,
-          )
-
-          if (!taskDefinition) {
-            this.logger.error(
-              `Task definition not found: ${scheduleTrigger.taskIdentifier}`,
-            )
-            continue
-          }
-
-          const { handlerType, handlerIdentifier } =
-            this.resolveTaskHandler(taskDefinition)
-
-          const newTask = withTaskIdempotencyKey({
-            id: uuidV4(),
-            invocation: {
-              kind: 'schedule',
-              invokeContext: {
-                timestampBucket: getUtcScheduleBucket(
-                  scheduleTrigger.config,
-                  now,
-                ).bucketStart.toISOString(),
-                name: scheduleTrigger.name,
-                config: {
-                  interval: scheduleTrigger.config.interval,
-                  unit: scheduleTrigger.config.unit,
-                },
-              },
-            },
-            taskIdentifier: taskDefinition.identifier,
-            taskDescription: taskDefinition.description,
-            data: {},
-            ownerId: app.identifier,
-            createdAt: now,
-            updatedAt: now,
-            handlerType,
-            handlerIdentifier,
-          })
-
-          const existingTask =
-            await this.ormService.db.query.tasksTable.findFirst({
-              columns: { id: true, createdAt: true },
-              where: and(
-                eq(tasksTable.ownerId, app.identifier),
-                eq(tasksTable.taskIdentifier, newTask.taskIdentifier),
-                eq(tasksTable.idempotencyKey, newTask.idempotencyKey),
-                gte(tasksTable.createdAt, earliestAllowed),
-              ),
-              orderBy: desc(tasksTable.createdAt),
-            })
-
-          if (existingTask) {
-            continue
-          }
-          tasksToInsert.push(newTask)
-        }
+        await tryEnqueueScheduleTask({
+          appConfig: row.config,
+          appIdentifier: row.identifier,
+          scheduleTrigger: row.trigger.definition,
+          runtimeTriggerId: row.trigger.id,
+        })
       }
 
       if (!tasksToInsert.length) {
@@ -387,105 +432,182 @@ export class EventService {
         : []
 
     const tasks: NewTask[] = []
+
+    // Per-trigger task build. Shared between config-sourced triggers (walked
+    // off subscribedApp.config.triggers) and runtime-sourced triggers
+    // (rows in app_runtime_triggers).
+    const buildEventTriggeredTask = async (input: {
+      subscribedApp: { identifier: string; config: AppConfig }
+      trigger: Extract<
+        NonNullable<AppConfig['triggers']>[number],
+        { kind: 'event' }
+      >
+      triggerRef:
+        | { source: 'config'; index: number }
+        | { source: 'runtime'; id: string }
+    }) => {
+      const { subscribedApp, trigger, triggerRef } = input
+      const taskDefinition = subscribedApp.config.tasks?.find(
+        (task) => task.identifier === trigger.taskIdentifier,
+      )
+      if (!taskDefinition) {
+        this.logger.error(
+          `Task definition not found for app "${subscribedApp.identifier}" and trigger "${trigger.kind}": ${trigger.taskIdentifier}`,
+        )
+        return
+      }
+
+      const triggerConditionResult = trigger.condition
+        ? evalTriggerHandlerCondition(trigger.condition, event)
+        : undefined
+
+      if (trigger.condition && triggerConditionResult === false) {
+        this.logger.debug(
+          `Trigger condition failed for app "${subscribedApp.identifier}" and trigger "${trigger.kind}": ${trigger.taskIdentifier}, on event: ${event.id} (${event.eventIdentifier})`,
+        )
+        return
+      }
+
+      const task: NewTask = withTaskIdempotencyKey({
+        id: uuidV4(),
+        invocation: {
+          ...trigger,
+          invokeContext: this.buildEventInvocation(
+            event,
+            triggerRef,
+            trigger.triggerKey,
+          ),
+        },
+        targetLocationFolderId: targetLocation?.folderId,
+        targetLocationObjectKey: targetLocation?.objectKey,
+        taskDescription: taskDefinition.description,
+        taskIdentifier: taskDefinition.identifier,
+        data: trigger.dataTemplate
+          ? await parseDataFromEventWithTrigger(trigger.dataTemplate, event, {
+              createPresignedUrl:
+                this.folderService.dataTemplateFunctions.buildCreatePresignedUrlFunction(
+                  subscribedApp.identifier,
+                ),
+            })
+          : {},
+        ownerId: subscribedApp.identifier,
+        systemLog: [
+          {
+            at: new Date(),
+            logType: 'started',
+            message: 'Task is started',
+          },
+        ],
+        createdAt: now,
+        updatedAt: now,
+        handlerType: taskDefinition.handler.type,
+        handlerIdentifier: (
+          taskDefinition.handler as { identifier: string } | undefined
+        )?.identifier,
+      })
+      tasks.push(task)
+      await this.emitRunnableTaskEnqueuedEvent(task, tx)
+    }
+
+    // Per-app folder/user access check — bails out early if the app is not
+    // enabled for this scope. Returns true if the app may proceed.
+    const checkAppAccess = async (
+      targetAppIdentifier: string,
+    ): Promise<boolean> => {
+      try {
+        if (targetLocation) {
+          await this.appService.validateAppFolderAccess({
+            appIdentifier: targetAppIdentifier,
+            folderId: targetLocation.folderId,
+            tx,
+          })
+        } else if (targetUserId) {
+          await this.appService.validateAppUserAccess({
+            appIdentifier: targetAppIdentifier,
+            userId: targetUserId,
+            tx,
+          })
+        }
+        return true
+      } catch (error) {
+        if (error instanceof UnauthorizedException) {
+          return false
+        }
+        throw error
+      }
+    }
+
     await Promise.all(
       subscribedApps.map(async (subscribedApp) => {
-        try {
-          if (targetLocation) {
-            await this.appService.validateAppFolderAccess({
-              appIdentifier: subscribedApp.identifier,
-              folderId: targetLocation.folderId,
-              tx,
-            })
-          } else if (targetUserId) {
-            await this.appService.validateAppUserAccess({
-              appIdentifier: subscribedApp.identifier,
-              userId: targetUserId,
-              tx,
-            })
-          }
-        } catch (error) {
-          if (error instanceof UnauthorizedException) {
-            // App is not enabled for this user or folder
-            return Promise.resolve()
-          }
+        if (!(await checkAppAccess(subscribedApp.identifier))) {
+          return
         }
-        return Promise.all(
+        await Promise.all(
           (subscribedApp.config.triggers ?? []).map(
             async (trigger, eventTriggerConfigIndex) => {
               if (
                 trigger.kind === 'event' &&
                 trigger.eventIdentifier === eventTriggerIdentifier
               ) {
-                const taskDefinition = subscribedApp.config.tasks?.find(
-                  (task) => task.identifier === trigger.taskIdentifier,
-                )
-                if (!taskDefinition) {
-                  this.logger.error(
-                    `Task definition not found for app "${subscribedApp.identifier}" and trigger "${trigger.kind}": ${trigger.taskIdentifier}`,
-                  )
-                  return Promise.resolve()
-                }
-
-                const triggerConditionResult = trigger.condition
-                  ? evalTriggerHandlerCondition(trigger.condition, event)
-                  : undefined
-
-                if (trigger.condition && triggerConditionResult === false) {
-                  this.logger.debug(
-                    `Trigger condition failed for app "${subscribedApp.identifier}" and trigger "${trigger.kind}": ${trigger.taskIdentifier}, on event: ${event.id} (${event.eventIdentifier})`,
-                  )
-                  return Promise.resolve()
-                }
-
-                // Build the base task object
-                const task: NewTask = withTaskIdempotencyKey({
-                  id: uuidV4(),
-                  invocation: {
-                    ...trigger,
-                    invokeContext: this.buildEventInvocation(
-                      event,
-                      eventTriggerConfigIndex,
-                    ),
+                await buildEventTriggeredTask({
+                  subscribedApp,
+                  trigger,
+                  triggerRef: {
+                    source: 'config',
+                    index: eventTriggerConfigIndex,
                   },
-                  targetLocationFolderId: targetLocation?.folderId,
-                  targetLocationObjectKey: targetLocation?.objectKey,
-                  taskDescription: taskDefinition.description,
-                  taskIdentifier: taskDefinition.identifier,
-                  data: trigger.dataTemplate
-                    ? await parseDataFromEventWithTrigger(
-                        trigger.dataTemplate,
-                        event,
-                        {
-                          createPresignedUrl:
-                            this.folderService.dataTemplateFunctions.buildCreatePresignedUrlFunction(
-                              subscribedApp.identifier,
-                            ),
-                        },
-                      )
-                    : {},
-                  ownerId: subscribedApp.identifier,
-                  systemLog: [
-                    {
-                      at: new Date(),
-                      logType: 'started',
-                      message: 'Task is started',
-                    },
-                  ],
-                  createdAt: now,
-                  updatedAt: now,
-                  handlerType: taskDefinition.handler.type,
-                  handlerIdentifier: (
-                    taskDefinition.handler as { identifier: string } | undefined
-                  )?.identifier,
                 })
-                tasks.push(task)
-                // emit a runnable task enqueued event that will trigger the creation of a docker or worker runner task
-                await this.emitRunnableTaskEnqueuedEvent(task, tx)
               }
-              return Promise.resolve()
             },
           ),
         )
+      }),
+    )
+
+    // Runtime-registered event triggers — joined to apps so we get
+    // identifier + config in one query, and filter on enabled status. For
+    // app-emitted (non-core) events we restrict to triggers belonging to
+    // the emitting app, matching the config-side semantics above.
+    const runtimeEventRows =
+      !isCoreEmitter && !app
+        ? []
+        : await tx
+            .select({
+              trigger: appRuntimeTriggersTable,
+              identifier: appsTable.identifier,
+              config: appsTable.config,
+            })
+            .from(appRuntimeTriggersTable)
+            .innerJoin(
+              appsTable,
+              eq(appRuntimeTriggersTable.appId, appsTable.id),
+            )
+            .where(
+              and(
+                // Uses the expression index on
+                // (definition->>'eventIdentifier') WHERE (definition->>'kind')='event'.
+                sql`(${appRuntimeTriggersTable.definition} ->> 'kind') = 'event'`,
+                sql`(${appRuntimeTriggersTable.definition} ->> 'eventIdentifier') = ${eventTriggerIdentifier}`,
+                eq(appsTable.enabled, true),
+                ...(isCoreEmitter || !app
+                  ? []
+                  : [eq(appRuntimeTriggersTable.appId, app.id)]),
+              ),
+            )
+
+    await Promise.all(
+      runtimeEventRows.map(async (row) => {
+        if (row.trigger.definition.kind !== 'event') {
+          return
+        }
+        if (!(await checkAppAccess(row.identifier))) {
+          return
+        }
+        await buildEventTriggeredTask({
+          subscribedApp: { identifier: row.identifier, config: row.config },
+          trigger: row.trigger.definition,
+          triggerRef: { source: 'runtime', id: row.trigger.id },
+        })
       }),
     )
 
@@ -681,10 +803,24 @@ export class EventService {
     })
   }
 
-  private buildEventInvocation(event: Event, eventTriggerConfigIndex: number) {
+  private buildEventInvocation(
+    event: Event,
+    triggerRef:
+      | number
+      | { source: 'config'; index: number }
+      | { source: 'runtime'; id: string },
+    triggerKey?: string,
+  ) {
+    const refFields =
+      typeof triggerRef === 'number'
+        ? { eventTriggerConfigIndex: triggerRef }
+        : triggerRef.source === 'config'
+          ? { eventTriggerConfigIndex: triggerRef.index }
+          : { runtimeTriggerId: triggerRef.id }
     return {
       eventId: event.id,
-      eventTriggerConfigIndex,
+      ...refFields,
+      ...(triggerKey ? { triggerKey } : {}),
       emitterId: event.emitterId,
       eventIdentifier: event.eventIdentifier,
       targetUserId: event.targetUserId ?? undefined,

--- a/packages/api/src/orm/app-database-access.e2e-spec.ts
+++ b/packages/api/src/orm/app-database-access.e2e-spec.ts
@@ -89,6 +89,15 @@ function createMockAppPlatformService(
     resolveAppDockerContainer: () => {
       throw new Error('Not implemented in test mock')
     },
+    registerAppTrigger: () => {
+      throw new Error('Not implemented in test mock')
+    },
+    unregisterAppTrigger: () => {
+      throw new Error('Not implemented in test mock')
+    },
+    listAppTriggers: () => {
+      throw new Error('Not implemented in test mock')
+    },
   }
 }
 

--- a/packages/api/src/orm/migrations/0000_chemical_shaman.sql
+++ b/packages/api/src/orm/migrations/0000_chemical_shaman.sql
@@ -32,6 +32,14 @@ CREATE TABLE "app_install_sequences" (
 	"next_position" integer NOT NULL
 );
 --> statement-breakpoint
+CREATE TABLE "app_runtime_triggers" (
+	"id" uuid PRIMARY KEY NOT NULL,
+	"app_id" text NOT NULL,
+	"definition" jsonb NOT NULL,
+	"created_at" timestamp NOT NULL,
+	"updated_at" timestamp NOT NULL
+);
+--> statement-breakpoint
 CREATE TABLE "app_user_settings" (
 	"user_id" uuid NOT NULL,
 	"app_id" text NOT NULL,
@@ -384,6 +392,7 @@ ALTER TABLE "app_custom_user_settings" ADD CONSTRAINT "app_custom_user_settings_
 ALTER TABLE "app_custom_user_settings" ADD CONSTRAINT "app_custom_user_settings_app_id_apps_id_fk" FOREIGN KEY ("app_id") REFERENCES "public"."apps"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
 ALTER TABLE "app_folder_settings" ADD CONSTRAINT "app_folder_settings_folder_id_folders_id_fk" FOREIGN KEY ("folder_id") REFERENCES "public"."folders"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
 ALTER TABLE "app_folder_settings" ADD CONSTRAINT "app_folder_settings_app_id_apps_id_fk" FOREIGN KEY ("app_id") REFERENCES "public"."apps"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+ALTER TABLE "app_runtime_triggers" ADD CONSTRAINT "app_runtime_triggers_app_id_apps_id_fk" FOREIGN KEY ("app_id") REFERENCES "public"."apps"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
 ALTER TABLE "app_user_settings" ADD CONSTRAINT "app_user_settings_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE no action ON UPDATE no action;--> statement-breakpoint
 ALTER TABLE "app_user_settings" ADD CONSTRAINT "app_user_settings_app_id_apps_id_fk" FOREIGN KEY ("app_id") REFERENCES "public"."apps"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
 ALTER TABLE "user_identities" ADD CONSTRAINT "user_identities_user_id_users_id_fk" FOREIGN KEY ("user_id") REFERENCES "public"."users"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
@@ -419,6 +428,9 @@ CREATE INDEX "app_custom_folder_settings_folder_app_idx" ON "app_custom_folder_s
 CREATE INDEX "app_custom_user_settings_user_app_idx" ON "app_custom_user_settings" USING btree ("user_id","app_id");--> statement-breakpoint
 CREATE INDEX "app_folder_settings_folder_id_idx" ON "app_folder_settings" USING btree ("folder_id");--> statement-breakpoint
 CREATE UNIQUE INDEX "app_folder_settings_folder_app_unique" ON "app_folder_settings" USING btree ("folder_id","app_id");--> statement-breakpoint
+CREATE INDEX "app_runtime_triggers_app_id_idx" ON "app_runtime_triggers" USING btree ("app_id");--> statement-breakpoint
+CREATE INDEX "app_runtime_triggers_event_identifier_idx" ON "app_runtime_triggers" USING btree (("definition" ->> 'eventIdentifier')) WHERE ("app_runtime_triggers"."definition" ->> 'kind') = 'event';--> statement-breakpoint
+CREATE UNIQUE INDEX "app_runtime_triggers_app_trigger_key_unique" ON "app_runtime_triggers" USING btree ("app_id",("definition" ->> 'triggerKey')) WHERE ("app_runtime_triggers"."definition" ->> 'triggerKey') IS NOT NULL;--> statement-breakpoint
 CREATE INDEX "app_user_settings_user_id_idx" ON "app_user_settings" USING btree ("user_id");--> statement-breakpoint
 CREATE UNIQUE INDEX "app_user_settings_user_app_unique" ON "app_user_settings" USING btree ("user_id","app_id");--> statement-breakpoint
 CREATE INDEX "apps_enabled_idx" ON "apps" USING btree ("enabled");--> statement-breakpoint

--- a/packages/api/src/orm/migrations/meta/0000_snapshot.json
+++ b/packages/api/src/orm/migrations/meta/0000_snapshot.json
@@ -1,5 +1,5 @@
 {
-  "id": "7fa75fad-3a4d-4826-8cb4-8cfd10c4b3a0",
+  "id": "5aa9087d-21a0-4c3d-b636-00cf00eeb06a",
   "prevId": "00000000-0000-0000-0000-000000000000",
   "version": "7",
   "dialect": "postgresql",
@@ -350,6 +350,117 @@
       },
       "indexes": {},
       "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.app_runtime_triggers": {
+      "name": "app_runtime_triggers",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "app_id": {
+          "name": "app_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "definition": {
+          "name": "definition",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "app_runtime_triggers_app_id_idx": {
+          "name": "app_runtime_triggers_app_id_idx",
+          "columns": [
+            {
+              "expression": "app_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "app_runtime_triggers_event_identifier_idx": {
+          "name": "app_runtime_triggers_event_identifier_idx",
+          "columns": [
+            {
+              "expression": "(\"definition\" ->> 'eventIdentifier')",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "(\"app_runtime_triggers\".\"definition\" ->> 'kind') = 'event'",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "app_runtime_triggers_app_trigger_key_unique": {
+          "name": "app_runtime_triggers_app_trigger_key_unique",
+          "columns": [
+            {
+              "expression": "app_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "(\"definition\" ->> 'triggerKey')",
+              "asc": true,
+              "isExpression": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "where": "(\"app_runtime_triggers\".\"definition\" ->> 'triggerKey') IS NOT NULL",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "app_runtime_triggers_app_id_apps_id_fk": {
+          "name": "app_runtime_triggers_app_id_apps_id_fk",
+          "tableFrom": "app_runtime_triggers",
+          "tableTo": "apps",
+          "columnsFrom": [
+            "app_id"
+          ],
+          "columnsTo": [
+            "id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
       "compositePrimaryKeys": {},
       "uniqueConstraints": {},
       "policies": {},

--- a/packages/api/src/orm/migrations/meta/_journal.json
+++ b/packages/api/src/orm/migrations/meta/_journal.json
@@ -5,8 +5,8 @@
     {
       "idx": 0,
       "version": "7",
-      "when": 1778942012665,
-      "tag": "0000_lethal_talkback",
+      "when": 1778964861419,
+      "tag": "0000_chemical_shaman",
       "breakpoints": true
     }
   ]

--- a/packages/api/src/orm/orm.service.ts
+++ b/packages/api/src/orm/orm.service.ts
@@ -31,6 +31,7 @@ import {
   appFolderSettingsTable,
 } from '../app/entities/app-folder-settings.entity'
 import { appInstallSequencesTable } from '../app/entities/app-install-sequence.entity'
+import { appRuntimeTriggersTable } from '../app/entities/app-runtime-trigger.entity'
 import {
   appUserSettingsRelations,
   appUserSettingsTable,
@@ -88,6 +89,7 @@ export const dbSchema = {
   folderObjectsTable,
   appsTable,
   appInstallSequencesTable,
+  appRuntimeTriggersTable,
   appFolderSettingsTable,
   appFolderSettingsRelations,
   appUserSettingsTable,

--- a/packages/api/src/task/tasks.e2e-spec.ts
+++ b/packages/api/src/task/tasks.e2e-spec.ts
@@ -930,7 +930,7 @@ describe('Task lifecycle', () => {
 
     if (firstTask.invocation.kind === 'schedule') {
       expect(firstTask.invocation.invokeContext).toEqual({
-        name: 'dummy_schedule',
+        triggerKey: 'dummy_schedule',
         config: {
           interval: 1,
           unit: 'hours',

--- a/packages/api/src/task/util/task-idempotency-key.util.ts
+++ b/packages/api/src/task/util/task-idempotency-key.util.ts
@@ -20,11 +20,17 @@ const buildTriggerIdempotencyData = (
         eventIdentifier: trigger.invokeContext.eventIdentifier,
         emitterId: trigger.invokeContext.emitterId,
         eventId: trigger.invokeContext.eventId,
-        eventTriggerConfigIndex: trigger.invokeContext.eventTriggerConfigIndex,
+        // Exactly one of these is set, depending on whether the trigger came
+        // from app.config.triggers (config-sourced) or app_runtime_triggers
+        // (runtime-sourced). Both flow into the idempotency hash so distinct
+        // triggers don't collide.
+        eventTriggerConfigIndex:
+          trigger.invokeContext.eventTriggerConfigIndex ?? null,
+        runtimeTriggerId: trigger.invokeContext.runtimeTriggerId ?? null,
       }
     case 'schedule':
       return {
-        name: trigger.invokeContext.name,
+        triggerKey: trigger.invokeContext.triggerKey,
         config: trigger.invokeContext.config,
         timestampBucket: trigger.invokeContext.timestampBucket,
       }

--- a/packages/api/test/e2e.setup.ts
+++ b/packages/api/test/e2e.setup.ts
@@ -157,7 +157,7 @@ const testAppDefinitions: AppConfig[] = [
     triggers: [
       {
         kind: 'schedule',
-        name: 'dummy_schedule',
+        triggerKey: 'dummy_schedule',
         config: {
           interval: 1,
           unit: 'hours',

--- a/packages/app-worker-sdk/src/app-worker-sdk.ts
+++ b/packages/app-worker-sdk/src/app-worker-sdk.ts
@@ -123,6 +123,18 @@ export interface IAppPlatformService {
     params: AppSocketMessageDataMap['RESOLVE_APP_DOCKER_CONTAINER'],
     options?: PlatformApiExecuteOptions,
   ) => Promise<SocketResponse<'RESOLVE_APP_DOCKER_CONTAINER'>>
+  registerAppTrigger: (
+    params: AppSocketMessageDataMap['REGISTER_APP_TRIGGER'],
+    options?: PlatformApiExecuteOptions,
+  ) => Promise<SocketResponse<'REGISTER_APP_TRIGGER'>>
+  unregisterAppTrigger: (
+    params: AppSocketMessageDataMap['UNREGISTER_APP_TRIGGER'],
+    options?: PlatformApiExecuteOptions,
+  ) => Promise<SocketResponse<'UNREGISTER_APP_TRIGGER'>>
+  listAppTriggers: (
+    params: AppSocketMessageDataMap['LIST_APP_TRIGGERS'],
+    options?: PlatformApiExecuteOptions,
+  ) => Promise<SocketResponse<'LIST_APP_TRIGGERS'>>
 }
 
 interface PlatformApiExecuteOptions {
@@ -263,6 +275,15 @@ export const buildAppClient = (
     },
     resolveAppDockerContainer(params, options) {
       return emitWithAck('RESOLVE_APP_DOCKER_CONTAINER', params, options)
+    },
+    registerAppTrigger(params, options) {
+      return emitWithAck('REGISTER_APP_TRIGGER', params, options)
+    },
+    unregisterAppTrigger(params, options) {
+      return emitWithAck('UNREGISTER_APP_TRIGGER', params, options)
+    },
+    listAppTriggers(params, options) {
+      return emitWithAck('LIST_APP_TRIGGERS', params, options)
     },
   }
 }

--- a/packages/core-worker/src/test/test-server-client.mock.ts
+++ b/packages/core-worker/src/test/test-server-client.mock.ts
@@ -77,6 +77,15 @@ export function buildTestServerClient(
     resolveAppDockerContainer: () => {
       throw new Error('Not implemented in test mock')
     },
+    registerAppTrigger: () => {
+      throw new Error('Not implemented in test mock')
+    },
+    unregisterAppTrigger: () => {
+      throw new Error('Not implemented in test mock')
+    },
+    listAppTriggers: () => {
+      throw new Error('Not implemented in test mock')
+    },
   }
 
   return { ...base, ...overrides }

--- a/packages/demo-apps/simple-demo/config.json
+++ b/packages/demo-apps/simple-demo/config.json
@@ -25,7 +25,7 @@
     },
     {
       "kind": "schedule",
-      "name": "hourly_job",
+      "triggerKey": "hourly_job",
       "config": {
         "interval": 1,
         "unit": "hours"

--- a/packages/types/src/__tests__/apps.types.test.ts
+++ b/packages/types/src/__tests__/apps.types.test.ts
@@ -367,7 +367,7 @@ describe('apps.types', () => {
           },
           {
             kind: 'schedule',
-            name: 'hourly_job',
+            triggerKey: 'hourly_job',
             config: {
               interval: 1,
               unit: 'hours',
@@ -424,7 +424,7 @@ describe('apps.types', () => {
         triggers: [
           {
             kind: 'schedule',
-            name: 'hourly_job',
+            triggerKey: 'hourly_job',
             config: {
               interval: 1,
               unit: 'hours',

--- a/packages/types/src/app-socket-message-schemas.ts
+++ b/packages/types/src/app-socket-message-schemas.ts
@@ -8,6 +8,7 @@ import { eventIdentifierSchema } from './events.types'
 import { jsonSerializableObjectSchema } from './json.types'
 import { SignedURLsRequestMethod } from './storage.types'
 import {
+  registerableTriggerConfigSchema,
   storageAccessPolicySchema,
   taskDTOSchema,
   taskOnCompleteConfigSchema,
@@ -216,6 +217,18 @@ export const resolveAppDockerContainerSchema = z.object({
   isolationKey: z.string(),
 })
 
+export const registerAppTriggerSchema = z.object({
+  trigger: registerableTriggerConfigSchema,
+})
+
+export const unregisterAppTriggerSchema = z.object({
+  triggerId: z.guid(),
+})
+
+export const listAppTriggersSchema = z.object({
+  kind: z.enum(['event', 'schedule']).optional(),
+})
+
 export const AppSocketMessageSchemaMap = {
   EMIT_EVENT: emitEventSchema,
   SAVE_LOG_ENTRY: logEntrySchema,
@@ -236,6 +249,9 @@ export const AppSocketMessageSchemaMap = {
   DELETE_BRIDGE_TUNNEL: deleteBridgeTunnelSchema,
   DESTROY_APP_DOCKER_CONTAINERS: destroyAppDockerContainersSchema,
   RESOLVE_APP_DOCKER_CONTAINER: resolveAppDockerContainerSchema,
+  REGISTER_APP_TRIGGER: registerAppTriggerSchema,
+  UNREGISTER_APP_TRIGGER: unregisterAppTriggerSchema,
+  LIST_APP_TRIGGERS: listAppTriggersSchema,
 } as const satisfies Record<z.infer<typeof AppSocketMessage>, z.ZodType>
 
 export type AppSocketMessageDataMap = {
@@ -376,6 +392,23 @@ export const AppSocketMessageResponseSchemaMap = {
   ),
   RESOLVE_APP_DOCKER_CONTAINER: createResponseSchema(
     z.object({ hostId: z.string(), containerId: z.string() }).nullable(),
+  ),
+  REGISTER_APP_TRIGGER: createResponseSchema(
+    z.object({ triggerId: z.string() }),
+  ),
+  UNREGISTER_APP_TRIGGER: createResponseSchema(
+    z.object({ success: z.boolean() }),
+  ),
+  LIST_APP_TRIGGERS: createResponseSchema(
+    z.object({
+      triggers: z.array(
+        z.object({
+          id: z.string(),
+          kind: z.enum(['event', 'schedule']),
+          definition: registerableTriggerConfigSchema,
+        }),
+      ),
+    }),
   ),
 } as const satisfies Record<z.infer<typeof AppSocketMessage>, z.ZodType>
 

--- a/packages/types/src/apps.types.ts
+++ b/packages/types/src/apps.types.ts
@@ -34,6 +34,9 @@ export const AppSocketMessage = z.enum([
   'DELETE_BRIDGE_TUNNEL',
   'DESTROY_APP_DOCKER_CONTAINERS',
   'RESOLVE_APP_DOCKER_CONTAINER',
+  'REGISTER_APP_TRIGGER',
+  'UNREGISTER_APP_TRIGGER',
+  'LIST_APP_TRIGGERS',
 ])
 
 export const appMessageErrorSchema = z.object({

--- a/packages/types/src/task.types.ts
+++ b/packages/types/src/task.types.ts
@@ -182,7 +182,12 @@ export const scheduleTaskTriggerConfigSchema = z
   .object({
     kind: z.literal('schedule'),
     config: scheduleConfigSchema,
-    name: z.string(),
+    // Stable, app-supplied handle for this trigger. Required on schedules so
+    // (a) the task handler can tell which schedule fired (carried into the
+    // invocation context), (b) the platform can dedupe per-bucket fires via
+    // the idempotency hash, and (c) the app gets durable identity across
+    // restarts without having to persist platform-generated UUIDs.
+    triggerKey: z.string(),
   })
   .extend(taskTriggerConfigBaseSchema.shape)
 
@@ -197,6 +202,10 @@ export const eventTaskTriggerConfigSchema = z
       corePrefixedEventIdentifierSchema,
     ),
     dataTemplate: jsonSerializableObjectSchema.optional(), // { "someKey": "{{event.data.someKey}}" }
+    // Optional on events — supply one to get the same idempotent-re-register
+    // and human-readable discriminator semantics that schedules get for free.
+    // When set, must be unique per app across all triggers (config + runtime).
+    triggerKey: z.string().optional(),
   })
   .extend(taskTriggerConfigBaseSchema.shape)
 
@@ -361,7 +370,13 @@ export const taskInvocationSchema = z.discriminatedUnion('kind', [
       eventIdentifier: eventIdentifierSchema.or(
         corePrefixedEventIdentifierSchema,
       ),
-      eventTriggerConfigIndex: z.number().int(),
+      // Config-sourced triggers carry their array index; runtime-sourced
+      // triggers omit this and set runtimeTriggerId instead.
+      eventTriggerConfigIndex: z.number().int().optional(),
+      runtimeTriggerId: z.guid().optional(),
+      // Mirrors the trigger's optional `triggerKey` — handlers can use it as
+      // a stable human-readable discriminator instead of the runtime UUID.
+      triggerKey: z.string().optional(),
       dataTemplate: jsonSerializableObjectSchema.optional(),
       targetUserId: z.guid().optional(),
       targetLocation: targetLocationContextDTOSchema.optional(),
@@ -374,11 +389,12 @@ export const taskInvocationSchema = z.discriminatedUnion('kind', [
     kind: z.literal('schedule'),
     invokeContext: z.object({
       timestampBucket: z.string(),
-      name: z.string(),
+      triggerKey: z.string(),
       config: z.object({
         interval: z.number().int().positive(),
         unit: z.enum(['minutes', 'hours', 'days']),
       }),
+      runtimeTriggerId: z.guid().optional(),
     }),
     onComplete: taskOnCompleteConfigSchema.array().optional(),
     onProgress: z.array(taskOnProgressConfigSchema).optional(),
@@ -434,6 +450,17 @@ export const taskTriggerConfigSchema = z.discriminatedUnion('kind', [
   scheduleTaskTriggerConfigSchema,
   userActionTaskTriggerConfigSchema,
 ])
+
+// Subset of taskTriggerConfigSchema that an app may add/remove at runtime via
+// the worker socket. user_action triggers are config-only.
+export const registerableTriggerConfigSchema = z.discriminatedUnion('kind', [
+  eventTaskTriggerConfigSchema,
+  scheduleTaskTriggerConfigSchema,
+])
+
+export type RegisterableTriggerConfig = z.infer<
+  typeof registerableTriggerConfigSchema
+>
 
 export type TaskInvocation = z.infer<typeof taskInvocationSchema>
 


### PR DESCRIPTION
## Summary

- New `app_runtime_trigger` entity + `AppRuntimeTriggerService`. Apps can now register/unregister schedule and event triggers at runtime through the socket API, alongside the existing static-config triggers.
- App-socket message handler gains REGISTER / UNREGISTER / LIST messages for runtime triggers; the same surface is exposed on `app-worker-sdk` so runtime workers can manage their own triggers.
- Static-config trigger field `name` → `triggerKey`, so static + runtime triggers share a single stable identity field. (Demo apps + types tests updated.)
- `event.service` and the task scheduling/dispatch path resolve both static and runtime triggers when an event fires.
- New `app-runtime-triggers.e2e-spec.ts` covers register / list / fire / unregister end-to-end.

> Stacked on top of [#266](https://github.com/LombokApp/lombok-web/pull/266) (`lombok/app-uninstall-id-rework`). Coder demo app's matching config rename (`name` → `triggerKey`) is intentionally not in this PR; that lives downstream on `apps/codicle/main`.

Linear: [LOM-331](https://linear.app/lombokapp/issue/LOM-331/runtime-registerable-task-triggers)

## Test plan

- [x] `./dx check all` → all green
- [x] `./dx e2e api` → 584 pass, 0 fail
- [x] Host-runnable unit tests (`api`, `types`, `utils`, `worker-utils`) → all pass; `core-worker` unit suite (requires docker for nsjail) validated on the tip of the stack (#269)
- [ ] From a runtime worker, register a schedule trigger via the SDK and confirm the task fires on the configured interval
- [ ] Register an event trigger, emit a matching event, confirm the task fires
- [ ] Unregister a runtime trigger and confirm subsequent matching events/schedules do not fire it