### PR TITLE
fix(LOM-337): fix local docker build scripts + docker-bridge packaging

### DIFF
--- a/deploy/build-separate-db.sh
+++ b/deploy/build-separate-db.sh
@@ -1,15 +1,40 @@
 #!/bin/bash
 set -e
 
-VERSION="${1:-}"
-if [ -z "$VERSION" ]; then
-    echo "Usage: $0 <version>   (e.g. $0 1.2.1-beta-rc3)" >&2
+BUILD_ID="${1:-}"
+PLATFORM_ARG="${2:-}"
+
+if [ -z "$BUILD_ID" ]; then
+    echo "Usage: $0 <build-id> [platform]   (e.g. $0 20260524-150000-abc1234 arm64)" >&2
+    echo "  platform: amd64 | arm64 (default: both)" >&2
     exit 1
 fi
 
-SHA1=$(git rev-parse --short HEAD)
-BUILD_ID="$VERSION-$SHA1"
+case "$PLATFORM_ARG" in
+    "")           PLATFORMS="linux/amd64 linux/arm64" ;;
+    amd64|arm64)  PLATFORMS="linux/$PLATFORM_ARG" ;;
+    linux/amd64|linux/arm64) PLATFORMS="$PLATFORM_ARG" ;;
+    *)
+        echo "Invalid platform: $PLATFORM_ARG (expected amd64 or arm64)" >&2
+        exit 1
+        ;;
+esac
+
 NAME=lombok
 
 echo "Building build ID: $BUILD_ID"
-docker build --platform linux/amd64 --no-cache --build-arg LOMBOK_BUILD_ID=$BUILD_ID --target release -t $NAME:$BUILD_ID -t $NAME:latest -f "../docker/app.Dockerfile" ../
+
+for PLATFORM in $PLATFORMS; do
+    ARCH="${PLATFORM##*/}"
+    echo "Building for $PLATFORM"
+    docker buildx build \
+        --platform "$PLATFORM" \
+        --load \
+        --no-cache \
+        --build-arg LOMBOK_BUILD_ID="$BUILD_ID" \
+        --target release \
+        -t "$NAME:$BUILD_ID-$ARCH" \
+        -t "$NAME:latest-$ARCH" \
+        -f "../docker/app.Dockerfile" \
+        ../
+done

--- a/deploy/build-standalone.sh
+++ b/deploy/build-standalone.sh
@@ -1,32 +1,40 @@
 #!/bin/bash
 set -e
 
-VERSION="${1:-}"
-if [ -z "$VERSION" ]; then
-    echo "Usage: $0 <version>   (e.g. $0 1.2.1-beta-rc3)" >&2
+BUILD_ID="${1:-}"
+PLATFORM_ARG="${2:-}"
+
+if [ -z "$BUILD_ID" ]; then
+    echo "Usage: $0 <build-id> [platform]   (e.g. $0 20260524-150000-abc1234 arm64)" >&2
+    echo "  platform: amd64 | arm64 (default: both)" >&2
     exit 1
 fi
 
-SHA1=$(git rev-parse --short HEAD)
-BUILD_ID="$VERSION-$SHA1"
+case "$PLATFORM_ARG" in
+    "")           PLATFORMS="linux/amd64 linux/arm64" ;;
+    amd64|arm64)  PLATFORMS="linux/$PLATFORM_ARG" ;;
+    linux/amd64|linux/arm64) PLATFORMS="$PLATFORM_ARG" ;;
+    *)
+        echo "Invalid platform: $PLATFORM_ARG (expected amd64 or arm64)" >&2
+        exit 1
+        ;;
+esac
+
 NAME=lombok-standalone
 
 echo "Building build ID: $BUILD_ID"
 
