### PR TITLE
chore(LOM-339): upgrade bun to 1.3.14

### DIFF
--- a/.github/workflows/linting.yml
+++ b/.github/workflows/linting.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: 1.3.13
+          bun-version: 1.3.14
       - run: bun install
       - run: bun --cwd packages/ui prettier:check
       - run: bun --cwd packages/ui lint:check
@@ -34,7 +34,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: 1.3.13
+          bun-version: 1.3.14
       - run: bun install
       - run: bun --cwd packages/api prettier:check
       - run: bun --cwd packages/api lint:check
@@ -50,7 +50,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: 1.3.13
+          bun-version: 1.3.14
       - run: bun install
       - run: bun --cwd packages/core-worker prettier:check
       - run: bun --cwd packages/core-worker lint:check
@@ -66,7 +66,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: 1.3.13
+          bun-version: 1.3.14
       - run: bun install
       - run: bun --cwd packages/worker-utils prettier:check
       - run: bun --cwd packages/worker-utils lint:check
@@ -82,7 +82,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: 1.3.13
+          bun-version: 1.3.14
 
       - run: bun install
       - run: bun --cwd packages/app-browser-sdk prettier:check
@@ -99,7 +99,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: 1.3.13
+          bun-version: 1.3.14
 
       - run: bun install
       - run: bun --cwd packages/app-worker-sdk prettier:check
@@ -116,7 +116,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: 1.3.13
+          bun-version: 1.3.14
 
       - run: bun install
       - run: bun install --cwd packages/demo-apps/simple-demo
@@ -134,7 +134,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: 1.3.13
+          bun-version: 1.3.14
 
       - run: bun install
       - run: bun --cwd packages/sdk prettier:check
@@ -151,7 +151,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: 1.3.13
+          bun-version: 1.3.14
       - run: bun install
       - run: bun --cwd packages/auth-utils prettier:check
       - run: bun --cwd packages/auth-utils lint:check
@@ -167,7 +167,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: 1.3.13
+          bun-version: 1.3.14
       - run: bun install
       - run: bun --cwd packages/utils prettier:check
       - run: bun --cwd packages/utils lint:check
@@ -183,7 +183,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: 1.3.13
+          bun-version: 1.3.14
       - run: bun install
       - run: bun --cwd packages/types prettier:check
       - run: bun --cwd packages/types lint:check
@@ -199,7 +199,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: 1.3.13
+          bun-version: 1.3.14
       - run: bun install
       - run: bun --cwd packages/ui-toolkit prettier:check
       - run: bun --cwd packages/ui-toolkit lint:check

--- a/.github/workflows/unit-tests.yml
+++ b/.github/workflows/unit-tests.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: 1.3.13
+          bun-version: 1.3.14
       - run: bun install
       - run: bun --cwd packages/api test:unit
 
@@ -32,7 +32,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: 1.3.13
+          bun-version: 1.3.14
       - run: bun install
       - run: bun --cwd packages/app-worker-sdk test:unit
 
@@ -46,7 +46,7 @@ jobs:
   #     - name: Setup Bun
   #       uses: oven-sh/setup-bun@v2
   #       with:
-  #         bun-version: 1.3.13
+  #         bun-version: 1.3.14
   #     - run: bun install
   #     - run: bun --cwd packages/auth-utils test:unit
 
@@ -60,7 +60,7 @@ jobs:
   #     - name: Setup Bun
   #       uses: oven-sh/setup-bun@v2
   #       with:
-  #         bun-version: 1.3.13
+  #         bun-version: 1.3.14
   #     - run: bun install
   #     - run: bun --cwd packages/core-worker test:unit
 
@@ -74,7 +74,7 @@ jobs:
   #     - name: Setup Bun
   #       uses: oven-sh/setup-bun@v2
   #       with:
-  #         bun-version: 1.3.13
+  #         bun-version: 1.3.14
   #     - run: bun install
   #     - run: bun --cwd packages/sdk test:unit
 
@@ -88,7 +88,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: 1.3.13
+          bun-version: 1.3.14
       - run: bun install
       - run: bun --cwd packages/types test:unit
 
@@ -102,7 +102,7 @@ jobs:
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
         with:
-          bun-version: 1.3.13
+          bun-version: 1.3.14
       - run: bun install
       - run: bun --cwd packages/utils test:unit
 
@@ -116,6 +116,6 @@ jobs:
   #     - name: Setup Bun
   #       uses: oven-sh/setup-bun@v2
   #       with:
-  #         bun-version: 1.3.13
+  #         bun-version: 1.3.14
   #     - run: bun install
   #     - run: bun --cwd packages/worker-utils test:unit

--- a/bun.lock
+++ b/bun.lock
@@ -550,7 +550,7 @@
     "@tailwindcss/vite": "4.2.4",
     "@tanstack/react-query": "5.90.21",
     "@tanstack/table-core": "8.21.3",
