### PR TITLE
fix(LOM-335): expose installed appIdentifier through the app-browser-sdk

### DIFF
--- a/packages/app-browser-sdk/src/app-browser-sdk.ts
+++ b/packages/app-browser-sdk/src/app-browser-sdk.ts
@@ -81,7 +81,7 @@ export class AppBrowserSdk implements AppBrowserSdkInstance {
     return `${protocol}//${hostname}${port ? `:${port}` : ''}`
   })()
 
-  private readonly appIdentifier: string = (() => {
+  public readonly appIdentifier: string = (() => {
     const firstLabel = window.location.hostname.split('.')[0] ?? ''
     return firstLabel.startsWith('app-server--')
       ? firstLabel.slice('app-server--'.length)

--- a/packages/app-browser-sdk/src/hooks/app-browser-sdk/app-browser-sdk.hook.ts
+++ b/packages/app-browser-sdk/src/hooks/app-browser-sdk/app-browser-sdk.hook.ts
@@ -10,6 +10,7 @@ export interface ISdkContext {
   authState: AppBrowserSdk['authenticator']['state']
   navigateTo: AppBrowserSdk['handleNavigateTo']
   lombokApiBasePath: AppBrowserSdk['lombokApiBasePath']
+  appIdentifier: AppBrowserSdk['appIdentifier']
   currentPathAndQuery: string
   getAccessToken: AppBrowserSdk['authenticator']['getAccessToken']
   executeWorkerScriptUrl: AppBrowserSdk['executeWorkerScriptUrl']

--- a/packages/app-browser-sdk/src/hooks/app-browser-sdk/app-browser-sdk.provider.tsx
+++ b/packages/app-browser-sdk/src/hooks/app-browser-sdk/app-browser-sdk.provider.tsx
@@ -97,6 +97,7 @@ export const AppBrowserSdkContextProvider = ({
         theme: sdk.theme,
         authState,
         lombokApiBasePath: sdk.lombokApiBasePath,
+        appIdentifier: sdk.appIdentifier,
         getAccessToken,
         navigateTo: sdk.handleNavigateTo,
         currentPathAndQuery: sdk.initialData?.pathAndQuery ?? '',


### PR DESCRIPTION
## Summary

Exposes the installed `appIdentifier` to app UIs through `@lombokapp/app-browser-sdk`. The SDK already derived it internally from the iframe hostname (`app-server--<identifier>` label) but kept it `private`, so app UIs had no first-class way to read their own identifier (e.g. to namespace storage keys, build app-scoped URLs, or filter their own events).

## Changes

- `app-browser-sdk.ts` — make `AppBrowserSdk.appIdentifier` `public` instead of `private`.
- `app-browser-sdk.hook.ts` — add `appIdentifier` to `ISdkContext`.
- `app-browser-sdk.provider.tsx` — surface `sdk.appIdentifier` through the context provider value.

Pure SDK surface addition — no behaviour change for existing consumers.

## Testing

- `./dx check all` — prettier, tsc, eslint all pass.
- `app-browser-sdk` builds clean (tsup ESM+CJS+dts); generated `index.d.ts` exposes `readonly appIdentifier: string` on the SDK and `appIdentifier` on the context.

Linear: [LOM-335](https://linear.app/lombokapp/issue/LOM-335/expose-installed-appidentifier-through-the-app-browser-sdk)