-# Detect local platform
-LOCAL_PLATFORM=$(uname -m)
-if [ "$LOCAL_PLATFORM" = "arm64" ] || [ "$LOCAL_PLATFORM" = "aarch64" ]; then
-    PLATFORM="linux/arm64"
-else
-    PLATFORM="linux/amd64"
-fi
-
-# Build for local platform with --load to make it available in local Docker
-echo "Building for local platform: $PLATFORM"
-docker buildx build --platform $PLATFORM --load --no-cache --build-arg LOMBOK_BUILD_ID=$BUILD_ID --target standalone-release -t $NAME:$BUILD_ID -t $NAME:latest -f "../docker/app.Dockerfile" ../
-
-# Run the container using docker-compose
-echo "Starting container with docker-compose..."
-cd ..
-docker-compose -f docker-compose.standalone.demo.yml up -d
-echo "Container started. Use 'docker-compose -f docker-compose.standalone.demo.yml logs -f' to view logs."
+for PLATFORM in $PLATFORMS; do
+    ARCH="${PLATFORM##*/}"
+    echo "Building for $PLATFORM"
+    docker buildx build \
+        --platform "$PLATFORM" \
+        --load \
+        --no-cache \
+        --build-arg LOMBOK_BUILD_ID="$BUILD_ID" \
+        --target standalone-release \
+        -t "$NAME:$BUILD_ID-$ARCH" \
+        -t "$NAME:latest-$ARCH" \
+        -f "../docker/app.Dockerfile" \
+        ../
+done

--- a/docker/app.Dockerfile
+++ b/docker/app.Dockerfile
@@ -90,18 +90,15 @@ RUN cd /temp/dev && \
   bun --cwd ./packages/app-worker-sdk build && \
   bun --cwd ./packages/app-browser-sdk build && \
   bun --cwd ./packages/api build && \