-    "@types/bun": "1.3.13",
+    "@types/bun": "1.3.14",
     "@types/dockerode": "4.0.1",
     "@types/nodemailer": "6.4.16",
     "@types/pg": "8.16.0",
@@ -1546,7 +1546,7 @@
 
     "@types/body-parser": ["@types/body-parser@1.19.6", "", { "dependencies": { "@types/connect": "*", "@types/node": "*" } }, "sha512-HLFeCYgz89uk22N5Qg3dvGvsv46B8GLvKKo1zKG4NybA8U2DiEO3w9lqGg29t/tfLRJpJ6iQxnVw4OnB7MoM9g=="],
 
-    "@types/bun": ["@types/bun@1.3.13", "", { "dependencies": { "bun-types": "1.3.13" } }, "sha512-9fqXWk5YIHGGnUau9TEi+qdlTYDAnOj+xLCmSTwXfAIqXr2x4tytJb43E9uCvt09zJURKXwAtkoH4nLQfzeTXw=="],
+    "@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
 
     "@types/connect": ["@types/connect@3.4.38", "", { "dependencies": { "@types/node": "*" } }, "sha512-K6uROf1LD88uDQqJCktA4yzL1YYAK6NgfsI0v/mTgyPKWsX1CnJ0XPSDhViejru1GcRkLWb8RlzFYJRqGUbaug=="],
 
@@ -1876,7 +1876,7 @@
 
     "buildcheck": ["buildcheck@0.0.7", "", {}, "sha512-lHblz4ahamxpTmnsk+MNTRWsjYKv965MwOrSJyeD588rR3Jcu7swE+0wN5F+PbL5cjgu/9ObkhfzEPuofEMwLA=="],
 
-    "bun-types": ["bun-types@1.3.13", "", { "dependencies": { "@types/node": "*" } }, "sha512-QXKeHLlOLqQX9LgYaHJfzdBaV21T63HhFJnvuRCcjZiaUDpbs5ED1MgxbMra71CsryN/1dAoXuJJJwIv/2drVA=="],
+    "bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
 
     "bundle-require": ["bundle-require@5.1.0", "", { "dependencies": { "load-tsconfig": "^0.2.3" }, "peerDependencies": { "esbuild": ">=0.18" } }, "sha512-3WrrOuZiyaaZPWiEt4G3+IffISVC9HYlWueJEBWED4ZH4aIAC2PnkdnuRrR94M+w6yGWn4AglWtJtBI8YqvgoA=="],
 

--- a/docker/app.Dockerfile
+++ b/docker/app.Dockerfile
@@ -1,7 +1,7 @@
 FROM cgr.dev/chainguard/minio:latest AS minio
 FROM cgr.dev/chainguard/minio-client:latest AS mc
 
-FROM oven/bun:1.3.13-alpine AS base
+FROM oven/bun:1.3.14-alpine AS base
 
 WORKDIR /usr/src/app
 

--- a/docker/docker-bridge/Dockerfile
+++ b/docker/docker-bridge/Dockerfile
@@ -1,4 +1,4 @@
-FROM oven/bun:1.3.13-alpine AS builder
+FROM oven/bun:1.3.14-alpine AS builder
 WORKDIR /build
 COPY package.json bun.lock* ./
 RUN bun install --frozen-lockfile

--- a/docker/worker-job-runner/mock-worker.Dockerfile
+++ b/docker/worker-job-runner/mock-worker.Dockerfile
@@ -16,7 +16,7 @@ COPY docker/worker-agent/ ./
 RUN CGO_ENABLED=0 GOOS=linux go build -ldflags="-s -w" -o lombok-worker-agent .
 
 # Stage 2: Final image with Bun and the agent
-FROM oven/bun:1.3.13-alpine
+FROM oven/bun:1.3.14-alpine
 
 WORKDIR /app
 

--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "eslint-plugin-simple-import-sort": "12.1.1",
     "eslint-plugin-sonarjs": "3.0.1",
     "eslint-plugin-storybook": "10.0.5",
-    "@types/bun": "1.3.13",
+    "@types/bun": "1.3.14",
     "@types/react": "18.3.1",
     "@types/react-dom": "18.3.1",
     "typescript": "5.9.3",

