### PR TITLE
fix(LOM-341): adjust extensions schema ownership in entrypoint.sh

### DIFF
--- a/packages/api/cmd/entrypoint.sh
+++ b/packages/api/cmd/entrypoint.sh
@@ -1,4 +1,5 @@
 #!/bin/sh
+set -e
 
 APP_USER="${APP_USER:-bun}"
 
@@ -84,11 +85,13 @@ if [ "$EMBEDDED_POSTGRES" = "true" ]; then
         # su-exec postgres createdb --username postgres --owner=${DB_USER} ${DB_NAME}
     fi
 
-    # Create extensions schema and vector extension as superuser
-    # This is required because extension creation typically needs superuser privileges
+    # Create the extensions schema + vector extension as superuser, then hand
+    # ownership to DB_USER so it can re-grant USAGE to the per-app roles the API
+    # creates later. A plain GRANT USAGE can't be re-granted onward, so app
+    # migrations would silently fail to resolve the vector type.
     su-exec postgres psql -v ON_ERROR_STOP=1 --username postgres -d "${DB_NAME}" -c "CREATE SCHEMA IF NOT EXISTS extensions;"
-    su-exec postgres psql -v ON_ERROR_STOP=1 --username postgres -d "${DB_NAME}" -c "GRANT USAGE ON SCHEMA extensions TO ${DB_USER};"
     su-exec postgres psql -v ON_ERROR_STOP=1 --username postgres -d "${DB_NAME}" -c "CREATE EXTENSION IF NOT EXISTS vector WITH SCHEMA extensions;"
+    su-exec postgres psql -v ON_ERROR_STOP=1 --username postgres -d "${DB_NAME}" -c "ALTER SCHEMA extensions OWNER TO ${DB_USER};"
 
     echo "Database setup complete."
 else


### PR DESCRIPTION
## Summary

In the embedded-postgres path, the API entrypoint created the `extensions` schema as the postgres superuser and only granted `USAGE` on it to `DB_USER`. `DB_USER` could use the schema itself but couldn't re-grant `USAGE` onward to the per-app database roles the API creates later — a plain grant isn't re-grantable. Those onward grants were silently dropped (`no privileges were granted`), and app migrations then failed to resolve the `vector` type.

## Fix

Transfer ownership of the `extensions` schema to `DB_USER` (`ALTER SCHEMA extensions OWNER TO ${DB_USER}`) instead of granting `USAGE`; as owner it can grant `USAGE` to per-app roles. Also add `set -e` so the entrypoint fails fast on any setup error.

## Changes

- `packages/api/cmd/entrypoint.sh` — add `set -e`; replace `GRANT USAGE ON SCHEMA extensions` with `ALTER SCHEMA extensions OWNER TO ${DB_USER}`, run after the extension is created.

## Testing

- `sh -n packages/api/cmd/entrypoint.sh` — syntax OK.

Note: this script is a shell entrypoint, so it isn't covered by `./dx check all` (prettier/tsc/eslint), and the embedded-postgres path runs only in the standalone image (not exercised by the API e2e suite).

Linear: [LOM-341](https://linear.app/lombokapp/issue/LOM-341/fix-extensions-schema-ownership-in-api-entrypoint-embedded-postgres)