### PR TITLE
fix(LOM-338): fix truncated files when transferred through bridge tunnels

### DIFF
--- a/docker/docker-bridge/src/sessions/tunnel-session-messages.test.ts
+++ b/docker/docker-bridge/src/sessions/tunnel-session-messages.test.ts
@@ -307,14 +307,19 @@ describe('TunnelSessionHandler — message handling', () => {
   })
 
   describe('handleAgentBinary', () => {
-    it('delivers binary to pending response expecting it', () => {
+    it('accumulates binary chunks and resolves at body_end', () => {
       const session = makeSession()
 
       const pendingMap = (
-        handler as unknown as { pendingHTTPResponses: Map<string, unknown> }
+        handler as unknown as {
+          pendingHTTPResponses: Map<
+            string,
+            { bodyChunks: Buffer[]; expectingBinary: boolean }
+          >
+        }
       ).pendingHTTPResponses
       let resolved: unknown = null
-      pendingMap.set('stream-bin', {
+      const pending = {
         resolve: (resp: unknown) => {
           resolved = resp
         },
@@ -326,17 +331,38 @@ describe('TunnelSessionHandler — message handling', () => {
           headers: { 'Content-Type': 'application/octet-stream' },
           body_follows: true,
         },
-        bodyChunks: [],
+        bodyChunks: [] as Buffer[],
         expectingBinary: true,
+      }
+      pendingMap.set('stream-bin', pending)
+
+      const setNextBinary = (id: string) => {
+        ;(
+          handler as unknown as { nextBinaryStreamId: string | null }
+        ).nextBinaryStreamId = id
+      }
+
+      // First chunk — drives the body_chunk → binary frame pair.
+      setNextBinary('stream-bin')
+      handler.handleAgentBinary(session, Buffer.from('hello '))
+
+      expect(resolved).toBeNull()
+      expect(pendingMap.has('stream-bin')).toBe(true)
+      expect(pending.bodyChunks.length).toBe(1)
+
+      // Second chunk — must also accumulate, not resolve early.
+      pending.expectingBinary = true
+      setNextBinary('stream-bin')
+      handler.handleAgentBinary(session, Buffer.from('binary'))
+
+      expect(resolved).toBeNull()
+      expect(pending.bodyChunks.length).toBe(2)
+
+      // body_end resolves with the full concatenated body.
+      handler.handleAgentMessage(session, {
+        type: 'body_end',
+        stream_id: 'stream-bin',
       })
-
-      // Set the stream ID that the next binary frame belongs to
-      // (normally set by forwardToClient when body_follows is true)
-      ;(
-        handler as unknown as { nextBinaryStreamId: string | null }
-      ).nextBinaryStreamId = 'stream-bin'
-
-      handler.handleAgentBinary(session, Buffer.from('hello binary'))
 
       expect(resolved).not.toBeNull()
       expect((resolved as { body: Buffer }).body.toString()).toBe(

--- a/docker/docker-bridge/src/sessions/tunnel-session.ts
+++ b/docker/docker-bridge/src/sessions/tunnel-session.ts
@@ -809,20 +809,6 @@ export class TunnelSessionHandler {
       if (pending?.expectingBinary) {
         pending.expectingBinary = false
         pending.bodyChunks.push(data)
-
-        // Single-body response (body_follows on http_response, not chunked) — resolve now
-        // Chunked responses resolve in handleBodyEnd
-        if (
-          pending.responseMeta?.body_follows &&
-          pending.bodyChunks.length === 1
-        ) {
-          this.pendingHTTPResponses.delete(streamId)
-          pending.resolve({
-            statusCode: pending.responseMeta.status_code,
-            headers: pending.responseMeta.headers,
-            body: Buffer.concat(pending.bodyChunks),
-          })
-        }
         return
       }
     }


### PR DESCRIPTION
## Summary

Binary HTTP responses proxied through a bridge tunnel were truncated to their first chunk. When a response had `body_follows` set, `TunnelSessionHandler.handleAgentBinary` resolved the pending response as soon as the first binary frame arrived (`bodyChunks.length === 1`), discarding subsequent chunks. Multi-chunk binary payloads — e.g. file downloads larger than a single frame — arrived truncated.

## Fix

Remove the premature single-chunk resolve. All binary responses now accumulate their chunks and resolve at `body_end` with the full concatenated body, the same path chunked responses already used.

## Changes

- `tunnel-session.ts` — drop the `body_follows && bodyChunks.length === 1` early-resolve branch; binary frames only accumulate.
- `tunnel-session-messages.test.ts` — rewrite the `handleAgentBinary` test to feed two binary chunks, assert it does not resolve early, then resolves with the full body at `body_end`.

## Testing

- `bun run typecheck` (docker/docker-bridge) — clean.
- `bun test src/sessions/tunnel-session-messages.test.ts` — 27 pass, 0 fail (includes the new multi-chunk case).
- Lint unchanged vs main (26 pre-existing errors in untouched files; the changed files add none).

Note: `docker/docker-bridge` is outside the `packages/*` workspace, so it isn't covered by `./dx check all`. The `tunnel-agent-integration.e2e.test.ts` suite requires a built Go agent binary and fails identically on `main` in this environment (binary not present) — unrelated to this change.

Linear: [LOM-338](https://linear.app/lombokapp/issue/LOM-338/fix-truncated-files-when-transferred-through-bridge-tunnels)