### PR TITLE
fix(LOM-347): return 401 for valid tokens whose user no longer exists; SDK logout on 401

### DIFF
--- a/packages/api/src/auth/auth-edge-cases.e2e-spec.ts
+++ b/packages/api/src/auth/auth-edge-cases.e2e-spec.ts
@@ -1,6 +1,8 @@
 import { afterAll, afterEach, beforeAll, describe, expect, it } from 'bun:test'
+import { eq } from 'drizzle-orm'
 import type { TestApiClient, TestModule } from 'src/test/test.types'
 import { buildTestModule, createTestUser } from 'src/test/test.util'
+import { usersTable } from 'src/users/entities/user.entity'
 
 const TEST_MODULE_KEY = 'auth_edge'
 
@@ -89,6 +91,63 @@ describe('Auth Edge Cases', () => {
     expect([200, 201]).toContain(res.response.status)
     expect(res.data?.session.accessToken).toBeTruthy()
     expect(res.data?.session.refreshToken).toBeTruthy()
+  })
+
+  it('should reject a valid token whose user no longer exists with 401', async () => {
+    const {
+      session: { accessToken },
+    } = await createTestUser(testModule!, {
+      username: 'ghosttoken',
+      password: 'pass123',
+    })
+
+    // Token is signature-valid; remove the user it refers to.
+    await testModule!.services.ormService.db
+      .delete(usersTable)
+      .where(eq(usersTable.username, 'ghosttoken'))
+
+    const res = await apiClient(accessToken).GET('/api/v1/folders')
+    expect(res.response.status).toBe(401)
+  })
+
+  it('should reject a valid app-user token whose user no longer exists with 401', async () => {
+    const {
+      session: { accessToken },
+    } = await createTestUser(testModule!, {
+      username: 'ghostappuser',
+      password: 'pass123',
+    })
+
+    const viewer = await apiClient(accessToken).GET('/api/v1/viewer')
+    const userId = viewer.data?.user.id
+    if (!userId) {
+      throw new Error('Failed to resolve user id')
+    }
+
+    // Mint a signature-valid app-user token with platform access for this user.
+    const appUserToken =
+      await testModule!.services.jwtService.createAppUserToken({
+        session: {
+          id: '11111111-1111-1111-1111-111111111111',
+          hash: 'hash',
+          userId,
+          type: 'app_user',
+          typeDetails: null,
+          expiresAt: new Date(Date.now() + 60_000),
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        },
+        appIdentifier: 'auth-edge-app',
+        platformAccess: true,
+      })
+
+    // Remove the user the token refers to.
+    await testModule!.services.ormService.db
+      .delete(usersTable)
+      .where(eq(usersTable.id, userId))
+
+    const res = await apiClient(appUserToken).GET('/api/v1/viewer')
+    expect(res.response.status).toBe(401)
   })
 
   it('should not allow duplicate username signup', async () => {

--- a/packages/api/src/auth/guards/auth.guard.ts
+++ b/packages/api/src/auth/guards/auth.guard.ts
@@ -36,7 +36,13 @@ export class AuthGuard implements CanActivate {
         ) {
           await this.jwtService.verifyUserJWT(token)
           const userId = subject.split(':')[1] ?? ''
-          request.user = await this.userService.getUserById({ id: userId })
+          const user = await this.userService
+            .getUserById({ id: userId })
+            .catch(() => null)
+          if (!user) {
+            throw new UnauthorizedException()
+          }
+          request.user = user
           return true
         } else if (
           subject.startsWith(APP_USER_JWT_SUB_PREFIX) &&
@@ -49,9 +55,13 @@ export class AuthGuard implements CanActivate {
           if (!claims.platformAccess) {
             throw new UnauthorizedException()
           }
-          request.user = await this.userService.getUserById({
-            id: claims.userId,
-          })
+          const user = await this.userService
+            .getUserById({ id: claims.userId })
+            .catch(() => null)
+          if (!user) {
+            throw new UnauthorizedException()
+          }
+          request.user = user
           return true
         }
         // Failed to verify that the subject passed the guard config

--- a/packages/sdk/src/lombok-sdk.ts
+++ b/packages/sdk/src/lombok-sdk.ts
@@ -6,6 +6,7 @@ import createFetchClient from 'openapi-fetch'
 export class LombokSdk {
   public apiClient: ReturnType<typeof createFetchClient<paths>>
   public authenticator: Authenticator
+  private logoutInFlight: Promise<void> | undefined
   constructor({
     basePath,
     onTokensCreated,
@@ -47,8 +48,25 @@ export class LombokSdk {
         if (token) {
           headers.set('Authorization', `Bearer ${token}`)
         }
-        return fetch(new Request(request, { headers }))
+        const response = await fetch(new Request(request, { headers }))
+        if (response.status === 401) {
+          // Session rejected server-side despite a locally-valid token; log out.
+          void this.handleUnauthorized()
+        }
+        return response
       },
     })
+  }
+
+  // Dedupes concurrent 401s into one logout; swallows errors so local state
+  // still clears even if the backend logout call fails.
+  private handleUnauthorized(): Promise<void> {
+    this.logoutInFlight ??= this.authenticator
+      .logout()
+      .catch(() => undefined)
+      .finally(() => {
+        this.logoutInFlight = undefined
+      })
+    return this.logoutInFlight
   }
 }


### PR DESCRIPTION
## Summary

A token could be signature-valid while the user it refers to no longer exists (e.g. deleted account). The auth guard didn't treat this as an auth failure, so these "ghost" tokens never got a clean 401, and the SDK had no signal to clear the dead session.

- `packages/api/src/auth/guards/auth.guard.ts` — reject a signature-valid token that resolves to a non-existent user with **401** (covers both regular and app-user tokens).
- `packages/sdk/src/lombok-sdk.ts` — log the user out on a returned **401**, so the client clears its dead session instead of looping.
- `packages/api/src/auth/auth-edge-cases.e2e-spec.ts` — new coverage for both ghost-user cases.

## Test plan

- `./dx check all` — green.
- `auth-edge-cases` e2e — 9 pass / 0 fail, including `should reject a valid token whose user no longer exists with 401` and the app-user-token equivalent.

Closes LOM-347
