### PR TITLE
feat(LOM-332): full cron expression based scheduled task triggers

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -93,6 +93,7 @@
         "@nestjs/websockets": "11.1.13",
         "aws4": "1.13.2",
         "cron": "4.4.0",
+        "cron-parser": "catalog:",
         "dockerode": "catalog:",
         "drizzle-orm": "catalog:",
         "express": "5.2.1",
@@ -297,6 +298,7 @@
       "name": "@lombokapp/types",
       "version": "0.0.1",
       "dependencies": {
+        "cron-parser": "catalog:",
         "jexpr": "catalog:",
         "zod": "catalog:",
       },
@@ -558,6 +560,7 @@
     "@typescript-eslint/parser": "8.46.3",
     "@vitejs/plugin-react-swc": "4.2.3",
     "autoprefixer": "10.4.20",
+    "cron-parser": "5.5.0",
     "dockerode": "4.0.9",
     "drizzle-kit": "0.31.8",
     "drizzle-orm": "0.45.1",
@@ -1996,6 +1999,8 @@
     "cpu-features": ["cpu-features@0.0.10", "", { "dependencies": { "buildcheck": "~0.0.6", "nan": "^2.19.0" } }, "sha512-9IkYqtX3YHPCzoVg1Py+o9057a3i0fp7S530UWokCSaFVTc7CwXPRiOjRjBQQ18ZCNafx78YfnG+HALxtVmOGA=="],
 
     "cron": ["cron@4.4.0", "", { "dependencies": { "@types/luxon": "~3.7.0", "luxon": "~3.7.0" } }, "sha512-fkdfq+b+AHI4cKdhZlppHveI/mgz2qpiYxcm+t5E5TsxX7QrLS1VE0+7GENEk9z0EeGPcpSciGv6ez24duWhwQ=="],
+
+    "cron-parser": ["cron-parser@5.5.0", "", { "dependencies": { "luxon": "^3.7.1" } }, "sha512-oML4lKUXxizYswqmxuOCpgFS8BNUJpIu6k/2HVHyaL8Ynnf3wdf9tkns0yRdJLSIjkJ+b0DXHMZEHGpMwjnPww=="],
 
     "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
 

--- a/package.json
+++ b/package.json
@@ -76,7 +76,8 @@
     "tsconfig-paths": "4.2.0",
     "tsup": "8.5.0",
     "jexpr": "1.0.0-pre.9",