--- a/packages/demo-apps/simple-demo/bun.lock
+++ b/packages/demo-apps/simple-demo/bun.lock
@@ -29,7 +29,7 @@
       "devDependencies": {
         "@eslint/js": "9.39.1",
         "@stylistic/eslint-plugin": "5.5.0",
-        "@types/bun": "1.3.13",
+        "@types/bun": "1.3.14",
         "@typescript-eslint/eslint-plugin": "8.46.3",
         "eslint": "9.39.1",
         "eslint-plugin-eslint-comments": "3.2.0",
@@ -56,7 +56,7 @@
       "devDependencies": {
         "@eslint/js": "9.39.1",
         "@stylistic/eslint-plugin": "5.5.0",
-        "@types/bun": "1.3.13",
+        "@types/bun": "1.3.14",
         "@types/react": "18.3.1",
         "@types/react-dom": "18.3.1",
         "@typescript-eslint/eslint-plugin": "8.46.3",
@@ -269,7 +269,7 @@
 
     "@tanstack/react-query": ["@tanstack/react-query@5.90.21", "", { "dependencies": { "@tanstack/query-core": "5.90.20" }, "peerDependencies": { "react": "^18 || ^19" } }, "sha512-0Lu6y5t+tvlTJMTO7oh5NSpJfpg/5D41LlThfepTixPYkJ0sE2Jj0m0f6yYqujBwIXlId87e234+MxG3D3g7kg=="],
 
-    "@types/bun": ["@types/bun@1.3.13", "", { "dependencies": { "bun-types": "1.3.13" } }, "sha512-9fqXWk5YIHGGnUau9TEi+qdlTYDAnOj+xLCmSTwXfAIqXr2x4tytJb43E9uCvt09zJURKXwAtkoH4nLQfzeTXw=="],
+    "@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
 
     "@types/estree": ["@types/estree@1.0.8", "", {}, "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w=="],
 
@@ -361,7 +361,7 @@
 
     "browserslist": ["browserslist@4.28.1", "", { "dependencies": { "baseline-browser-mapping": "^2.9.0", "caniuse-lite": "^1.0.30001759", "electron-to-chromium": "^1.5.263", "node-releases": "^2.0.27", "update-browserslist-db": "^1.2.0" }, "bin": { "browserslist": "cli.js" } }, "sha512-ZC5Bd0LgJXgwGqUknZY/vkUQ04r8NXnJZ3yYi4vDmSiZmC/pdSN0NbNRPxZpbtO4uAfDUAFffO8IZoM3Gj8IkA=="],
 
-    "bun-types": ["bun-types@1.3.13", "", { "dependencies": { "@types/node": "*" } }, "sha512-QXKeHLlOLqQX9LgYaHJfzdBaV21T63HhFJnvuRCcjZiaUDpbs5ED1MgxbMra71CsryN/1dAoXuJJJwIv/2drVA=="],
+    "bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
 
     "call-bind": ["call-bind@1.0.8", "", { "dependencies": { "call-bind-apply-helpers": "^1.0.0", "es-define-property": "^1.0.0", "get-intrinsic": "^1.2.4", "set-function-length": "^1.2.2" } }, "sha512-oKlSFMcMwpUg2ednkhQ454wfWiU/ul3CkJe/PEHcTKuiX6RpbehUiFMXu13HalGZxfUwCQzZG747YXBn1im9ww=="],
 

--- a/packages/demo-apps/simple-demo/runtime/package.json
+++ b/packages/demo-apps/simple-demo/runtime/package.json
@@ -16,7 +16,7 @@
   },
   "devDependencies": {
     "@eslint/js": "9.39.1",
-    "@types/bun": "1.3.13",
+    "@types/bun": "1.3.14",
     "eslint": "9.39.1",
     "typescript-eslint": "8.46.3",
     "@typescript-eslint/eslint-plugin": "8.46.3",

--- a/packages/demo-apps/simple-demo/ui/package.json
+++ b/packages/demo-apps/simple-demo/ui/package.json
@@ -23,7 +23,7 @@
   "devDependencies": {
     "@eslint/js": "9.39.1",
     "@stylistic/eslint-plugin": "5.5.0",
-    "@types/bun": "1.3.13",
+    "@types/bun": "1.3.14",
     "@types/react": "18.3.1",
     "@types/react-dom": "18.3.1",
     "@typescript-eslint/eslint-plugin": "8.46.3",


### PR DESCRIPTION
## Summary

Bumps the pinned Bun toolchain from 1.3.13 to 1.3.14 across CI, Docker base images, and `@types/bun`.

## Changes

- `.github/workflows/linting.yml`, `.github/workflows/unit-tests.yml` — `setup-bun` 1.3.13 → 1.3.14.
- `docker/app.Dockerfile`, `docker/docker-bridge/Dockerfile`, `docker/worker-job-runner/mock-worker.Dockerfile` — `oven/bun:1.3.13-alpine` → `1.3.14-alpine`.
- `@types/bun` 1.3.13 → 1.3.14 in root, `simple-demo/runtime`, and `simple-demo/ui`; lockfiles regenerated.

## Testing

- `bun install` (root + simple-demo) — consistent with the committed lockfiles (no further changes).
- `./dx check all` — prettier, tsc, eslint all pass.
- `bun --cwd packages/{types,utils} test:unit` — 190 + 85 pass, 0 fail, under Bun 1.3.14.

Linear: [LOM-339](https://linear.app/lombokapp/issue/LOM-339/upgrade-bun-to-1314)