+  bun --cwd ./docker/docker-bridge build && \
   (cd ./packages/ui && node node_modules/.bin/vite build --mode production) && mv ./packages/ui/dist ./frontend && \
   # copy the sql migration files over (which were ignored by the build... maybe fix that)
   mkdir ./packages/api/dist/src/migrations/ && cp ./packages/api/src/orm/migrations/*.sql ./packages/api/dist/src/migrations/ && \
   mkdir ./packages/api/dist/src/migrations/meta && cp -r ./packages/api/src/orm/migrations/meta ./packages/api/dist/src/migrations/ && \
-  # build docker-bridge binary (compiled Bun executable + dockerode runtime dep)
-  cd ./docker/docker-bridge && \
-  bun build src/index.ts --compile --outfile docker-bridge --external dockerode && \
-  rm -rf src tsconfig.json bun.lock eslint.config.ts && \
-  cd /temp/dev && \
+  rm -rf ./docker/docker-bridge/src ./docker/docker-bridge/tsconfig.json ./docker/docker-bridge/eslint.config.ts && \
   # remove all but production deps
   rm -rf ./node_modules && \
-  bun install --production --filter ./packages/api && \
+  bun install --production --filter ./packages/api --filter ./docker/docker-bridge && \
   # remove as much unnecessary stuff as possible
   rm -rf ./packages/ui && \
   rm -rf ./packages/ui-toolkit && \

--- a/docker/docker-bridge/Dockerfile
+++ b/docker/docker-bridge/Dockerfile
@@ -4,7 +4,7 @@ COPY package.json bun.lock* ./
 RUN bun install --frozen-lockfile
 COPY tsconfig.json ./
 COPY src/ src/
-RUN bun build src/index.ts --compile --outfile docker-bridge --external dockerode
+RUN bun run build:binary
 
 FROM debian:bookworm-slim
 RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates && rm -rf /var/lib/apt/lists/*

--- a/docker/docker-bridge/package.json
+++ b/docker/docker-bridge/package.json
@@ -4,7 +4,8 @@
   "type": "module",
   "scripts": {
     "dev": "bun run src/index.ts",
-    "build": "bun build src/index.ts --compile --outfile docker-bridge",
+    "build": "bun build src/index.ts --outfile dist/index.js --target bun --format esm --external dockerode --minify-syntax --minify-whitespace",
+    "build:binary": "bun build src/index.ts --compile --outfile docker-bridge --external dockerode",
     "test": "bun test",
     "typecheck": "tsc --noEmit",
     "lint:check": "eslint .",

--- a/package.json
+++ b/package.json
@@ -7,8 +7,8 @@
   ],
   "scripts": {
     "install:clean": "sh ./cmd/dev-clean-install.sh",
-    "build:standalone": "(cd ./deploy && sh ./build-standalone.sh)",
-    "build:separate-db": "(cd ./deploy && sh ./build-separate-db.sh)",
+    "build:standalone": "sh -c '(cd ./deploy && sh ./build-standalone.sh \"$(date -u +%Y%m%d-%H%M%S)-$(git rev-parse --short HEAD)\" \"$@\")' --",
+    "build:separate-db": "sh -c '(cd ./deploy && sh ./build-separate-db.sh \"$(date -u +%Y%m%d-%H%M%S)-$(git rev-parse --short HEAD)\" \"$@\")' --",
     "generate:openapi": "bun --cwd packages/api generate:openapi",
     "dx": "./dx"
   },

--- a/packages/api/src/docker/services/docker-bridge.service.ts
+++ b/packages/api/src/docker/services/docker-bridge.service.ts
@@ -81,20 +81,19 @@ export class DockerBridgeService {
       })
     })
 
-    // Resolve bridge directory by walking up from __dirname until we find it.
-    // In dev: __dirname = .../packages/api/src/docker/services
-    // In prod: __dirname = .../packages/api/dist/src/docker/services
-    const bridgeDir = this.findBridgeDir(__dirname)
-    const binaryPath = path.join(bridgeDir, 'docker-bridge')
+    // Walk up from cwd, not __dirname: Bun's bundler bakes __dirname in as the
+    // build-time source path, which doesn't exist in the standalone image.
+    const bridgeDir = this.findBridgeDir(process.cwd())
+    const bundlePath = path.join(bridgeDir, 'dist/index.js')
     const sourcePath = path.join(bridgeDir, 'src/index.ts')
 
     let cmd: string[]
-    if (fs.existsSync(binaryPath)) {
-      cmd = [binaryPath]
+    if (fs.existsSync(bundlePath)) {
+      cmd = ['bun', bundlePath]
     } else if (fs.existsSync(sourcePath)) {
       cmd = ['bun', 'run', sourcePath]
     } else {
-      this.logger.error('No bridge binary or source found')
+      this.logger.error('No bridge bundle or source found')
       return
     }
 
@@ -346,8 +345,7 @@ export class DockerBridgeService {
       }
       dir = parent
     }
-    // Fallback: try relative to cwd (covers edge cases)
-    return path.resolve(process.cwd(), 'docker/docker-bridge')
+    return path.resolve(startDir, 'docker/docker-bridge')
   }
 
   private loadOrCreateSecret(): string {


### PR DESCRIPTION
## Summary

Fixes the local image build scripts and reworks how the docker-bridge is packaged so it runs reliably in the standalone image.

The docker-bridge was shipped as a Bun-compiled binary whose path `DockerBridgeService` resolved from `__dirname` — but Bun's bundler bakes `__dirname` in as the build-time source path, which doesn't exist at runtime in the standalone image. The build scripts also hardcoded a single platform and an awkward `<version>-<sha>` build-id.

## Changes

- **deploy/build-standalone.sh, deploy/build-separate-db.sh** — take an explicit build-id arg plus an optional `amd64`/`arm64` platform (defaults to both), producing per-arch tags via `docker buildx --load`. Removed the `docker-compose up` side effect from the standalone build.
- **package.json** — `build:standalone` / `build:separate-db` generate the build-id (`<utc-timestamp>-<short-sha>`) and forward an optional platform arg.
- **docker-bridge packaging** — ship a bundled `dist/index.js` (`bun build --target bun --format esm --external dockerode`) instead of a compiled binary; `build:binary` is kept for the standalone Dockerfile. `app.Dockerfile` builds the bundle and installs production deps for `docker/docker-bridge`.
- **docker-bridge.service.ts** — launch `bun dist/index.js` with a source fallback; resolve the bridge dir by walking up from `process.cwd()` instead of `__dirname`.

## Testing

- `./dx check all` — prettier, tsc, eslint all pass.
- `bash -n` on both build scripts — valid.
- `bun run build` in `docker/docker-bridge` — produces `dist/index.js` (bundled, dockerode externalized).

No e2e: the bridge-launch path and image build scripts aren't exercised by the API e2e suite (which mocks the docker adapter).

Linear: [LOM-337](https://linear.app/lombokapp/issue/LOM-337/fix-local-docker-build-scripts-docker-bridge-packaging)