-    "jose": "6.2.3"
+    "jose": "6.2.3",
+    "cron-parser": "5.5.0"
   },
   "devDependencies": {
     "@eslint/js": "catalog:",

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -50,6 +50,7 @@
     "@nestjs/websockets": "11.1.13",
     "aws4": "1.13.2",
     "cron": "4.4.0",
+    "cron-parser": "catalog:",
     "dockerode": "catalog:",
     "drizzle-orm": "catalog:",
     "express": "5.2.1",

--- a/packages/api/src/app/tests/app-runtime-triggers.e2e-spec.ts
+++ b/packages/api/src/app/tests/app-runtime-triggers.e2e-spec.ts
@@ -89,7 +89,7 @@ describe('App Runtime Triggers', () => {
   }): RegisterableTriggerConfig => ({
     kind: 'schedule',
     triggerKey: overrides?.triggerKey ?? 'runtime-schedule-1',
-    config: { interval: 1, unit: 'minutes' },
+    config: { kind: 'interval', interval: 1, unit: 'minutes' },
     taskIdentifier: overrides?.taskIdentifier ?? 'socket_test_task',
   })
 

--- a/packages/api/src/event/services/event.service.ts
+++ b/packages/api/src/event/services/event.service.ts
@@ -104,16 +104,6 @@ export class EventService {
     @Inject(forwardRef(() => AppService)) private readonly _appService,
   ) {}
 
-  private getScheduleIntervalMs(scheduleTrigger: ScheduleTaskTriggerConfig) {
-    if (scheduleTrigger.config.unit === 'minutes') {
-      return scheduleTrigger.config.interval * 60 * 1000
-    }
-    if (scheduleTrigger.config.unit === 'hours') {
-      return scheduleTrigger.config.interval * 60 * 60 * 1000
-    }
-    return scheduleTrigger.config.interval * 24 * 60 * 60 * 1000
-  }
-
   private resolveTaskHandler(taskDefinition: AppTaskConfig): {
     handlerType: NewTask['handlerType']
     handlerIdentifier?: NewTask['handlerIdentifier']
@@ -135,7 +125,6 @@ export class EventService {
     this.isProcessingScheduleTriggers = true
     try {
       const now = new Date()
-      const nowMs = now.getTime()
       const enabledApps = await this.ormService.db.query.appsTable.findMany({
         where: eq(appsTable.enabled, true),
         columns: {
@@ -154,8 +143,14 @@ export class EventService {
       }) => {
         const { appConfig, appIdentifier, scheduleTrigger, runtimeTriggerId } =
           input
-        const intervalMs = this.getScheduleIntervalMs(scheduleTrigger)
-        const earliestAllowed = new Date(nowMs - intervalMs)
+        const { bucketStart } = getUtcScheduleBucket(
+          scheduleTrigger.config,
+          now,
+        )
+        // bucketStart anchors both dedupe (idempotency key encodes it) and
+        // the createdAt floor — any task created at-or-after bucketStart with
+        // the same key means this bucket has already fired.
+        const earliestAllowed = bucketStart
 
         const taskDefinition = appConfig.tasks?.find(
           (task) => task.identifier === scheduleTrigger.taskIdentifier,
@@ -176,15 +171,9 @@ export class EventService {
           invocation: {
             kind: 'schedule',
             invokeContext: {
-              timestampBucket: getUtcScheduleBucket(
-                scheduleTrigger.config,
-                now,
-              ).bucketStart.toISOString(),
+              timestampBucket: bucketStart.toISOString(),
               triggerKey: scheduleTrigger.triggerKey,
-              config: {
-                interval: scheduleTrigger.config.interval,
-                unit: scheduleTrigger.config.unit,
-              },
+              config: scheduleTrigger.config,
               ...(runtimeTriggerId ? { runtimeTriggerId } : {}),
             },
           },

--- a/packages/api/src/openapi.json
+++ b/packages/api/src/openapi.json
@@ -10531,6 +10531,9 @@
                                 "$ref": "#/components/schemas/AppInstallResponse__schema0"
                               }
                             },
+                            "triggerKey": {
+                              "type": "string"
+                            },
                             "condition": {
                               "type": "string",
                               "minLength": 1
@@ -10590,28 +10593,56 @@
                               "const": "schedule"
                             },
                             "config": {
-                              "type": "object",
-                              "properties": {
-                                "interval": {
-                                  "type": "integer",
-                                  "exclusiveMinimum": 0,
-                                  "maximum": 9007199254740991
+                              "oneOf": [
+                                {
+                                  "type": "object",
+                                  "properties": {
+                                    "kind": {
+                                      "type": "string",
+                                      "const": "interval"
+                                    },
+                                    "interval": {
+                                      "type": "integer",
+                                      "exclusiveMinimum": 0,
+                                      "maximum": 9007199254740991
+                                    },
+                                    "unit": {
+                                      "type": "string",
+                                      "enum": [
+                                        "minutes",
+                                        "hours",
+                                        "days"
+                                      ]
+                                    }
+                                  },
+                                  "required": [
+                                    "kind",
+                                    "interval",
+                                    "unit"
+                                  ]
                                 },
-                                "unit": {
-                                  "type": "string",
-                                  "enum": [
-                                    "minutes",
-                                    "hours",
-                                    "days"
+                                {
+                                  "type": "object",
+                                  "properties": {
+                                    "kind": {
+                                      "type": "string",
+                                      "const": "cron"
+                                    },
+                                    "expression": {
+                                      "type": "string"
+                                    },
+                                    "timezone": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "kind",
+                                    "expression"
                                   ]
                                 }
-                              },
-                              "required": [
-                                "interval",
-                                "unit"
                               ]
                             },
-                            "name": {
+                            "triggerKey": {
                               "type": "string"
                             },
                             "condition": {
@@ -10662,7 +10693,7 @@
                           "required": [
                             "kind",
                             "config",
-                            "name",
+                            "triggerKey",
                             "taskIdentifier"
                           ]
                         },
@@ -13670,6 +13701,9 @@
                                   "$ref": "#/components/schemas/AppListResponse__schema0"
                                 }
                               },
+                              "triggerKey": {
+                                "type": "string"
+                              },
                               "condition": {
                                 "type": "string",
                                 "minLength": 1
@@ -13729,28 +13763,56 @@
                                 "const": "schedule"
                               },
                               "config": {
-                                "type": "object",
-                                "properties": {
-                                  "interval": {
-                                    "type": "integer",
-                                    "exclusiveMinimum": 0,
-                                    "maximum": 9007199254740991
+                                "oneOf": [
+                                  {
+                                    "type": "object",
+                                    "properties": {
+                                      "kind": {
+                                        "type": "string",
+                                        "const": "interval"
+                                      },
+                                      "interval": {
+                                        "type": "integer",
+                                        "exclusiveMinimum": 0,
+                                        "maximum": 9007199254740991
+                                      },
+                                      "unit": {
+                                        "type": "string",
+                                        "enum": [
+                                          "minutes",
+                                          "hours",
+                                          "days"
+                                        ]
+                                      }
+                                    },
+                                    "required": [
+                                      "kind",
+                                      "interval",
+                                      "unit"
+                                    ]
                                   },
-                                  "unit": {
-                                    "type": "string",
-                                    "enum": [
-                                      "minutes",
-                                      "hours",
-                                      "days"
+                                  {
+                                    "type": "object",
+                                    "properties": {
+                                      "kind": {
+                                        "type": "string",
+                                        "const": "cron"
+                                      },
+                                      "expression": {
+                                        "type": "string"
+                                      },
+                                      "timezone": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "kind",
+                                      "expression"
                                     ]
                                   }
-                                },
-                                "required": [
-                                  "interval",
-                                  "unit"
                                 ]
                               },
-                              "name": {
+                              "triggerKey": {
                                 "type": "string"
                               },
                               "condition": {
@@ -13801,7 +13863,7 @@
                             "required": [
                               "kind",
                               "config",
-                              "name",
+                              "triggerKey",
                               "taskIdentifier"
                             ]
                           },
@@ -16809,6 +16871,9 @@
                                 "$ref": "#/components/schemas/AppGetResponse__schema0"
                               }
                             },
+                            "triggerKey": {
+                              "type": "string"
+                            },
                             "condition": {
                               "type": "string",
                               "minLength": 1
@@ -16868,28 +16933,56 @@
                               "const": "schedule"
                             },
                             "config": {
-                              "type": "object",
-                              "properties": {
-                                "interval": {
-                                  "type": "integer",
-                                  "exclusiveMinimum": 0,
-                                  "maximum": 9007199254740991
+                              "oneOf": [
+                                {
+                                  "type": "object",
+                                  "properties": {
+                                    "kind": {
+                                      "type": "string",
+                                      "const": "interval"
+                                    },
+                                    "interval": {
+                                      "type": "integer",
+                                      "exclusiveMinimum": 0,
+                                      "maximum": 9007199254740991
+                                    },
+                                    "unit": {
+                                      "type": "string",
+                                      "enum": [
+                                        "minutes",
+                                        "hours",
+                                        "days"
+                                      ]
+                                    }
+                                  },
+                                  "required": [
+                                    "kind",
+                                    "interval",
+                                    "unit"
+                                  ]
                                 },
-                                "unit": {
-                                  "type": "string",
-                                  "enum": [
-                                    "minutes",
-                                    "hours",
-                                    "days"
+                                {
+                                  "type": "object",
+                                  "properties": {
+                                    "kind": {
+                                      "type": "string",
+                                      "const": "cron"
+                                    },
+                                    "expression": {
+                                      "type": "string"
+                                    },
+                                    "timezone": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "kind",
+                                    "expression"
                                   ]
                                 }
-                              },
-                              "required": [
-                                "interval",
-                                "unit"
                               ]
                             },
-                            "name": {
+                            "triggerKey": {
                               "type": "string"
                             },
                             "condition": {
@@ -16940,7 +17033,7 @@
                           "required": [
                             "kind",
                             "config",
-                            "name",
+                            "triggerKey",
                             "taskIdentifier"
                           ]
                         },
@@ -19980,6 +20073,9 @@
                                   "$ref": "#/components/schemas/UserAppListResponse__schema0"
                                 }
                               },
+                              "triggerKey": {
+                                "type": "string"
+                              },
                               "condition": {
                                 "type": "string",
                                 "minLength": 1
@@ -20039,28 +20135,56 @@
                                 "const": "schedule"
                               },
                               "config": {
-                                "type": "object",
-                                "properties": {
-                                  "interval": {
-                                    "type": "integer",
-                                    "exclusiveMinimum": 0,
-                                    "maximum": 9007199254740991
+                                "oneOf": [
+                                  {
+                                    "type": "object",
+                                    "properties": {
+                                      "kind": {
+                                        "type": "string",
+                                        "const": "interval"
+                                      },
+                                      "interval": {
+                                        "type": "integer",
+                                        "exclusiveMinimum": 0,
+                                        "maximum": 9007199254740991
+                                      },
+                                      "unit": {
+                                        "type": "string",
+                                        "enum": [
+                                          "minutes",
+                                          "hours",
+                                          "days"
+                                        ]
+                                      }
+                                    },
+                                    "required": [
+                                      "kind",
+                                      "interval",
+                                      "unit"
+                                    ]
                                   },
-                                  "unit": {
-                                    "type": "string",
-                                    "enum": [
-                                      "minutes",
-                                      "hours",
-                                      "days"
+                                  {
+                                    "type": "object",
+                                    "properties": {
+                                      "kind": {
+                                        "type": "string",
+                                        "const": "cron"
+                                      },
+                                      "expression": {
+                                        "type": "string"
+                                      },
+                                      "timezone": {
+                                        "type": "string"
+                                      }
+                                    },
+                                    "required": [
+                                      "kind",
+                                      "expression"
                                     ]
                                   }
-                                },
-                                "required": [
-                                  "interval",
-                                  "unit"
                                 ]
                               },
-                              "name": {
+                              "triggerKey": {
                                 "type": "string"
                               },
                               "condition": {
@@ -20111,7 +20235,7 @@
                             "required": [
                               "kind",
                               "config",
-                              "name",
+                              "triggerKey",
                               "taskIdentifier"
                             ]
                           },
@@ -22994,6 +23118,9 @@
                                 "$ref": "#/components/schemas/UserAppGetResponse__schema0"
                               }
                             },
+                            "triggerKey": {
+                              "type": "string"
+                            },
                             "condition": {
                               "type": "string",
                               "minLength": 1
@@ -23053,28 +23180,56 @@
                               "const": "schedule"
                             },
                             "config": {
-                              "type": "object",
-                              "properties": {
-                                "interval": {
-                                  "type": "integer",
-                                  "exclusiveMinimum": 0,
-                                  "maximum": 9007199254740991
+                              "oneOf": [
+                                {
+                                  "type": "object",
+                                  "properties": {
+                                    "kind": {
+                                      "type": "string",
+                                      "const": "interval"
+                                    },
+                                    "interval": {
+                                      "type": "integer",
+                                      "exclusiveMinimum": 0,
+                                      "maximum": 9007199254740991
+                                    },
+                                    "unit": {
+                                      "type": "string",
+                                      "enum": [
+                                        "minutes",
+                                        "hours",
+                                        "days"
+                                      ]
+                                    }
+                                  },
+                                  "required": [
+                                    "kind",
+                                    "interval",
+                                    "unit"
+                                  ]
                                 },
-                                "unit": {
-                                  "type": "string",
-                                  "enum": [
-                                    "minutes",
-                                    "hours",
-                                    "days"
+                                {
+                                  "type": "object",
+                                  "properties": {
+                                    "kind": {
+                                      "type": "string",
+                                      "const": "cron"
+                                    },
+                                    "expression": {
+                                      "type": "string"
+                                    },
+                                    "timezone": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "kind",
+                                    "expression"
                                   ]
                                 }
-                              },
-                              "required": [
-                                "interval",
-                                "unit"
                               ]
                             },
-                            "name": {
+                            "triggerKey": {
                               "type": "string"
                             },
                             "condition": {
@@ -23125,7 +23280,7 @@
                           "required": [
                             "kind",
                             "config",
-                            "name",
+                            "triggerKey",
                             "taskIdentifier"
                           ]
                         },
@@ -30572,6 +30727,14 @@
                             "minimum": -9007199254740991,
                             "maximum": 9007199254740991
                           },
+                          "runtimeTriggerId": {
+                            "type": "string",
+                            "format": "uuid",
+                            "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12})$"
+                          },
+                          "triggerKey": {
+                            "type": "string"
+                          },
                           "dataTemplate": {
                             "type": "object",
                             "propertyNames": {
@@ -30616,7 +30779,6 @@
                           "eventId",
                           "emitterId",
                           "eventIdentifier",
-                          "eventTriggerConfigIndex",
                           "eventData"
                         ]
                       },
@@ -30674,35 +30836,68 @@
                           "timestampBucket": {
                             "type": "string"
                           },
-                          "name": {
+                          "triggerKey": {
                             "type": "string"
                           },
                           "config": {
-                            "type": "object",
-                            "properties": {
-                              "interval": {
-                                "type": "integer",
-                                "exclusiveMinimum": 0,
-                                "maximum": 9007199254740991
+                            "oneOf": [
+                              {
+                                "type": "object",
+                                "properties": {
+                                  "kind": {
+                                    "type": "string",
+                                    "const": "interval"
+                                  },
+                                  "interval": {
+                                    "type": "integer",
+                                    "exclusiveMinimum": 0,
+                                    "maximum": 9007199254740991
+                                  },
+                                  "unit": {
+                                    "type": "string",
+                                    "enum": [
+                                      "minutes",
+                                      "hours",
+                                      "days"
+                                    ]
+                                  }
+                                },
+                                "required": [
+                                  "kind",
+                                  "interval",
+                                  "unit"
+                                ]
                               },
-                              "unit": {
-                                "type": "string",
-                                "enum": [
-                                  "minutes",
-                                  "hours",
-                                  "days"
+                              {
+                                "type": "object",
+                                "properties": {
+                                  "kind": {
+                                    "type": "string",
+                                    "const": "cron"
+                                  },
+                                  "expression": {
+                                    "type": "string"
+                                  },
+                                  "timezone": {
+                                    "type": "string"
+                                  }
+                                },
+                                "required": [
+                                  "kind",
+                                  "expression"
                                 ]
                               }
-                            },
-                            "required": [
-                              "interval",
-                              "unit"
                             ]
+                          },
+                          "runtimeTriggerId": {
+                            "type": "string",
+                            "format": "uuid",
+                            "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12})$"
                           }
                         },
                         "required": [
                           "timestampBucket",
-                          "name",
+                          "triggerKey",
                           "config"
                         ]
                       },
@@ -31772,6 +31967,14 @@
                               "minimum": -9007199254740991,
                               "maximum": 9007199254740991
                             },
+                            "runtimeTriggerId": {
+                              "type": "string",
+                              "format": "uuid",
+                              "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12})$"
+                            },
+                            "triggerKey": {
+                              "type": "string"
+                            },
                             "dataTemplate": {
                               "type": "object",
                               "propertyNames": {
@@ -31816,7 +32019,6 @@
                             "eventId",
                             "emitterId",
                             "eventIdentifier",
-                            "eventTriggerConfigIndex",
                             "eventData"
                           ]
                         },
@@ -31874,35 +32076,68 @@
                             "timestampBucket": {
                               "type": "string"
                             },
-                            "name": {
+                            "triggerKey": {
                               "type": "string"
                             },
                             "config": {
-                              "type": "object",
-                              "properties": {
-                                "interval": {
-                                  "type": "integer",
-                                  "exclusiveMinimum": 0,
-                                  "maximum": 9007199254740991
+                              "oneOf": [
+                                {
+                                  "type": "object",
+                                  "properties": {
+                                    "kind": {
+                                      "type": "string",
+                                      "const": "interval"
+                                    },
+                                    "interval": {
+                                      "type": "integer",
+                                      "exclusiveMinimum": 0,
+                                      "maximum": 9007199254740991
+                                    },
+                                    "unit": {
+                                      "type": "string",
+                                      "enum": [
+                                        "minutes",
+                                        "hours",
+                                        "days"
+                                      ]
+                                    }
+                                  },
+                                  "required": [
+                                    "kind",
+                                    "interval",
+                                    "unit"
+                                  ]
                                 },
-                                "unit": {
-                                  "type": "string",
-                                  "enum": [
-                                    "minutes",
-                                    "hours",
-                                    "days"
+                                {
+                                  "type": "object",
+                                  "properties": {
+                                    "kind": {
+                                      "type": "string",
+                                      "const": "cron"
+                                    },
+                                    "expression": {
+                                      "type": "string"
+                                    },
+                                    "timezone": {
+                                      "type": "string"
+                                    }
+                                  },
+                                  "required": [
+                                    "kind",
+                                    "expression"
                                   ]
                                 }
-                              },
-                              "required": [
-                                "interval",
-                                "unit"
                               ]
+                            },
+                            "runtimeTriggerId": {
+                              "type": "string",
+                              "format": "uuid",
+                              "pattern": "^([0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12})$"
                             }
                           },
                           "required": [
                             "timestampBucket",
-                            "name",
+                            "triggerKey",
                             "config"
                           ]
                         },

--- a/packages/api/src/task/tasks.e2e-spec.ts
+++ b/packages/api/src/task/tasks.e2e-spec.ts
@@ -52,9 +52,35 @@ const TEST_EXECUTOR_METADATA_PARTIAL = {
 const getTaskByIdentifier = async (
   testModuleRef: TestModule,
   identifier: string,
+  filter?: { invocationKind?: string; invocationTriggerKey?: string },
 ) => {
-  return testModuleRef.services.ormService.db.query.tasksTable.findFirst({
-    where: eq(tasksTable.taskIdentifier, identifier),
+  const all =
+    await testModuleRef.services.ormService.db.query.tasksTable.findMany({
+      where: eq(tasksTable.taskIdentifier, identifier),
+    })
+  if (!filter) {
+    return all[0]
+  }
+  return all.find((task) => {
+    if (
+      filter.invocationKind &&
+      task.invocation.kind !== filter.invocationKind
+    ) {
+      return false
+    }
+    if (filter.invocationTriggerKey) {
+      if (
+        task.invocation.kind !== 'schedule' &&
+        task.invocation.kind !== 'event'
+      ) {
+        return false
+      }
+      const ctx = task.invocation.invokeContext as { triggerKey?: string }
+      if (ctx.triggerKey !== filter.invocationTriggerKey) {
+        return false
+      }
+    }
+    return true
   })
 }
 
@@ -923,7 +949,10 @@ describe('Task lifecycle', () => {
 
     await testModule!.services.eventService.processScheduledTaskTriggers()
 
-    const firstTask = await getTaskByIdentifier(testModule!, SCHEDULE_TASK_ID)
+    const firstTask = await getTaskByIdentifier(testModule!, SCHEDULE_TASK_ID, {
+      invocationKind: 'schedule',
+      invocationTriggerKey: 'dummy_schedule',
+    })
     if (!firstTask) {
       throw new Error('Schedule task was not created.')
     }
@@ -932,6 +961,7 @@ describe('Task lifecycle', () => {
       expect(firstTask.invocation.invokeContext).toEqual({
         triggerKey: 'dummy_schedule',
         config: {
+          kind: 'interval',
           interval: 1,
           unit: 'hours',
         },
@@ -955,7 +985,55 @@ describe('Task lifecycle', () => {
         where: eq(tasksTable.taskIdentifier, SCHEDULE_TASK_ID),
       })
 
-    expect(existingTasks.length).toBe(1)
+    // Two distinct trigger keys (interval + cron `* * * * *`) -> one task each
+    // per poll, deduped on subsequent polls within the same bucket.
+    expect(existingTasks.length).toBe(2)
+  })
+
+  it('creates cron-triggered tasks with the prev fire as bucket and dedupes within bucket', async () => {
+    await testModule?.installLocalAppBundles([LIFECYCLE_APP_SLUG])
+
+    await testModule!.services.eventService.processScheduledTaskTriggers()
+
+    const cronTask = await getTaskByIdentifier(testModule!, SCHEDULE_TASK_ID, {
+      invocationKind: 'schedule',
+      invocationTriggerKey: 'dummy_cron_schedule',
+    })
+    if (!cronTask) {
+      throw new Error('Cron-triggered schedule task was not created.')
+    }
+
+    if (cronTask.invocation.kind !== 'schedule') {
+      throw new Error('Schedule task trigger was not schedule.')
+    }
+    expect(cronTask.invocation.invokeContext.config).toEqual({
+      kind: 'cron',
+      expression: '* * * * *',
+    })
+    expect(cronTask.invocation.invokeContext.triggerKey).toBe(
+      'dummy_cron_schedule',
+    )
+    // For `* * * * *`, the bucket is the most recent whole minute at-or-before
+    // the task's createdAt — i.e. createdAt truncated to seconds=0,ms=0.
+    const expectedBucket = new Date(cronTask.createdAt)
+    expectedBucket.setUTCSeconds(0, 0)
+    expect(cronTask.invocation.invokeContext.timestampBucket).toBe(
+      expectedBucket.toISOString(),
+    )
+
+    // Second poll within the same minute should not produce another cron task.
+    await testModule!.services.eventService.processScheduledTaskTriggers()
+
+    const cronTasks =
+      await testModule!.services.ormService.db.query.tasksTable.findMany({
+        where: eq(tasksTable.taskIdentifier, SCHEDULE_TASK_ID),
+      })
+    const cronOnly = cronTasks.filter(
+      (t) =>
+        t.invocation.kind === 'schedule' &&
+        t.invocation.invokeContext.triggerKey === 'dummy_cron_schedule',
+    )
+    expect(cronOnly.length).toBe(1)
   })
 
   it('creates a user_action task and tracks lifecycle fields', async () => {

--- a/packages/api/src/task/util/schedule-bucket.util.ts
+++ b/packages/api/src/task/util/schedule-bucket.util.ts
@@ -1,12 +1,27 @@
 import type { ScheduleConfig } from '@lombokapp/types'
+import { CronExpressionParser } from 'cron-parser'
 import { getUtcTimestampBucket } from 'src/shared/utils/timestamp.util'
 
 export function getUtcScheduleBucket(
   schedule: ScheduleConfig,
   at: Date,
 ): {
-  bucketIndex: number
   bucketStart: Date
 } {
-  return getUtcTimestampBucket(schedule.interval, schedule.unit, at)
+  if (schedule.kind === 'interval') {
+    return getUtcTimestampBucket(schedule.interval, schedule.unit, at)
+  }
+  // cron: prev fire time at or before `at`, in the schedule's timezone.
+  // cron-parser semantics: prev() returns the most recent fire strictly before
+  // currentDate, so we pass currentDate one millisecond past `at` to include a
+  // fire scheduled exactly at `at`.
+  const parsed = CronExpressionParser.parse(schedule.expression, {
+    currentDate: new Date(at.getTime() + 1),
+    tz: schedule.timezone ?? 'UTC',
+  })
+  const bucketStart = parsed.prev().toDate()
+  // Truncate to the start of the minute. Cron is minute-granular; without
+  // truncation, idempotency-bucket strings could vary by milliseconds.
+  bucketStart.setUTCSeconds(0, 0)
+  return { bucketStart }
 }

--- a/packages/api/test/e2e.setup.ts
+++ b/packages/api/test/e2e.setup.ts
@@ -159,8 +159,18 @@ const testAppDefinitions: AppConfig[] = [
         kind: 'schedule',
         triggerKey: 'dummy_schedule',
         config: {
+          kind: 'interval',
           interval: 1,
           unit: 'hours',
+        },
+        taskIdentifier: 'lifecycle_schedule_task',
+      },
+      {
+        kind: 'schedule',
+        triggerKey: 'dummy_cron_schedule',
+        config: {
+          kind: 'cron',
+          expression: '* * * * *',
         },
         taskIdentifier: 'lifecycle_schedule_task',
       },

--- a/packages/demo-apps/simple-demo/config.json
+++ b/packages/demo-apps/simple-demo/config.json
@@ -27,8 +27,19 @@
       "kind": "schedule",
       "triggerKey": "hourly_job",
       "config": {
+        "kind": "interval",
         "interval": 1,
         "unit": "hours"
+      },
+      "taskIdentifier": "demo_scheduled_worker_task"
+    },
+    {
+      "kind": "schedule",
+      "triggerKey": "weekday_morning_job",
+      "config": {
+        "kind": "cron",
+        "expression": "0 9 * * 1-5",
+        "timezone": "UTC"
       },
       "taskIdentifier": "demo_scheduled_worker_task"
     }

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -37,6 +37,7 @@
     "tsup": "catalog:"
   },
   "dependencies": {
+    "cron-parser": "catalog:",
     "jexpr": "catalog:",
     "zod": "catalog:"
   }

--- a/packages/types/src/__tests__/apps.types.test.ts
+++ b/packages/types/src/__tests__/apps.types.test.ts
@@ -369,6 +369,7 @@ describe('apps.types', () => {
             kind: 'schedule',
             triggerKey: 'hourly_job',
             config: {
+              kind: 'interval',
               interval: 1,
               unit: 'hours',
             },
@@ -426,6 +427,7 @@ describe('apps.types', () => {
             kind: 'schedule',
             triggerKey: 'hourly_job',
             config: {
+              kind: 'interval',
               interval: 1,
               unit: 'hours',
             },

--- a/packages/types/src/__tests__/task.types.test.ts
+++ b/packages/types/src/__tests__/task.types.test.ts
@@ -6,6 +6,8 @@ type SafeParseReturnType<Input, Output> =
   | { success: false; error: z.ZodError<Input> }
 
 import {
+  scheduleConfigSchema,
+  scheduleTaskTriggerConfigSchema,
   storageAccessPolicySchema,
   taskConfigSchema,
   taskDataSchema,
@@ -471,6 +473,97 @@ describe('task.types', () => {
       }
       const result = taskConfigSchema.safeParse(invalidTask)
       expectZodFailure(result)
+    })
+  })
+
+  describe('scheduleConfigSchema', () => {
+    it('accepts interval kind', () => {
+      const result = scheduleConfigSchema.safeParse({
+        kind: 'interval',
+        interval: 30,
+        unit: 'minutes',
+      })
+      expectZodSuccess(result)
+    })
+
+    it('rejects flat (legacy) shape without kind', () => {
+      const result = scheduleConfigSchema.safeParse({
+        interval: 30,
+        unit: 'minutes',
+      })
+      expectZodFailure(result)
+    })
+
+    it('accepts cron kind without timezone', () => {
+      const result = scheduleConfigSchema.safeParse({
+        kind: 'cron',
+        expression: '0 9 * * 1-5',
+      })
+      expectZodSuccess(result)
+    })
+
+    it('accepts cron kind with valid IANA timezone', () => {
+      const result = scheduleConfigSchema.safeParse({
+        kind: 'cron',
+        expression: '*/15 * * * *',
+        timezone: 'America/New_York',
+      })
+      expectZodSuccess(result)
+    })
+
+    it('rejects cron with invalid expression', () => {
+      const result = scheduleConfigSchema.safeParse({
+        kind: 'cron',
+        expression: 'not a cron',
+      })
+      expectZodFailure(result)
+    })
+
+    it('rejects 6-field cron (sub-minute granularity not supported)', () => {
+      const result = scheduleConfigSchema.safeParse({
+        kind: 'cron',
+        expression: '0 0 9 * * 1-5',
+      })
+      expectZodFailure(result)
+    })
+
+    it('rejects cron with bogus timezone', () => {
+      const result = scheduleConfigSchema.safeParse({
+        kind: 'cron',
+        expression: '0 9 * * 1-5',
+        timezone: 'Mars/Olympus_Mons',
+      })
+      expectZodFailure(result)
+    })
+  })
+
+  describe('scheduleTaskTriggerConfigSchema', () => {
+    it('accepts a cron-form trigger', () => {
+      const result = scheduleTaskTriggerConfigSchema.safeParse({
+        kind: 'schedule',
+        triggerKey: 'weekday_digest',
+        taskIdentifier: 'send_digest',
+        config: {
+          kind: 'cron',
+          expression: '0 9 * * 1-5',
+          timezone: 'America/New_York',
+        },
+      })
+      expectZodSuccess(result)
+    })
+
+    it('accepts an interval-form trigger', () => {
+      const result = scheduleTaskTriggerConfigSchema.safeParse({
+        kind: 'schedule',
+        triggerKey: 'half_hourly',
+        taskIdentifier: 'poll_inbox',
+        config: {
+          kind: 'interval',
+          interval: 30,
+          unit: 'minutes',
+        },
+      })
+      expectZodSuccess(result)
     })
   })
 })

--- a/packages/types/src/api-paths.d.ts
+++ b/packages/types/src/api-paths.d.ts
@@ -2100,6 +2100,7 @@ export interface components {
                         dataTemplate?: {
                             [key: string]: components["schemas"]["AppInstallResponse__schema0"];
                         };
+                        triggerKey?: string;
                         condition?: string;
                         taskIdentifier: string;
                         onComplete?: components["schemas"]["AppInstallResponse__schema1"][];
@@ -2114,11 +2115,18 @@ export interface components {
                         /** @constant */
                         kind: "schedule";
                         config: {
+                            /** @constant */
+                            kind: "interval";
                             interval: number;
                             /** @enum {string} */
                             unit: "minutes" | "hours" | "days";
+                        } | {
+                            /** @constant */
+                            kind: "cron";
+                            expression: string;
+                            timezone?: string;
                         };
-                        name: string;
+                        triggerKey: string;
                         condition?: string;
                         taskIdentifier: string;
                         onComplete?: components["schemas"]["AppInstallResponse__schema1"][];
@@ -2800,6 +2808,7 @@ export interface components {
                         dataTemplate?: {
                             [key: string]: components["schemas"]["AppListResponse__schema0"];
                         };
+                        triggerKey?: string;
                         condition?: string;
                         taskIdentifier: string;
                         onComplete?: components["schemas"]["AppListResponse__schema1"][];
@@ -2814,11 +2823,18 @@ export interface components {
                         /** @constant */
                         kind: "schedule";
                         config: {
+                            /** @constant */
+                            kind: "interval";
                             interval: number;
                             /** @enum {string} */
                             unit: "minutes" | "hours" | "days";
+                        } | {
+                            /** @constant */
+                            kind: "cron";
+                            expression: string;
+                            timezone?: string;
                         };
-                        name: string;
+                        triggerKey: string;
                         condition?: string;
                         taskIdentifier: string;
                         onComplete?: components["schemas"]["AppListResponse__schema1"][];
@@ -3500,6 +3516,7 @@ export interface components {
                         dataTemplate?: {
                             [key: string]: components["schemas"]["AppGetResponse__schema0"];
                         };
+                        triggerKey?: string;
                         condition?: string;
                         taskIdentifier: string;
                         onComplete?: components["schemas"]["AppGetResponse__schema1"][];
@@ -3514,11 +3531,18 @@ export interface components {
                         /** @constant */
                         kind: "schedule";
                         config: {
+                            /** @constant */
+                            kind: "interval";
                             interval: number;
                             /** @enum {string} */
                             unit: "minutes" | "hours" | "days";
+                        } | {
+                            /** @constant */
+                            kind: "cron";
+                            expression: string;
+                            timezone?: string;
                         };
-                        name: string;
+                        triggerKey: string;
                         condition?: string;
                         taskIdentifier: string;
                         onComplete?: components["schemas"]["AppGetResponse__schema1"][];
@@ -4209,6 +4233,7 @@ export interface components {
                         dataTemplate?: {
                             [key: string]: components["schemas"]["UserAppListResponse__schema0"];
                         };
+                        triggerKey?: string;
                         condition?: string;
                         taskIdentifier: string;
                         onComplete?: components["schemas"]["UserAppListResponse__schema1"][];
@@ -4223,11 +4248,18 @@ export interface components {
                         /** @constant */
                         kind: "schedule";
                         config: {
+                            /** @constant */
+                            kind: "interval";
                             interval: number;
                             /** @enum {string} */
                             unit: "minutes" | "hours" | "days";
+                        } | {
+                            /** @constant */
+                            kind: "cron";
+                            expression: string;
+                            timezone?: string;
                         };
-                        name: string;
+                        triggerKey: string;
                         condition?: string;
                         taskIdentifier: string;
                         onComplete?: components["schemas"]["UserAppListResponse__schema1"][];
@@ -4881,6 +4913,7 @@ export interface components {
                         dataTemplate?: {
                             [key: string]: components["schemas"]["UserAppGetResponse__schema0"];
                         };
+                        triggerKey?: string;
                         condition?: string;
                         taskIdentifier: string;
                         onComplete?: components["schemas"]["UserAppGetResponse__schema1"][];
@@ -4895,11 +4928,18 @@ export interface components {
                         /** @constant */
                         kind: "schedule";
                         config: {
+                            /** @constant */
+                            kind: "interval";
                             interval: number;
                             /** @enum {string} */
                             unit: "minutes" | "hours" | "days";
+                        } | {
+                            /** @constant */
+                            kind: "cron";
+                            expression: string;
+                            timezone?: string;
                         };
-                        name: string;
+                        triggerKey: string;
                         condition?: string;
                         taskIdentifier: string;
                         onComplete?: components["schemas"]["UserAppGetResponse__schema1"][];
@@ -6606,7 +6646,10 @@ export interface components {
                         eventId: string;
                         emitterId: string;
                         eventIdentifier: string;
-                        eventTriggerConfigIndex: number;
+                        eventTriggerConfigIndex?: number;
+                        /** Format: uuid */
+                        runtimeTriggerId?: string;
+                        triggerKey?: string;
                         dataTemplate?: {
                             [key: string]: components["schemas"]["TaskGetResponse__schema0"];
                         };
@@ -6634,12 +6677,21 @@ export interface components {
                     kind: "schedule";
                     invokeContext: {
                         timestampBucket: string;
-                        name: string;
+                        triggerKey: string;
                         config: {
+                            /** @constant */
+                            kind: "interval";
                             interval: number;
                             /** @enum {string} */
                             unit: "minutes" | "hours" | "days";
+                        } | {
+                            /** @constant */
+                            kind: "cron";
+                            expression: string;
+                            timezone?: string;
                         };
+                        /** Format: uuid */
+                        runtimeTriggerId?: string;
                     };
                     onComplete?: components["schemas"]["TaskGetResponse__schema1"][];
                     onProgress?: {
@@ -6914,7 +6966,10 @@ export interface components {
                         eventId: string;
                         emitterId: string;
                         eventIdentifier: string;
-                        eventTriggerConfigIndex: number;
+                        eventTriggerConfigIndex?: number;
+                        /** Format: uuid */
+                        runtimeTriggerId?: string;
+                        triggerKey?: string;
                         dataTemplate?: {
                             [key: string]: components["schemas"]["TaskListResponse__schema0"];
                         };
@@ -6942,12 +6997,21 @@ export interface components {
                     kind: "schedule";
                     invokeContext: {
                         timestampBucket: string;
-                        name: string;
+                        triggerKey: string;
                         config: {
+                            /** @constant */
+                            kind: "interval";
                             interval: number;
                             /** @enum {string} */
                             unit: "minutes" | "hours" | "days";
+                        } | {
+                            /** @constant */
+                            kind: "cron";
+                            expression: string;
+                            timezone?: string;
                         };
+                        /** Format: uuid */
+                        runtimeTriggerId?: string;
                     };
                     onComplete?: components["schemas"]["TaskListResponse__schema1"][];
                     onProgress?: {

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -1,5 +1,6 @@
 export * from './apps.types'
 export * from './condition-validation.util'
+export * from './schedule-validation.util'
 export * from './content.types'
 export * from './folder.types'
 export * from './messages.types'

--- a/packages/types/src/schedule-validation.util.ts
+++ b/packages/types/src/schedule-validation.util.ts
@@ -1,0 +1,25 @@
+import { CronExpressionParser } from 'cron-parser'
+
+// Reject 6-field expressions (seconds). The platform's schedule polling cadence
+// is 1 minute, so sub-minute granularity would over-promise.
+export function isValidCronExpression(expression: string): boolean {
+  const fields = expression.trim().split(/\s+/)
+  if (fields.length !== 5) {
+    return false
+  }
+  try {
+    CronExpressionParser.parse(expression)
+    return true
+  } catch {
+    return false
+  }
+}
+
+export function isValidIanaTimezone(timezone: string): boolean {
+  try {
+    new Intl.DateTimeFormat('en-US', { timeZone: timezone })
+    return true
+  } catch {
+    return false
+  }
+}

--- a/packages/types/src/task.types.ts
+++ b/packages/types/src/task.types.ts
@@ -9,6 +9,10 @@ import { targetLocationContextDTOSchema } from './folder.types'
 import { taskIdentifierSchema } from './identifiers.types'
 import type { JsonSerializableObject } from './json.types'
 import { jsonSerializableObjectSchema } from './json.types'
+import {
+  isValidCronExpression,
+  isValidIanaTimezone,
+} from './schedule-validation.util'
 import { SignedURLsRequestMethod } from './storage.types'
 
 export type TaskData = JsonSerializableObject
@@ -172,10 +176,39 @@ const taskTriggerConfigBaseSchema = z.object({
 
 export const scheduleUnitSchema = z.enum(['minutes', 'hours', 'days'])
 export type ScheduleUnit = z.infer<typeof scheduleUnitSchema>
-export const scheduleConfigSchema = z.object({
+
+export const scheduleIntervalConfigSchema = z.object({
+  kind: z.literal('interval'),
   interval: z.number().int().positive(),
   unit: scheduleUnitSchema,
 })
+export type ScheduleIntervalConfig = z.infer<
+  typeof scheduleIntervalConfigSchema
+>
+
+export const scheduleCronConfigSchema = z.object({
+  kind: z.literal('cron'),
+  // Standard 5-field cron (minute hour dom month dow). Sub-minute granularity
+  // is intentionally rejected — the platform's schedule poll cadence is 1m.
+  expression: z
+    .string()
+    .refine(
+      isValidCronExpression,
+      'invalid cron expression (5-field required)',
+    ),
+  // IANA timezone (e.g. "America/New_York"). Defaults to UTC at evaluation
+  // time when omitted.
+  timezone: z
+    .string()
+    .refine(isValidIanaTimezone, 'invalid IANA timezone')
+    .optional(),
+})
+export type ScheduleCronConfig = z.infer<typeof scheduleCronConfigSchema>
+
+export const scheduleConfigSchema = z.discriminatedUnion('kind', [
+  scheduleIntervalConfigSchema,
+  scheduleCronConfigSchema,
+])
 export type ScheduleConfig = z.infer<typeof scheduleConfigSchema>
 
 export const scheduleTaskTriggerConfigSchema = z
@@ -390,10 +423,7 @@ export const taskInvocationSchema = z.discriminatedUnion('kind', [
     invokeContext: z.object({
       timestampBucket: z.string(),
       triggerKey: z.string(),
-      config: z.object({
-        interval: z.number().int().positive(),
-        unit: z.enum(['minutes', 'hours', 'days']),
-      }),
+      config: scheduleConfigSchema,
       runtimeTriggerId: z.guid().optional(),
     }),
     onComplete: taskOnCompleteConfigSchema.array().optional(),

--- a/packages/ui/src/utils/trigger-utils.ts
+++ b/packages/ui/src/utils/trigger-utils.ts
@@ -7,15 +7,24 @@ type ConfigurableTrigger =
       kind: 'event'
       eventIdentifier: string
       taskIdentifier: string
+      triggerKey?: string
       dataTemplate?: Record<string, unknown>
       onComplete?: unknown[]
     }
   | {
       kind: 'schedule'
-      config: {
-        interval: number
-        unit: 'minutes' | 'hours' | 'days'
-      }
+      triggerKey: string
+      config:
+        | {
+            kind: 'interval'
+            interval: number
+            unit: 'minutes' | 'hours' | 'days'
+          }
+        | {
+            kind: 'cron'
+            expression: string
+            timezone?: string
+          }
       taskIdentifier: string
       onComplete?: unknown[]
     }
@@ -46,6 +55,10 @@ export function formatTriggerLabel(trigger: ConfigurableTrigger): string {
   }
 
   if (trigger.kind === 'schedule') {
+    if (trigger.config.kind === 'cron') {
+      const tz = trigger.config.timezone ? ` ${trigger.config.timezone}` : ''
+      return `schedule (cron: ${trigger.config.expression}${tz})`
+    }
     const { interval, unit } = trigger.config
     const unitLabel = interval === 1 ? unit.slice(0, -1) : unit
     return `schedule (every ${interval} ${unitLabel})`


### PR DESCRIPTION
## Summary

- `schedule` trigger config becomes a discriminated union: `{ kind: 'interval', interval, unit }` (existing) **or** `{ kind: 'cron', expression, timezone? }` (new, full cron expression + optional IANA tz).
- New `schedule-validation.util` validates cron expressions at config parse time so bad expressions fail loud on app install / runtime-register, not at the next tick.
- `schedule-bucket.util` updated to bucket cron-driven schedules alongside interval-driven ones; `event.service` resolves cron triggers on tick and dispatches the matching tasks.
- `formatTriggerLabel` in the UI handles the new cron variant.
- E2e coverage added in `app-runtime-triggers.e2e-spec.ts` + `tasks.e2e-spec.ts`; openapi.json regenerated.

> Stacked on top of [#267](https://github.com/LombokApp/lombok-web/pull/267) (`lombok/runtime-task-triggers`).

Linear: [LOM-332](https://linear.app/lombokapp/issue/LOM-332/full-cron-expression-support-for-scheduled-task-triggers)

## Test plan

- [x] `./dx check all` → all green
- [x] `./dx e2e api` → 585 pass, 0 fail
- [x] Host-runnable unit tests (`api`, `types`, `utils`, `worker-utils`) → all pass; `core-worker` unit suite (requires docker for nsjail) validated on the tip of the stack (#269)
- [ ] Install an app whose config declares a cron trigger; confirm it fires on schedule in a non-UTC timezone
- [ ] Register a cron trigger at runtime via `app-worker-sdk`; confirm tick dispatches and `formatTriggerLabel` renders the expression in the apps server UI
- [ ] Submit an invalid cron expression and confirm install/registration is rejected at parse time