### PR TITLE
chore(LOM-334): live-edit dev-entrypoint.sh without image rebuild

### DIFF
--- a/docker/app.Dockerfile
+++ b/docker/app.Dockerfile
@@ -15,9 +15,6 @@ FROM base AS dev
 
 COPY . .
 
-# cp the dev entrypoint script to 1 dir above the root (to keep it out of the way of local volume mappings)
-COPY packages/api/cmd/dev-entrypoint.sh ../dev-entrypoint.sh
-
 RUN apk add --no-cache \
   curl \
   git \
@@ -45,7 +42,7 @@ RUN mkdir -p /var/lib/minio/data && \
 
 RUN chown -R bun:bun . && su-exec bun bun install --frozen-lockfile
 
-ENTRYPOINT ["sh", "../dev-entrypoint.sh"]
+ENTRYPOINT ["sh", "packages/api/cmd/dev-entrypoint.sh"]
 
 FROM dev AS test
 

--- a/packages/api/cmd/dev-entrypoint.sh
+++ b/packages/api/cmd/dev-entrypoint.sh
@@ -4,9 +4,7 @@ APP_USER=bun
 PLATFORM_HOST="${PLATFORM_HOST:-lombok.localhost}"
 APP_UI_HOST="${APP_UI_HOST:-http://127.0.0.1:3001}"
 
-# Change to ./app relative to this script's location
-SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
-cd "$SCRIPT_DIR/app" || { echo "Error: Cannot cd to $SCRIPT_DIR/app"; exit 1; }
+cd /usr/src/app || { echo "Error: Cannot cd to /usr/src/app"; exit 1; }
 
 # Clean up background processes on exit
 cleanup() {


### PR DESCRIPTION
## Summary

- Drop `COPY packages/api/cmd/dev-entrypoint.sh ../dev-entrypoint.sh` and point `ENTRYPOINT` at the bind-mounted `packages/api/cmd/dev-entrypoint.sh` so the dev entrypoint is live-editable.
- Replace the `SCRIPT_DIR`-relative `cd "$SCRIPT_DIR/app"` (which assumed the script lived one dir above the repo root) with a direct `cd /usr/src/app`.
- `dev-nginx.conf` was already live-editable via the bind-mount; this change makes the entrypoint behave the same way.

Linear: [LOM-334](https://linear.app/lombokapp/issue/LOM-334/live-edit-dev-entrypointsh-without-image-rebuild)

## Why

Iterating on entrypoint logic (postgres/minio setup, nginx config templating, vite/bun bootstrapping) previously required a full image rebuild before each test cycle. The `1 dir above the root` placement was defensive against the `./:/usr/src/app:cached` bind-mount, but it's exactly what blocks live edits — the running entrypoint lived where the bind-mount can't reach. The `COPY . .` already ships the script into the image at the same path for image-only runs, so dropping the parallel copy doesn't break standalone builds.

## Test plan

- [ ] `./dx down && docker compose build api && ./dx up -d` boots cleanly.
- [ ] Add `echo "ENTRYPOINT-EDIT-MARKER"` near the top of `packages/api/cmd/dev-entrypoint.sh`, `docker compose restart api`, then `docker compose logs api | grep ENTRYPOINT-EDIT-MARKER` — marker appears without a rebuild.
- [ ] Add a `# nginx-edit-marker` comment to `packages/api/nginx/dev-nginx.conf`, `docker compose restart api`, then `docker compose exec api grep nginx-edit-marker /etc/nginx/http.d/default.conf` — marker appears.
- [ ] Revert markers, confirm dev environment still boots and is reachable at `http://lombok.localhost:8080`.