### PR TITLE
chore(LOM-342): add platform api url override via flag in dev install

### DIFF
--- a/packages/demo-apps/dev-install.sh
+++ b/packages/demo-apps/dev-install.sh
@@ -1,12 +1,13 @@
 #!/bin/bash
 
 # Generic dev install script for demo apps
-# Usage: ./dev-install.sh [--install-deps] [--run-scripts] <app-name>
+# Usage: ./dev-install.sh [--install-deps] [--run-scripts] [--api-url <url>] <app-name>
 
 set -euo pipefail
 
 RUN_INSTALL=false
 RUN_SCRIPTS=false
+API_URL_OVERRIDE=""
 
 # Parse flags
 while [[ $# -gt 0 ]]; do
@@ -19,9 +20,21 @@ while [[ $# -gt 0 ]]; do
       RUN_SCRIPTS=true
       shift
       ;;
+    --api-url)
+      if [ $# -lt 2 ]; then
+        echo "Error: --api-url requires a value"
+        exit 1
+      fi
+      API_URL_OVERRIDE="$2"
+      shift 2
+      ;;
+    --api-url=*)
+      API_URL_OVERRIDE="${1#*=}"
+      shift
+      ;;
     -*)
       echo "Unknown flag: $1"
-      echo "Usage: $0 [--install-deps] [--run-scripts] <app-name>"
+      echo "Usage: $0 [--install-deps] [--run-scripts] [--api-url <url>] <app-name>"
       exit 1
       ;;
     *)
@@ -32,8 +45,9 @@ done
 
 # Check for app name argument
 if [ $# -eq 0 ]; then
-  echo "Usage: $0 [--install-deps] [--run-scripts] <app-name>"
+  echo "Usage: $0 [--install-deps] [--run-scripts] [--api-url <url>] <app-name>"
   echo "Example: $0 --install-deps --run-scripts simple-demo"
+  echo "Example: $0 --api-url https://lombok.example.com simple-demo"
   exit 1
 fi
 
@@ -53,7 +67,7 @@ if [ "$RUN_INSTALL" = true ]; then
   (cd "$APP_DIR" && bun install)
 fi
 
-API_URL="${API_URL:-http://localhost:3000}"
+API_URL_ENV="${API_URL:-}"
 CREDENTIALS_FILE="$SCRIPT_DIR/.lombok-credentials"
 ZIP_FILE="$APP_NAME.zip"
 
@@ -90,6 +104,11 @@ else
   USERNAME="Admin1"
   PASSWORD="123123123123"
 fi
+
+# Resolve API_URL precedence: --api-url flag > API_URL env > value sourced from credentials > default.
+# Re-applied after sourcing so the credentials file cannot override an explicit flag/env.
+API_URL="${API_URL_OVERRIDE:-${API_URL_ENV:-${API_URL:-http://localhost:3000}}}"
+echo "Using API URL: $API_URL"
 
 if [ -z "$USERNAME" ] || [ -z "$PASSWORD" ]; then
   echo "Error: USERNAME and PASSWORD must be set in $CREDENTIALS_FILE" or remove the .lombok-credentials file


### PR DESCRIPTION
## Summary

The shared demo-apps `dev-install.sh` only resolved the platform API URL from the `API_URL` env var (defaulting to `http://localhost:3000`). This adds an explicit `--api-url <url>` flag so a target platform can be chosen per-invocation without exporting an env var — useful for installing demo apps against a remote/staging platform.

## Changes

- `packages/demo-apps/dev-install.sh`:
  - Parse `--api-url <url>` and `--api-url=<url>`, with a missing-value guard.
  - Resolve the API URL with precedence `--api-url` flag > `API_URL` env > value sourced from the credentials file > `http://localhost:3000` default, re-applied after sourcing credentials so the file can't override an explicit flag/env.
  - Echo the resolved API URL; extend usage/examples.

## Testing

- `bash -n` — syntax OK.
- Flag parsing smoke tests: `--api-url` with no value errors and exits 1; an unknown flag errors with usage; no app-name prints usage including the new flag/example.

Note: this is a dev shell script under `packages/demo-apps/`, not covered by `./dx check all`.

Linear: [LOM-342](https://linear.app/lombokapp/issue/LOM-342/add-api-url-override-flag-to-demo-apps-dev-install-script)