### PR TITLE
fix(LOM-348): notification task timing guards + timezone-aware timestamps

### DIFF
--- a/packages/api/src/app/entities/app-custom-folder-settings.entity.ts
+++ b/packages/api/src/app/entities/app-custom-folder-settings.entity.ts
@@ -23,8 +23,8 @@ export const appCustomFolderSettingsTable = pgTable(
       .notNull(),
     key: text('key').notNull(),
     value: jsonb('value').$type<unknown>().notNull(),
-    createdAt: timestamp('created_at').notNull(),
-    updatedAt: timestamp('updated_at').notNull(),
+    createdAt: timestamp('created_at', { withTimezone: true }).notNull(),
+    updatedAt: timestamp('updated_at', { withTimezone: true }).notNull(),
   },
   (table) => [
     primaryKey({

--- a/packages/api/src/app/entities/app-custom-user-settings.entity.ts
+++ b/packages/api/src/app/entities/app-custom-user-settings.entity.ts
@@ -23,8 +23,8 @@ export const appCustomUserSettingsTable = pgTable(
       .notNull(),
     key: text('key').notNull(),
     value: jsonb('value').$type<unknown>().notNull(),
-    createdAt: timestamp('created_at').notNull(),
-    updatedAt: timestamp('updated_at').notNull(),
+    createdAt: timestamp('created_at', { withTimezone: true }).notNull(),
+    updatedAt: timestamp('updated_at', { withTimezone: true }).notNull(),
   },
   (table) => [
     primaryKey({

--- a/packages/api/src/app/entities/app-folder-settings.entity.ts
+++ b/packages/api/src/app/entities/app-folder-settings.entity.ts
@@ -25,8 +25,8 @@ export const appFolderSettingsTable = pgTable(
       .notNull(),
     enabled: boolean('enabled'),
     permissions: jsonb('permissions').$type<FolderScopeAppPermissions[]>(),
-    createdAt: timestamp('created_at').notNull(),
-    updatedAt: timestamp('updated_at').notNull(),
+    createdAt: timestamp('created_at', { withTimezone: true }).notNull(),
+    updatedAt: timestamp('updated_at', { withTimezone: true }).notNull(),
   },
   (table) => [
     index('app_folder_settings_folder_id_idx').on(table.folderId),

--- a/packages/api/src/app/entities/app-runtime-trigger.entity.ts
+++ b/packages/api/src/app/entities/app-runtime-trigger.entity.ts
@@ -35,8 +35,8 @@ export const appRuntimeTriggersTable = pgTable(
     definition: jsonb('definition')
       .$type<RegisterableTriggerConfig>()
       .notNull(),
-    createdAt: timestamp('created_at').notNull(),
-    updatedAt: timestamp('updated_at').notNull(),
+    createdAt: timestamp('created_at', { withTimezone: true }).notNull(),
+    updatedAt: timestamp('updated_at', { withTimezone: true }).notNull(),
   },
   (table) => [
     index('app_runtime_triggers_app_id_idx').on(table.appId),

--- a/packages/api/src/app/entities/app-user-settings.entity.ts
+++ b/packages/api/src/app/entities/app-user-settings.entity.ts
@@ -32,8 +32,8 @@ export const appUserSettingsTable = pgTable(
       'folder_scope_permissions_default',
     ).$type<FolderScopeAppPermissions[]>(),
     permissions: jsonb('permissions').$type<UserScopeAppPermissions[]>(),
-    createdAt: timestamp('created_at').notNull(),
-    updatedAt: timestamp('updated_at').notNull(),
+    createdAt: timestamp('created_at', { withTimezone: true }).notNull(),
+    updatedAt: timestamp('updated_at', { withTimezone: true }).notNull(),
   },
   (table) => [
     index('app_user_settings_user_id_idx').on(table.userId),

--- a/packages/api/src/app/entities/app.entity.ts
+++ b/packages/api/src/app/entities/app.entity.ts
@@ -72,8 +72,8 @@ export const appsTable = pgTable(
       .notNull()
       .default({}),
     enabled: boolean('enabled').notNull().default(false),
-    createdAt: timestamp('created_at').notNull(),
-    updatedAt: timestamp('updated_at').notNull(),
+    createdAt: timestamp('created_at', { withTimezone: true }).notNull(),
+    updatedAt: timestamp('updated_at', { withTimezone: true }).notNull(),
   },
   (table) => [index('apps_enabled_idx').on(table.enabled)],
 )

--- a/packages/api/src/app/services/app.service.ts
+++ b/packages/api/src/app/services/app.service.ts
@@ -1750,7 +1750,7 @@ export class AppService {
       .where(
         and(
           eq(tasksTable.ownerId, appIdentifier),
-          sql`${tasksTable.completedAt} >= ${oneDayAgo.toISOString()}::timestamp`,
+          sql`${tasksTable.completedAt} >= ${oneDayAgo.toISOString()}::timestamptz`,
         ),
       )
 
@@ -1759,7 +1759,7 @@ export class AppService {
       .select({
         total: count(logEntriesTable.id),
         last10Minutes: count(
-          sql`CASE WHEN ${logEntriesTable.createdAt} >= ${tenMinutesAgo.toISOString()}::timestamp THEN 1 END`,
+          sql`CASE WHEN ${logEntriesTable.createdAt} >= ${tenMinutesAgo.toISOString()}::timestamptz THEN 1 END`,
         ),
       })
       .from(logEntriesTable)
@@ -1767,7 +1767,7 @@ export class AppService {
         and(
           eq(logEntriesTable.emitterId, appIdentifier),
           eq(logEntriesTable.level, LogEntryLevel.ERROR),
-          sql`${logEntriesTable.createdAt} >= ${oneDayAgo.toISOString()}::timestamp`,
+          sql`${logEntriesTable.createdAt} >= ${oneDayAgo.toISOString()}::timestamptz`,
         ),
       )
 
@@ -1776,14 +1776,14 @@ export class AppService {
       .select({
         total: count(eventsTable.id),
         last10Minutes: count(
-          sql`CASE WHEN ${eventsTable.createdAt} >= ${tenMinutesAgo.toISOString()}::timestamp THEN 1 END`,
+          sql`CASE WHEN ${eventsTable.createdAt} >= ${tenMinutesAgo.toISOString()}::timestamptz THEN 1 END`,
         ),
       })
       .from(eventsTable)
       .where(
         and(
           eq(eventsTable.emitterId, appIdentifier),
-          sql`${eventsTable.createdAt} >= ${oneDayAgo.toISOString()}::timestamp`,
+          sql`${eventsTable.createdAt} >= ${oneDayAgo.toISOString()}::timestamptz`,
         ),
       )
 

--- a/packages/api/src/auth/entities/session.entity.ts
+++ b/packages/api/src/auth/entities/session.entity.ts
@@ -16,9 +16,9 @@ export const sessionsTable = pgTable(
     userId: uuid('user_id').notNull(),
     type: text('type').notNull(),
     typeDetails: jsonb('type_details').$type<JsonSerializableObject>(),
-    expiresAt: timestamp('expires_at').notNull(),
-    createdAt: timestamp('created_at').notNull(),
-    updatedAt: timestamp('updated_at').notNull(),
+    expiresAt: timestamp('expires_at', { withTimezone: true }).notNull(),
+    createdAt: timestamp('created_at', { withTimezone: true }).notNull(),
+    updatedAt: timestamp('updated_at', { withTimezone: true }).notNull(),
   },
   (table) => [
     index('session_user_id_idx').on(table.userId),

--- a/packages/api/src/auth/entities/user-identity.entity.ts
+++ b/packages/api/src/auth/entities/user-identity.entity.ts
@@ -12,8 +12,8 @@ export const userIdentitiesTable = pgTable(
     providerUserId: text('provider_user_id').notNull(), // External provider's user ID
     providerEmail: text('provider_email'), // Email from provider (informational)
     providerName: text('provider_name'), // Name from provider (informational)
-    createdAt: timestamp('created_at').notNull(),
-    updatedAt: timestamp('updated_at').notNull(),
+    createdAt: timestamp('created_at', { withTimezone: true }).notNull(),
+    updatedAt: timestamp('updated_at', { withTimezone: true }).notNull(),
   },
   (table) => [
     unique('unique_provider_user').on(table.provider, table.providerUserId),

--- a/packages/api/src/comments/entities/comment-mention.entity.ts
+++ b/packages/api/src/comments/entities/comment-mention.entity.ts
@@ -19,7 +19,9 @@ export const commentMentionsTable = pgTable(
     userId: uuid('user_id')
       .notNull()
       .references(() => usersTable.id, { onDelete: 'cascade' }),
-    createdAt: timestamp('created_at').notNull().defaultNow(),
+    createdAt: timestamp('created_at', { withTimezone: true })
+      .notNull()
+      .defaultNow(),
   },
   (table) => [
     primaryKey({ columns: [table.commentId, table.userId] }),

--- a/packages/api/src/comments/entities/comment-reaction.entity.ts
+++ b/packages/api/src/comments/entities/comment-reaction.entity.ts
@@ -21,7 +21,9 @@ export const commentReactionsTable = pgTable(
       .notNull()
       .references(() => usersTable.id, { onDelete: 'cascade' }),
     emoji: text('emoji').notNull(),
-    createdAt: timestamp('created_at').notNull().defaultNow(),
+    createdAt: timestamp('created_at', { withTimezone: true })
+      .notNull()
+      .defaultNow(),
   },
   (table) => [
     primaryKey({ columns: [table.commentId, table.userId, table.emoji] }),

--- a/packages/api/src/comments/entities/comment.entity.ts
+++ b/packages/api/src/comments/entities/comment.entity.ts
@@ -30,9 +30,13 @@ export const commentsTable = pgTable(
       .references(() => usersTable.id),
     content: text('content').notNull(),
     anchor: jsonb('anchor').$type<CommentAnchor | null>(),
-    createdAt: timestamp('created_at').notNull().defaultNow(),
-    updatedAt: timestamp('updated_at').notNull().defaultNow(),
-    deletedAt: timestamp('deleted_at'),
+    createdAt: timestamp('created_at', { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+    updatedAt: timestamp('updated_at', { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+    deletedAt: timestamp('deleted_at', { withTimezone: true }),
   },
   (table) => [
     check('content_not_empty', sql`length(content) > 0`),

--- a/packages/api/src/docker/entities/docker-host.entity.ts
+++ b/packages/api/src/docker/entities/docker-host.entity.ts
@@ -30,9 +30,9 @@ export const dockerHostsTable = pgTable(
       .notNull()
       .$type<'healthy' | 'unhealthy' | 'unknown'>()
       .default('unknown'),
-    lastHealthCheck: timestamp('last_health_check'),
-    createdAt: timestamp('created_at').notNull(),
-    updatedAt: timestamp('updated_at').notNull(),
+    lastHealthCheck: timestamp('last_health_check', { withTimezone: true }),
+    createdAt: timestamp('created_at', { withTimezone: true }).notNull(),
+    updatedAt: timestamp('updated_at', { withTimezone: true }).notNull(),
   },
   (table) => [
     index('docker_hosts_is_default_idx').on(table.isDefault),

--- a/packages/api/src/docker/entities/docker-profile-resource-assignment.entity.ts
+++ b/packages/api/src/docker/entities/docker-profile-resource-assignment.entity.ts
@@ -34,8 +34,8 @@ export const dockerProfileResourceAssignmentsTable = pgTable(
       .$type<Record<string, string>>()
       .notNull()
       .default({}),
-    createdAt: timestamp('created_at').notNull(),
-    updatedAt: timestamp('updated_at').notNull(),
+    createdAt: timestamp('created_at', { withTimezone: true }).notNull(),
+    updatedAt: timestamp('updated_at', { withTimezone: true }).notNull(),
   },
   (table) => [
     uniqueIndex('docker_profile_resource_assignments_app_profile_unique').on(

--- a/packages/api/src/docker/entities/docker-registry-credential.entity.ts
+++ b/packages/api/src/docker/entities/docker-registry-credential.entity.ts
@@ -14,8 +14,8 @@ export const dockerRegistryCredentialsTable = pgTable(
     serverAddress: text('server_address').notNull(),
     username: text('username').notNull(),
     password: text('password').notNull(),
-    createdAt: timestamp('created_at').notNull(),
-    updatedAt: timestamp('updated_at').notNull(),
+    createdAt: timestamp('created_at', { withTimezone: true }).notNull(),
+    updatedAt: timestamp('updated_at', { withTimezone: true }).notNull(),
   },
   (table) => [
     uniqueIndex('docker_registry_credentials_registry_unique').on(

--- a/packages/api/src/docker/entities/docker-standalone-container.entity.ts
+++ b/packages/api/src/docker/entities/docker-standalone-container.entity.ts
@@ -36,8 +36,8 @@ export const dockerStandaloneContainersTable = pgTable(
       .$type<Record<string, string>>()
       .notNull()
       .default({}),
-    createdAt: timestamp('created_at').notNull(),
-    updatedAt: timestamp('updated_at').notNull(),
+    createdAt: timestamp('created_at', { withTimezone: true }).notNull(),
+    updatedAt: timestamp('updated_at', { withTimezone: true }).notNull(),
   },
   (table) => [
     index('docker_standalone_containers_desired_status_idx').on(

--- a/packages/api/src/event/entities/event.entity.ts
+++ b/packages/api/src/event/entities/event.entity.ts
@@ -22,8 +22,10 @@ export const eventsTable = pgTable(
     targetLocationObjectKey: text('target_location_object_key'),
     data: jsonbBase64('data').$type<JsonSerializableObject>(),
     aggregationKey: text('aggregation_key'),
-    aggregationHandledAt: timestamp('aggregation_handled_at'),
-    createdAt: timestamp('created_at').notNull(),
+    aggregationHandledAt: timestamp('aggregation_handled_at', {
+      withTimezone: true,
+    }),
+    createdAt: timestamp('created_at', { withTimezone: true }).notNull(),
   },
   (table) => [
     check(

--- a/packages/api/src/folders/entities/folder-object.entity.ts
+++ b/packages/api/src/folders/entities/folder-object.entity.ts
@@ -43,8 +43,8 @@ export const folderObjectsTable = pgTable(
       (): SQL =>
         sql`setweight(to_tsvector('english', coalesce(${folderObjectsTable.filename}, '')), 'A') || setweight(to_tsvector('english', coalesce(${folderObjectsTable.objectKey}, '')), 'B')`,
     ),
-    createdAt: timestamp('created_at').notNull(),
-    updatedAt: timestamp('updated_at').notNull(),
+    createdAt: timestamp('created_at', { withTimezone: true }).notNull(),
+    updatedAt: timestamp('updated_at', { withTimezone: true }).notNull(),
   },
   (table) => [
     index('folder_objects_folder_id_media_type_size_bytes_idx').on(

--- a/packages/api/src/folders/entities/folder-share.entity.ts
+++ b/packages/api/src/folders/entities/folder-share.entity.ts
@@ -25,10 +25,10 @@ export const folderSharesTable = pgTable(
       .array()
       .notNull()
       .$type<FolderPermissionName[]>(),
-    createdAt: timestamp('created_at')
+    createdAt: timestamp('created_at', { withTimezone: true })
       .default(sql`CURRENT_TIMESTAMP`)
       .notNull(),
-    updatedAt: timestamp('updated_at')
+    updatedAt: timestamp('updated_at', { withTimezone: true })
       .default(sql`CURRENT_TIMESTAMP`)
       .notNull(),
   },

--- a/packages/api/src/folders/entities/folder.entity.ts
+++ b/packages/api/src/folders/entities/folder.entity.ts
@@ -31,9 +31,9 @@ export const foldersTable = pgTable(
       message: string
       code: string
     }>(),
-    iconUpdatedAt: timestamp('icon_updated_at'),
-    createdAt: timestamp('created_at').notNull(),
-    updatedAt: timestamp('updated_at').notNull(),
+    iconUpdatedAt: timestamp('icon_updated_at', { withTimezone: true }),
+    createdAt: timestamp('created_at', { withTimezone: true }).notNull(),
+    updatedAt: timestamp('updated_at', { withTimezone: true }).notNull(),
   },
   (table) => [
     index('folders_owner_id_idx').on(table.ownerId),

--- a/packages/api/src/log/entities/log-entry.entity.ts
+++ b/packages/api/src/log/entities/log-entry.entity.ts
@@ -12,7 +12,7 @@ export const logEntriesTable = pgTable(
     targetLocationObjectKey: text('target_location_object_key'),
     level: text('level').notNull().$type<LogEntryLevel>(),
     data: jsonbBase64('data').$type<JsonSerializableObject>(),
-    createdAt: timestamp('created_at').notNull(),
+    createdAt: timestamp('created_at', { withTimezone: true }).notNull(),
   },
   (table) => [
     index('log_entries_target_location_folder_id_idx').on(

--- a/packages/api/src/mcp/entities/mcp-folder-settings.entity.ts
+++ b/packages/api/src/mcp/entities/mcp-folder-settings.entity.ts
@@ -22,8 +22,8 @@ export const mcpFolderSettingsTable = pgTable(
     canWrite: boolean('can_write'),
     canDelete: boolean('can_delete'),
     canMove: boolean('can_move'),
-    createdAt: timestamp('created_at').notNull(),
-    updatedAt: timestamp('updated_at').notNull(),
+    createdAt: timestamp('created_at', { withTimezone: true }).notNull(),
+    updatedAt: timestamp('updated_at', { withTimezone: true }).notNull(),
   },
   (table) => [
     uniqueIndex('mcp_folder_settings_folder_user_unique').on(

--- a/packages/api/src/mcp/entities/mcp-user-settings.entity.ts
+++ b/packages/api/src/mcp/entities/mcp-user-settings.entity.ts
@@ -18,8 +18,8 @@ export const mcpUserSettingsTable = pgTable(
     canWrite: boolean('can_write'),
     canDelete: boolean('can_delete'),
     canMove: boolean('can_move'),
-    createdAt: timestamp('created_at').notNull(),
-    updatedAt: timestamp('updated_at').notNull(),
+    createdAt: timestamp('created_at', { withTimezone: true }).notNull(),
+    updatedAt: timestamp('updated_at', { withTimezone: true }).notNull(),
   },
   (table) => [uniqueIndex('mcp_user_settings_user_id_unique').on(table.userId)],
 )

--- a/packages/api/src/notification/entities/notification-delivery.entity.ts
+++ b/packages/api/src/notification/entities/notification-delivery.entity.ts
@@ -29,24 +29,26 @@ export const notificationDeliveriesTable = pgTable(
     userId: uuid('user_id')
       .notNull()
       .references(() => usersTable.id, { onDelete: 'cascade' }),
-    readAt: timestamp('read_at'),
+    readAt: timestamp('read_at', { withTimezone: true }),
     // Email channel (null status = not requested)
     emailStatus: text('email_status').$type<
       'pending' | 'sent' | 'failed' | null
     >(),
-    emailSentAt: timestamp('email_sent_at'),
-    emailFailedAt: timestamp('email_failed_at'),
+    emailSentAt: timestamp('email_sent_at', { withTimezone: true }),
+    emailFailedAt: timestamp('email_failed_at', { withTimezone: true }),
     emailError:
       jsonbBase64('email_error').$type<NotificationDeliveryChannelError>(),
     // Mobile channel (null status = not requested)
     mobileStatus: text('mobile_status').$type<
       'pending' | 'sent' | 'failed' | null
     >(),
-    mobileSentAt: timestamp('mobile_sent_at'),
-    mobileFailedAt: timestamp('mobile_failed_at'),
+    mobileSentAt: timestamp('mobile_sent_at', { withTimezone: true }),
+    mobileFailedAt: timestamp('mobile_failed_at', { withTimezone: true }),
     mobileError:
       jsonbBase64('mobile_error').$type<NotificationDeliveryChannelError>(),
-    createdAt: timestamp('created_at').notNull().defaultNow(),
+    createdAt: timestamp('created_at', { withTimezone: true })
+      .notNull()
+      .defaultNow(),
   },
   (table) => [
     index('notification_deliveries_notification_id_idx').on(

--- a/packages/api/src/notification/entities/notification-settings.entity.ts
+++ b/packages/api/src/notification/entities/notification-settings.entity.ts
@@ -24,8 +24,12 @@ export const notificationSettingsTable = pgTable(
     folderId: uuid('folder_id').references(() => foldersTable.id, {
       onDelete: 'cascade',
     }),
-    createdAt: timestamp('created_at').notNull().defaultNow(),
-    updatedAt: timestamp('updated_at').notNull().defaultNow(),
+    createdAt: timestamp('created_at', { withTimezone: true })
+      .notNull()
+      .defaultNow(),
+    updatedAt: timestamp('updated_at', { withTimezone: true })
+      .notNull()
+      .defaultNow(),
   },
   (table) => [
     index('notification_settings_user_id_emitter_identifier_idx').on(

--- a/packages/api/src/notification/entities/notification.entity.ts
+++ b/packages/api/src/notification/entities/notification.entity.ts
@@ -22,7 +22,9 @@ export const notificationsTable = pgTable(
     body: text('body'),
     image: text('image'),
     path: text('path'),
-    createdAt: timestamp('created_at').notNull().defaultNow(),
+    createdAt: timestamp('created_at', { withTimezone: true })
+      .notNull()
+      .defaultNow(),
   },
   (table) => [
     index('notifications_user_id_created_at_idx').on(

--- a/packages/api/src/notification/processors/create-event-notifications.processor.ts
+++ b/packages/api/src/notification/processors/create-event-notifications.processor.ts
@@ -24,7 +24,7 @@ export class CreateEventNotificationsProcessor extends BaseCoreTaskProcessor<Cor
     private readonly notificationBatchingService: NotificationBatchingService,
   ) {
     super(CoreTaskName.CreateEventNotifications, async (task) => {
-      const { aggregationKey } = task.data
+      const { aggregationKey, requeueCount = 0 } = task.data
 
       // Get unhandled events for this aggregation key
       const [unhandledEvent] =
@@ -46,6 +46,7 @@ export class CreateEventNotificationsProcessor extends BaseCoreTaskProcessor<Cor
           {
             eventIdentifier: unhandledEvent.eventIdentifier,
             emitterIdentifier: unhandledEvent.emitterId,
+            requeueCount,
           },
         )
 
@@ -70,7 +71,7 @@ export class CreateEventNotificationsProcessor extends BaseCoreTaskProcessor<Cor
               },
             },
             taskDescription: 'Create event notifications',
-            data: { aggregationKey },
+            data: { aggregationKey, requeueCount: requeueCount + 1 },
             dontStartBefore,
             createdAt: now,
             updatedAt: now,

--- a/packages/api/src/notification/services/notification-batching.service.ts
+++ b/packages/api/src/notification/services/notification-batching.service.ts
@@ -1,5 +1,5 @@
 import { CORE_IDENTIFIER, CoreEvent } from '@lombokapp/types'
-import { Injectable } from '@nestjs/common'
+import { Injectable, Logger } from '@nestjs/common'
 import { and, eq, isNull } from 'drizzle-orm'
 import { type Event, eventsTable } from 'src/event/entities/event.entity'
 import { OrmService } from 'src/orm/orm.service'
@@ -11,8 +11,17 @@ export interface BatchingDecision {
   requeueDelayMs?: number
 }
 
+/**
+ * Hard ceiling on requeues when an event type has no maxIntervalSeconds. Under
+ * a sane clock the debounce/maxInterval logic flushes long before this; it only
+ * exists so a misbehaving clock can't requeue forever.
+ */
+const ABSOLUTE_MAX_REQUEUES = 100
+
 @Injectable()
 export class NotificationBatchingService {
+  private readonly logger = new Logger(NotificationBatchingService.name)
+
   constructor(private readonly ormService: OrmService) {}
 
   /**
@@ -24,9 +33,11 @@ export class NotificationBatchingService {
     {
       emitterIdentifier,
       eventIdentifier,
+      requeueCount = 0,
     }: {
       eventIdentifier: string
       emitterIdentifier: string
+      requeueCount?: number
     },
   ): Promise<BatchingDecision> {
     const config =
@@ -66,11 +77,35 @@ export class NotificationBatchingService {
       return { shouldFlush: true }
     }
 
+    // Guard against clock anomalies (e.g. an NTP step correcting a drifted
+    // container clock). If an event's createdAt is at or ahead of `now`, the
+    // wall-clock debounce below would compute a negative quietFor, never
+    // satisfy the debounce, and requeue indefinitely. Treat that as "quiet"
+    // and flush rather than spin.
+    if (lastUnhandledAt.getTime() >= now.getTime()) {
+      return { shouldFlush: true }
+    }
+
     // Check debounce: quietFor = now - lastUnhandledAt
     const quietForMs = now.getTime() - lastUnhandledAt.getTime()
     const debounceMs = config.debounceSeconds * 1000
 
     if (quietForMs < debounceMs) {
+      // Backstop: under a sane clock the debounce settles (and maxInterval
+      // force-flushes) within a bounded number of requeues. If we blow past
+      // that ceiling something is wrong with timekeeping — flush rather than
+      // requeue forever. The ceiling tracks maxIntervalSeconds (worst case one
+      // requeue per second until that window elapses) with headroom.
+      const maxRequeues = config.maxIntervalSeconds
+        ? config.maxIntervalSeconds + 10
+        : ABSOLUTE_MAX_REQUEUES
+      if (requeueCount >= maxRequeues) {
+        this.logger.warn(
+          `Forcing notification flush for aggregationKey "${aggregationKey}" after ${requeueCount} requeues (debounce never settled — check for clock drift)`,
+        )
+        return { shouldFlush: true }
+      }
+
       // Not quiet long enough, requeue
       const requeueDelayMs = debounceMs - quietForMs
       return {

--- a/packages/api/src/notification/services/notification-batching.service.unit-spec.ts
+++ b/packages/api/src/notification/services/notification-batching.service.unit-spec.ts
@@ -1,0 +1,96 @@
+import { CORE_IDENTIFIER, CoreEvent } from '@lombokapp/types'
+import { describe, expect, it } from 'bun:test'
+
+import type { Event } from '../../event/entities/event.entity'
+import type { OrmService } from '../../orm/orm.service'
+import { NotificationBatchingService } from './notification-batching.service'
+
+const AGG_KEY = `core:${CoreEvent.object_added}:folder-1:`
+
+const makeEvent = (createdAt: Date): Event => ({
+  id: 'event-id',
+  eventIdentifier: CoreEvent.object_added,
+  emitterId: CORE_IDENTIFIER,
+  aggregationHandledAt: null,
+  aggregationKey: AGG_KEY,
+  targetUserId: null,
+  actorUserId: null,
+  targetLocationFolderId: 'folder-1',
+  targetLocationObjectKey: 'file.txt',
+  data: {},
+  createdAt,
+})
+
+// Minimal stub of the drizzle chain used by shouldFlushEvents:
+//   db.select().from(table).where(cond) -> Promise<Event[]>
+const makeService = (events: Event[]) => {
+  const db = {
+    select: () => ({
+      from: () => ({
+        where: () => Promise.resolve(events),
+      }),
+    }),
+  }
+  return new NotificationBatchingService({ db } as unknown as OrmService)
+}
+
+const eventMeta = {
+  eventIdentifier: CoreEvent.object_added,
+  emitterIdentifier: CORE_IDENTIFIER,
+}
+
+describe('NotificationBatchingService.shouldFlushEvents', () => {
+  it('flushes once the debounce window has gone quiet', async () => {
+    const service = makeService([makeEvent(new Date(Date.now() - 6000))])
+
+    const decision = await service.shouldFlushEvents(AGG_KEY, eventMeta)
+
+    expect(decision.shouldFlush).toBe(true)
+  })
+
+  it('requeues while events are still arriving within the debounce window', async () => {
+    const service = makeService([makeEvent(new Date(Date.now() - 1000))])
+
+    const decision = await service.shouldFlushEvents(AGG_KEY, eventMeta)
+
+    expect(decision.shouldFlush).toBe(false)
+    expect(decision.requeueDelayMs).toBeGreaterThanOrEqual(1000)
+  })
+
+  it('flushes instead of requeuing when an event timestamp is in the future (clock anomaly)', async () => {
+    // Simulates a container clock that ran ahead when the event was written
+    // and was then stepped back: createdAt is ahead of now.
+    const service = makeService([makeEvent(new Date(Date.now() + 120_000))])
+
+    const decision = await service.shouldFlushEvents(AGG_KEY, eventMeta)
+
+    expect(decision.shouldFlush).toBe(true)
+    expect(decision.requeueDelayMs).toBeUndefined()
+  })
+
+  it('force-flushes once the requeue ceiling is exceeded', async () => {
+    // Event is genuinely recent (would normally requeue), but the requeue
+    // count has blown past maxIntervalSeconds (60) + headroom.
+    const service = makeService([makeEvent(new Date(Date.now() - 500))])
+
+    const decision = await service.shouldFlushEvents(AGG_KEY, {
+      ...eventMeta,
+      requeueCount: 100,
+    })
+
+    expect(decision.shouldFlush).toBe(true)
+    expect(decision.requeueDelayMs).toBeUndefined()
+  })
+
+  it('still requeues when below the requeue ceiling', async () => {
+    const service = makeService([makeEvent(new Date(Date.now() - 500))])
+
+    const decision = await service.shouldFlushEvents(AGG_KEY, {
+      ...eventMeta,
+      requeueCount: 3,
+    })
+
+    expect(decision.shouldFlush).toBe(false)
+    expect(decision.requeueDelayMs).toBeGreaterThanOrEqual(1000)
+  })
+})

--- a/packages/api/src/orm/migrations/0000_dark_naoko.sql
+++ b/packages/api/src/orm/migrations/0000_dark_naoko.sql
@@ -3,8 +3,8 @@ CREATE TABLE "app_custom_folder_settings" (
 	"app_id" text NOT NULL,
 	"key" text NOT NULL,
 	"value" jsonb NOT NULL,
-	"created_at" timestamp NOT NULL,
-	"updated_at" timestamp NOT NULL,
+	"created_at" timestamp with time zone NOT NULL,
+	"updated_at" timestamp with time zone NOT NULL,
 	CONSTRAINT "app_custom_folder_settings_folder_id_app_id_key_pk" PRIMARY KEY("folder_id","app_id","key")
 );
 --> statement-breakpoint
@@ -13,8 +13,8 @@ CREATE TABLE "app_custom_user_settings" (
 	"app_id" text NOT NULL,
 	"key" text NOT NULL,
 	"value" jsonb NOT NULL,
-	"created_at" timestamp NOT NULL,
-	"updated_at" timestamp NOT NULL,
+	"created_at" timestamp with time zone NOT NULL,
+	"updated_at" timestamp with time zone NOT NULL,
 	CONSTRAINT "app_custom_user_settings_user_id_app_id_key_pk" PRIMARY KEY("user_id","app_id","key")
 );
 --> statement-breakpoint
@@ -23,8 +23,8 @@ CREATE TABLE "app_folder_settings" (
 	"app_id" text NOT NULL,
 	"enabled" boolean,
 	"permissions" jsonb,
-	"created_at" timestamp NOT NULL,
-	"updated_at" timestamp NOT NULL
+	"created_at" timestamp with time zone NOT NULL,
+	"updated_at" timestamp with time zone NOT NULL
 );
 --> statement-breakpoint
 CREATE TABLE "app_install_sequences" (
@@ -36,8 +36,8 @@ CREATE TABLE "app_runtime_triggers" (
 	"id" uuid PRIMARY KEY NOT NULL,
 	"app_id" text NOT NULL,
 	"definition" jsonb NOT NULL,
-	"created_at" timestamp NOT NULL,
-	"updated_at" timestamp NOT NULL
+	"created_at" timestamp with time zone NOT NULL,
+	"updated_at" timestamp with time zone NOT NULL
 );
 --> statement-breakpoint
 CREATE TABLE "app_user_settings" (
@@ -47,8 +47,8 @@ CREATE TABLE "app_user_settings" (
 	"folder_scope_enabled_default" boolean,
 	"folder_scope_permissions_default" jsonb,
 	"permissions" jsonb,
-	"created_at" timestamp NOT NULL,
-	"updated_at" timestamp NOT NULL
+	"created_at" timestamp with time zone NOT NULL,
+	"updated_at" timestamp with time zone NOT NULL
 );
 --> statement-breakpoint
 CREATE TABLE "apps" (
@@ -70,8 +70,8 @@ CREATE TABLE "apps" (
 	"manifest" jsonb NOT NULL,
 	"container_profiles" jsonb DEFAULT '{}'::jsonb NOT NULL,
 	"enabled" boolean DEFAULT false NOT NULL,
-	"created_at" timestamp NOT NULL,
-	"updated_at" timestamp NOT NULL,
+	"created_at" timestamp with time zone NOT NULL,
+	"updated_at" timestamp with time zone NOT NULL,
 	CONSTRAINT "apps_id_unique" UNIQUE("id")
 );
 --> statement-breakpoint
@@ -81,9 +81,9 @@ CREATE TABLE "session" (
 	"user_id" uuid NOT NULL,
 	"type" text NOT NULL,
 	"type_details" jsonb,
-	"expires_at" timestamp NOT NULL,
-	"created_at" timestamp NOT NULL,
-	"updated_at" timestamp NOT NULL
+	"expires_at" timestamp with time zone NOT NULL,
+	"created_at" timestamp with time zone NOT NULL,
+	"updated_at" timestamp with time zone NOT NULL
 );
 --> statement-breakpoint
 CREATE TABLE "user_identities" (
@@ -93,8 +93,8 @@ CREATE TABLE "user_identities" (
 	"provider_user_id" text NOT NULL,
 	"provider_email" text,
 	"provider_name" text,
-	"created_at" timestamp NOT NULL,
-	"updated_at" timestamp NOT NULL,
+	"created_at" timestamp with time zone NOT NULL,
+	"updated_at" timestamp with time zone NOT NULL,
 	CONSTRAINT "unique_provider_user" UNIQUE("provider","provider_user_id"),
 	CONSTRAINT "unique_user_provider" UNIQUE("user_id","provider")
 );
@@ -102,7 +102,7 @@ CREATE TABLE "user_identities" (
 CREATE TABLE "comment_mentions" (
 	"comment_id" uuid NOT NULL,
 	"user_id" uuid NOT NULL,
-	"created_at" timestamp DEFAULT now() NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
 	CONSTRAINT "comment_mentions_comment_id_user_id_pk" PRIMARY KEY("comment_id","user_id")
 );
 --> statement-breakpoint
@@ -110,7 +110,7 @@ CREATE TABLE "comment_reactions" (
 	"comment_id" uuid NOT NULL,
 	"user_id" uuid NOT NULL,
 	"emoji" text NOT NULL,
-	"created_at" timestamp DEFAULT now() NOT NULL,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
 	CONSTRAINT "comment_reactions_comment_id_user_id_emoji_pk" PRIMARY KEY("comment_id","user_id","emoji")
 );
 --> statement-breakpoint
@@ -123,9 +123,9 @@ CREATE TABLE "comments" (
 	"author_id" uuid NOT NULL,
 	"content" text NOT NULL,
 	"anchor" jsonb,
-	"created_at" timestamp DEFAULT now() NOT NULL,
-	"updated_at" timestamp DEFAULT now() NOT NULL,
-	"deleted_at" timestamp,
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"deleted_at" timestamp with time zone,
 	CONSTRAINT "content_not_empty" CHECK (length(content) > 0),
 	CONSTRAINT "anchor_only_on_root" CHECK (
       (root_id IS NOT NULL AND anchor IS NULL) OR
@@ -143,9 +143,9 @@ CREATE TABLE "docker_hosts" (
 	"is_default" boolean DEFAULT false NOT NULL,
 	"enabled" boolean DEFAULT true NOT NULL,
 	"health_status" text DEFAULT 'unknown' NOT NULL,
-	"last_health_check" timestamp,
-	"created_at" timestamp NOT NULL,
-	"updated_at" timestamp NOT NULL
+	"last_health_check" timestamp with time zone,
+	"created_at" timestamp with time zone NOT NULL,
+	"updated_at" timestamp with time zone NOT NULL
 );
 --> statement-breakpoint
 CREATE TABLE "docker_profile_resource_assignments" (
@@ -155,8 +155,8 @@ CREATE TABLE "docker_profile_resource_assignments" (
 	"docker_host_id" uuid NOT NULL,
 	"config" jsonb DEFAULT '{}'::jsonb NOT NULL,
 	"config_hashes" jsonb DEFAULT '{}'::jsonb NOT NULL,
-	"created_at" timestamp NOT NULL,
-	"updated_at" timestamp NOT NULL
+	"created_at" timestamp with time zone NOT NULL,
+	"updated_at" timestamp with time zone NOT NULL
 );
 --> statement-breakpoint
 CREATE TABLE "docker_registry_credentials" (
@@ -165,8 +165,8 @@ CREATE TABLE "docker_registry_credentials" (
 	"server_address" text NOT NULL,
 	"username" text NOT NULL,
 	"password" text NOT NULL,
-	"created_at" timestamp NOT NULL,
-	"updated_at" timestamp NOT NULL
+	"created_at" timestamp with time zone NOT NULL,
+	"updated_at" timestamp with time zone NOT NULL
 );
 --> statement-breakpoint
 CREATE TABLE "docker_standalone_containers" (
@@ -179,8 +179,8 @@ CREATE TABLE "docker_standalone_containers" (
 	"container_id" text NOT NULL,
 	"config" jsonb DEFAULT '{}'::jsonb NOT NULL,
 	"config_hashes" jsonb DEFAULT '{}'::jsonb NOT NULL,
-	"created_at" timestamp NOT NULL,
-	"updated_at" timestamp NOT NULL
+	"created_at" timestamp with time zone NOT NULL,
+	"updated_at" timestamp with time zone NOT NULL
 );
 --> statement-breakpoint
 CREATE TABLE "events" (
@@ -193,8 +193,8 @@ CREATE TABLE "events" (
 	"target_location_object_key" text,
 	"data" jsonb,
 	"aggregation_key" text,
-	"aggregation_handled_at" timestamp,
-	"created_at" timestamp NOT NULL,
+	"aggregation_handled_at" timestamp with time zone,
+	"created_at" timestamp with time zone NOT NULL,
 	CONSTRAINT "anchor_only_on_root" CHECK (
       (target_user_id IS NOT NULL AND target_location_folder_id IS NULL AND target_location_object_key IS NULL) OR
       (target_user_id IS NULL AND target_location_folder_id IS NULL AND target_location_object_key IS NULL) OR
@@ -216,16 +216,16 @@ CREATE TABLE "folder_objects" (
 	"mime_type" text NOT NULL,
 	"media_type" text NOT NULL,
 	"search_vector" "tsvector" GENERATED ALWAYS AS (setweight(to_tsvector('english', coalesce("folder_objects"."filename", '')), 'A') || setweight(to_tsvector('english', coalesce("folder_objects"."object_key", '')), 'B')) STORED,
-	"created_at" timestamp NOT NULL,
-	"updated_at" timestamp NOT NULL
+	"created_at" timestamp with time zone NOT NULL,
+	"updated_at" timestamp with time zone NOT NULL
 );
 --> statement-breakpoint
 CREATE TABLE "folder_shares" (
 	"folder_id" uuid NOT NULL,
 	"user_id" uuid NOT NULL,
 	"permissions" text[] NOT NULL,
-	"created_at" timestamp DEFAULT CURRENT_TIMESTAMP NOT NULL,
-	"updated_at" timestamp DEFAULT CURRENT_TIMESTAMP NOT NULL
+	"created_at" timestamp with time zone DEFAULT CURRENT_TIMESTAMP NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT CURRENT_TIMESTAMP NOT NULL
 );
 --> statement-breakpoint
 CREATE TABLE "folders" (
@@ -235,9 +235,9 @@ CREATE TABLE "folders" (
 	"metadata_location_id" uuid NOT NULL,
 	"owner_id" uuid NOT NULL,
 	"access_error" jsonb,
-	"icon_updated_at" timestamp,
-	"created_at" timestamp NOT NULL,
-	"updated_at" timestamp NOT NULL
+	"icon_updated_at" timestamp with time zone,
+	"created_at" timestamp with time zone NOT NULL,
+	"updated_at" timestamp with time zone NOT NULL
 );
 --> statement-breakpoint
 CREATE TABLE "log_entries" (
@@ -248,7 +248,7 @@ CREATE TABLE "log_entries" (
 	"target_location_object_key" text,
 	"level" text NOT NULL,
 	"data" jsonb,
-	"created_at" timestamp NOT NULL
+	"created_at" timestamp with time zone NOT NULL
 );
 --> statement-breakpoint
 CREATE TABLE "mcp_folder_settings" (
@@ -258,8 +258,8 @@ CREATE TABLE "mcp_folder_settings" (
 	"can_write" boolean,
 	"can_delete" boolean,
 	"can_move" boolean,
-	"created_at" timestamp NOT NULL,
-	"updated_at" timestamp NOT NULL
+	"created_at" timestamp with time zone NOT NULL,
+	"updated_at" timestamp with time zone NOT NULL
 );
 --> statement-breakpoint
 CREATE TABLE "mcp_user_settings" (
@@ -268,24 +268,24 @@ CREATE TABLE "mcp_user_settings" (
 	"can_write" boolean,
 	"can_delete" boolean,
 	"can_move" boolean,
-	"created_at" timestamp NOT NULL,
-	"updated_at" timestamp NOT NULL
+	"created_at" timestamp with time zone NOT NULL,
+	"updated_at" timestamp with time zone NOT NULL
 );
 --> statement-breakpoint
 CREATE TABLE "notification_deliveries" (
 	"id" uuid PRIMARY KEY DEFAULT gen_random_uuid() NOT NULL,
 	"notification_id" uuid NOT NULL,
 	"user_id" uuid NOT NULL,
-	"read_at" timestamp,
+	"read_at" timestamp with time zone,
 	"email_status" text,
-	"email_sent_at" timestamp,
-	"email_failed_at" timestamp,
+	"email_sent_at" timestamp with time zone,
+	"email_failed_at" timestamp with time zone,
 	"email_error" jsonb,
 	"mobile_status" text,
-	"mobile_sent_at" timestamp,
-	"mobile_failed_at" timestamp,
+	"mobile_sent_at" timestamp with time zone,
+	"mobile_failed_at" timestamp with time zone,
 	"mobile_error" jsonb,
-	"created_at" timestamp DEFAULT now() NOT NULL
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL
 );
 --> statement-breakpoint
 CREATE TABLE "notification_settings" (
@@ -295,8 +295,8 @@ CREATE TABLE "notification_settings" (
 	"channel" text NOT NULL,
 	"enabled" boolean NOT NULL,
 	"folder_id" uuid,
-	"created_at" timestamp DEFAULT now() NOT NULL,
-	"updated_at" timestamp DEFAULT now() NOT NULL
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL,
+	"updated_at" timestamp with time zone DEFAULT now() NOT NULL
 );
 --> statement-breakpoint
 CREATE TABLE "notifications" (
@@ -312,14 +312,14 @@ CREATE TABLE "notifications" (
 	"body" text,
 	"image" text,
 	"path" text,
-	"created_at" timestamp DEFAULT now() NOT NULL
+	"created_at" timestamp with time zone DEFAULT now() NOT NULL
 );
 --> statement-breakpoint
 CREATE TABLE "server_settings" (
 	"key" text PRIMARY KEY NOT NULL,
 	"value" jsonb,
-	"created_at" timestamp NOT NULL,
-	"updated_at" timestamp NOT NULL
+	"created_at" timestamp with time zone NOT NULL,
+	"updated_at" timestamp with time zone NOT NULL
 );
 --> statement-breakpoint
 CREATE TABLE "storage_locations" (
@@ -335,8 +335,8 @@ CREATE TABLE "storage_locations" (
 	"bucket" text NOT NULL,
 	"prefix" text NOT NULL,
 	"user_id" uuid NOT NULL,
-	"created_at" timestamp NOT NULL,
-	"updated_at" timestamp NOT NULL
+	"created_at" timestamp with time zone NOT NULL,
+	"updated_at" timestamp with time zone NOT NULL
 );
 --> statement-breakpoint
 CREATE TABLE "tasks" (
@@ -350,20 +350,20 @@ CREATE TABLE "tasks" (
 	"target_user_id" uuid,
 	"target_location_folder_id" uuid,
 	"target_location_object_key" text,
-	"started_at" timestamp,
-	"completed_at" timestamp,
+	"started_at" timestamp with time zone,
+	"completed_at" timestamp with time zone,
 	"attempt_count" integer DEFAULT 0 NOT NULL,
 	"failure_count" integer DEFAULT 0 NOT NULL,
-	"dont_start_before" timestamp,
+	"dont_start_before" timestamp with time zone,
 	"system_log" jsonb DEFAULT '[]'::jsonb NOT NULL,
 	"task_log" jsonb DEFAULT '[]'::jsonb NOT NULL,
 	"storage_access_policy" jsonb,
 	"success" boolean,
 	"user_visible" boolean DEFAULT true,
 	"error" jsonb,
-	"created_at" timestamp NOT NULL,
-	"updated_at" timestamp NOT NULL,
-	"latest_heartbeat_at" timestamp,
+	"created_at" timestamp with time zone NOT NULL,
+	"updated_at" timestamp with time zone NOT NULL,
+	"latest_heartbeat_at" timestamp with time zone,
 	"handler_type" text NOT NULL,
 	"handler_identifier" text,
 	"progress_reports" jsonb DEFAULT '[]'::jsonb NOT NULL,
@@ -383,9 +383,9 @@ CREATE TABLE "users" (
 	"permissions" jsonb DEFAULT '[]'::jsonb NOT NULL,
 	"password_hash" text,
 	"password_salt" text,
-	"avatar_updated_at" timestamp,
-	"created_at" timestamp NOT NULL,
-	"updated_at" timestamp NOT NULL
+	"avatar_updated_at" timestamp with time zone,
+	"created_at" timestamp with time zone NOT NULL,
+	"updated_at" timestamp with time zone NOT NULL
 );
 --> statement-breakpoint
 ALTER TABLE "app_custom_folder_settings" ADD CONSTRAINT "app_custom_folder_settings_folder_id_folders_id_fk" FOREIGN KEY ("folder_id") REFERENCES "public"."folders"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint

--- a/packages/api/src/orm/migrations/meta/0000_snapshot.json
+++ b/packages/api/src/orm/migrations/meta/0000_snapshot.json
@@ -1,5 +1,5 @@
 {
-  "id": "877f1f31-989b-4e60-9ae8-d8c9f42bc3aa",
+  "id": "d1d29cd0-e198-46a5-abb4-e3ba0991eb2e",
   "prevId": "00000000-0000-0000-0000-000000000000",
   "version": "7",
   "dialect": "postgresql",
@@ -34,13 +34,13 @@
         },
         "created_at": {
           "name": "created_at",
-          "type": "timestamp",
+          "type": "timestamp with time zone",
           "primaryKey": false,
           "notNull": true
         },
         "updated_at": {
           "name": "updated_at",
-          "type": "timestamp",
+          "type": "timestamp with time zone",
           "primaryKey": false,
           "notNull": true
         }
@@ -141,13 +141,13 @@
         },
         "created_at": {
           "name": "created_at",
-          "type": "timestamp",
+          "type": "timestamp with time zone",
           "primaryKey": false,
           "notNull": true
         },
         "updated_at": {
           "name": "updated_at",
-          "type": "timestamp",
+          "type": "timestamp with time zone",
           "primaryKey": false,
           "notNull": true
         }
@@ -248,13 +248,13 @@
         },
         "created_at": {
           "name": "created_at",
-          "type": "timestamp",
+          "type": "timestamp with time zone",
           "primaryKey": false,
           "notNull": true
         },
         "updated_at": {
           "name": "updated_at",
-          "type": "timestamp",
+          "type": "timestamp with time zone",
           "primaryKey": false,
           "notNull": true
         }
@@ -380,13 +380,13 @@
         },
         "created_at": {
           "name": "created_at",
-          "type": "timestamp",
+          "type": "timestamp with time zone",
           "primaryKey": false,
           "notNull": true
         },
         "updated_at": {
           "name": "updated_at",
-          "type": "timestamp",
+          "type": "timestamp with time zone",
           "primaryKey": false,
           "notNull": true
         }
@@ -509,13 +509,13 @@
         },
         "created_at": {
           "name": "created_at",
-          "type": "timestamp",
+          "type": "timestamp with time zone",
           "primaryKey": false,
           "notNull": true
         },
         "updated_at": {
           "name": "updated_at",
-          "type": "timestamp",
+          "type": "timestamp with time zone",
           "primaryKey": false,
           "notNull": true
         }
@@ -712,13 +712,13 @@
         },
         "created_at": {
           "name": "created_at",
-          "type": "timestamp",
+          "type": "timestamp with time zone",
           "primaryKey": false,
           "notNull": true
         },
         "updated_at": {
           "name": "updated_at",
-          "type": "timestamp",
+          "type": "timestamp with time zone",
           "primaryKey": false,
           "notNull": true
         }
@@ -791,19 +791,19 @@
         },
         "expires_at": {
           "name": "expires_at",
-          "type": "timestamp",
+          "type": "timestamp with time zone",
           "primaryKey": false,
           "notNull": true
         },
         "created_at": {
           "name": "created_at",
-          "type": "timestamp",
+          "type": "timestamp with time zone",
           "primaryKey": false,
           "notNull": true
         },
         "updated_at": {
           "name": "updated_at",
-          "type": "timestamp",
+          "type": "timestamp with time zone",
           "primaryKey": false,
           "notNull": true
         }
@@ -889,13 +889,13 @@
         },
         "created_at": {
           "name": "created_at",
-          "type": "timestamp",
+          "type": "timestamp with time zone",
           "primaryKey": false,
           "notNull": true
         },
         "updated_at": {
           "name": "updated_at",
-          "type": "timestamp",
+          "type": "timestamp with time zone",
           "primaryKey": false,
           "notNull": true
         }
@@ -957,7 +957,7 @@
         },
         "created_at": {
           "name": "created_at",
-          "type": "timestamp",
+          "type": "timestamp with time zone",
           "primaryKey": false,
           "notNull": true,
           "default": "now()"
@@ -1052,7 +1052,7 @@
         },
         "created_at": {
           "name": "created_at",
-          "type": "timestamp",
+          "type": "timestamp with time zone",
           "primaryKey": false,
           "notNull": true,
           "default": "now()"
@@ -1179,21 +1179,21 @@
         },
         "created_at": {
           "name": "created_at",
-          "type": "timestamp",
+          "type": "timestamp with time zone",
           "primaryKey": false,
           "notNull": true,
           "default": "now()"
         },
         "updated_at": {
           "name": "updated_at",
-          "type": "timestamp",
+          "type": "timestamp with time zone",
           "primaryKey": false,
           "notNull": true,
           "default": "now()"
         },
         "deleted_at": {
           "name": "deleted_at",
-          "type": "timestamp",
+          "type": "timestamp with time zone",
           "primaryKey": false,
           "notNull": false
         }
@@ -1435,19 +1435,19 @@
         },
         "last_health_check": {
           "name": "last_health_check",
-          "type": "timestamp",
+          "type": "timestamp with time zone",
           "primaryKey": false,
           "notNull": false
         },
         "created_at": {
           "name": "created_at",
-          "type": "timestamp",
+          "type": "timestamp with time zone",
           "primaryKey": false,
           "notNull": true
         },
         "updated_at": {
           "name": "updated_at",
-          "type": "timestamp",
+          "type": "timestamp with time zone",
           "primaryKey": false,
           "notNull": true
         }
@@ -1535,13 +1535,13 @@
         },
         "created_at": {
           "name": "created_at",
-          "type": "timestamp",
+          "type": "timestamp with time zone",
           "primaryKey": false,
           "notNull": true
         },
         "updated_at": {
           "name": "updated_at",
-          "type": "timestamp",
+          "type": "timestamp with time zone",
           "primaryKey": false,
           "notNull": true
         }
@@ -1669,13 +1669,13 @@
         },
         "created_at": {
           "name": "created_at",
-          "type": "timestamp",
+          "type": "timestamp with time zone",
           "primaryKey": false,
           "notNull": true
         },
         "updated_at": {
           "name": "updated_at",
-          "type": "timestamp",
+          "type": "timestamp with time zone",
           "primaryKey": false,
           "notNull": true
         }
@@ -1768,13 +1768,13 @@
         },
         "created_at": {
           "name": "created_at",
-          "type": "timestamp",
+          "type": "timestamp with time zone",
           "primaryKey": false,
           "notNull": true
         },
         "updated_at": {
           "name": "updated_at",
-          "type": "timestamp",
+          "type": "timestamp with time zone",
           "primaryKey": false,
           "notNull": true
         }
@@ -1892,13 +1892,13 @@
         },
         "aggregation_handled_at": {
           "name": "aggregation_handled_at",
-          "type": "timestamp",
+          "type": "timestamp with time zone",
           "primaryKey": false,
           "notNull": false
         },
         "created_at": {
           "name": "created_at",
-          "type": "timestamp",
+          "type": "timestamp with time zone",
           "primaryKey": false,
           "notNull": true
         }
@@ -2140,13 +2140,13 @@
         },
         "created_at": {
           "name": "created_at",
-          "type": "timestamp",
+          "type": "timestamp with time zone",
           "primaryKey": false,
           "notNull": true
         },
         "updated_at": {
           "name": "updated_at",
-          "type": "timestamp",
+          "type": "timestamp with time zone",
           "primaryKey": false,
           "notNull": true
         }
@@ -2298,14 +2298,14 @@
         },
         "created_at": {
           "name": "created_at",
-          "type": "timestamp",
+          "type": "timestamp with time zone",
           "primaryKey": false,
           "notNull": true,
           "default": "CURRENT_TIMESTAMP"
         },
         "updated_at": {
           "name": "updated_at",
-          "type": "timestamp",
+          "type": "timestamp with time zone",
           "primaryKey": false,
           "notNull": true,
           "default": "CURRENT_TIMESTAMP"
@@ -2425,19 +2425,19 @@
         },
         "icon_updated_at": {
           "name": "icon_updated_at",
-          "type": "timestamp",
+          "type": "timestamp with time zone",
           "primaryKey": false,
           "notNull": false
         },
         "created_at": {
           "name": "created_at",
-          "type": "timestamp",
+          "type": "timestamp with time zone",
           "primaryKey": false,
           "notNull": true
         },
         "updated_at": {
           "name": "updated_at",
-          "type": "timestamp",
+          "type": "timestamp with time zone",
           "primaryKey": false,
           "notNull": true
         }
@@ -2584,7 +2584,7 @@
         },
         "created_at": {
           "name": "created_at",
-          "type": "timestamp",
+          "type": "timestamp with time zone",
           "primaryKey": false,
           "notNull": true
         }
@@ -2736,13 +2736,13 @@
         },
         "created_at": {
           "name": "created_at",
-          "type": "timestamp",
+          "type": "timestamp with time zone",
           "primaryKey": false,
           "notNull": true
         },
         "updated_at": {
           "name": "updated_at",
-          "type": "timestamp",
+          "type": "timestamp with time zone",
           "primaryKey": false,
           "notNull": true
         }
@@ -2840,13 +2840,13 @@
         },
         "created_at": {
           "name": "created_at",
-          "type": "timestamp",
+          "type": "timestamp with time zone",
           "primaryKey": false,
           "notNull": true
         },
         "updated_at": {
           "name": "updated_at",
-          "type": "timestamp",
+          "type": "timestamp with time zone",
           "primaryKey": false,
           "notNull": true
         }
@@ -2914,7 +2914,7 @@
         },
         "read_at": {
           "name": "read_at",
-          "type": "timestamp",
+          "type": "timestamp with time zone",
           "primaryKey": false,
           "notNull": false
         },
@@ -2926,13 +2926,13 @@
         },
         "email_sent_at": {
           "name": "email_sent_at",
-          "type": "timestamp",
+          "type": "timestamp with time zone",
           "primaryKey": false,
           "notNull": false
         },
         "email_failed_at": {
           "name": "email_failed_at",
-          "type": "timestamp",
+          "type": "timestamp with time zone",
           "primaryKey": false,
           "notNull": false
         },
@@ -2950,13 +2950,13 @@
         },
         "mobile_sent_at": {
           "name": "mobile_sent_at",
-          "type": "timestamp",
+          "type": "timestamp with time zone",
           "primaryKey": false,
           "notNull": false
         },
         "mobile_failed_at": {
           "name": "mobile_failed_at",
-          "type": "timestamp",
+          "type": "timestamp with time zone",
           "primaryKey": false,
           "notNull": false
         },
@@ -2968,7 +2968,7 @@
         },
         "created_at": {
           "name": "created_at",
-          "type": "timestamp",
+          "type": "timestamp with time zone",
           "primaryKey": false,
           "notNull": true,
           "default": "now()"
@@ -3103,14 +3103,14 @@
         },
         "created_at": {
           "name": "created_at",
-          "type": "timestamp",
+          "type": "timestamp with time zone",
           "primaryKey": false,
           "notNull": true,
           "default": "now()"
         },
         "updated_at": {
           "name": "updated_at",
-          "type": "timestamp",
+          "type": "timestamp with time zone",
           "primaryKey": false,
           "notNull": true,
           "default": "now()"
@@ -3321,7 +3321,7 @@
         },
         "created_at": {
           "name": "created_at",
-          "type": "timestamp",
+          "type": "timestamp with time zone",
           "primaryKey": false,
           "notNull": true,
           "default": "now()"
@@ -3447,13 +3447,13 @@
         },
         "created_at": {
           "name": "created_at",
-          "type": "timestamp",
+          "type": "timestamp with time zone",
           "primaryKey": false,
           "notNull": true
         },
         "updated_at": {
           "name": "updated_at",
-          "type": "timestamp",
+          "type": "timestamp with time zone",
           "primaryKey": false,
           "notNull": true
         }
@@ -3544,13 +3544,13 @@
         },
         "created_at": {
           "name": "created_at",
-          "type": "timestamp",
+          "type": "timestamp with time zone",
           "primaryKey": false,
           "notNull": true
         },
         "updated_at": {
           "name": "updated_at",
-          "type": "timestamp",
+          "type": "timestamp with time zone",
           "primaryKey": false,
           "notNull": true
         }
@@ -3716,13 +3716,13 @@
         },
         "started_at": {
           "name": "started_at",
-          "type": "timestamp",
+          "type": "timestamp with time zone",
           "primaryKey": false,
           "notNull": false
         },
         "completed_at": {
           "name": "completed_at",
-          "type": "timestamp",
+          "type": "timestamp with time zone",
           "primaryKey": false,
           "notNull": false
         },
@@ -3742,7 +3742,7 @@
         },
         "dont_start_before": {
           "name": "dont_start_before",
-          "type": "timestamp",
+          "type": "timestamp with time zone",
           "primaryKey": false,
           "notNull": false
         },
@@ -3787,19 +3787,19 @@
         },
         "created_at": {
           "name": "created_at",
-          "type": "timestamp",
+          "type": "timestamp with time zone",
           "primaryKey": false,
           "notNull": true
         },
         "updated_at": {
           "name": "updated_at",
-          "type": "timestamp",
+          "type": "timestamp with time zone",
           "primaryKey": false,
           "notNull": true
         },
         "latest_heartbeat_at": {
           "name": "latest_heartbeat_at",
-          "type": "timestamp",
+          "type": "timestamp with time zone",
           "primaryKey": false,
           "notNull": false
         },
@@ -4072,19 +4072,19 @@
         },
         "avatar_updated_at": {
           "name": "avatar_updated_at",
-          "type": "timestamp",
+          "type": "timestamp with time zone",
           "primaryKey": false,
           "notNull": false
         },
         "created_at": {
           "name": "created_at",
-          "type": "timestamp",
+          "type": "timestamp with time zone",
           "primaryKey": false,
           "notNull": true
         },
         "updated_at": {
           "name": "updated_at",
-          "type": "timestamp",
+          "type": "timestamp with time zone",
           "primaryKey": false,
           "notNull": true
         }

--- a/packages/api/src/orm/migrations/meta/_journal.json
+++ b/packages/api/src/orm/migrations/meta/_journal.json
@@ -5,8 +5,8 @@
     {
       "idx": 0,
       "version": "7",
-      "when": 1779993864266,
-      "tag": "0000_ordinary_trish_tilby",
+      "when": 1780048505649,
+      "tag": "0000_dark_naoko",
       "breakpoints": true
     }
   ]

--- a/packages/api/src/server/entities/server-configuration.entity.ts
+++ b/packages/api/src/server/entities/server-configuration.entity.ts
@@ -4,8 +4,8 @@ import { jsonbBase64 } from 'src/orm/util/json-base64-type'
 export const serverSettingsTable = pgTable('server_settings', {
   key: text('key').primaryKey(),
   value: jsonbBase64('value').$type<unknown>(),
-  createdAt: timestamp('created_at').notNull(),
-  updatedAt: timestamp('updated_at').notNull(),
+  createdAt: timestamp('created_at', { withTimezone: true }).notNull(),
+  updatedAt: timestamp('updated_at', { withTimezone: true }).notNull(),
 })
 
 export type ServerSetting = typeof serverSettingsTable.$inferSelect

--- a/packages/api/src/storage/entities/storage-location.entity.ts
+++ b/packages/api/src/storage/entities/storage-location.entity.ts
@@ -18,8 +18,8 @@ export const storageLocationsTable = pgTable(
     userId: uuid('user_id')
       .notNull()
       .references(() => usersTable.id),
-    createdAt: timestamp('created_at').notNull(),
-    updatedAt: timestamp('updated_at').notNull(),
+    createdAt: timestamp('created_at', { withTimezone: true }).notNull(),
+    updatedAt: timestamp('updated_at', { withTimezone: true }).notNull(),
   },
   (table) => [
     index('storage_locations_user_id_idx').on(table.userId),

--- a/packages/api/src/task/entities/task.entity.ts
+++ b/packages/api/src/task/entities/task.entity.ts
@@ -72,11 +72,11 @@ export const tasksTable = pgTable(
     targetUserId: uuid('target_user_id'),
     targetLocationFolderId: uuid('target_location_folder_id'),
     targetLocationObjectKey: text('target_location_object_key'),
-    startedAt: timestamp('started_at'),
-    completedAt: timestamp('completed_at'),
+    startedAt: timestamp('started_at', { withTimezone: true }),
+    completedAt: timestamp('completed_at', { withTimezone: true }),
     attemptCount: integer('attempt_count').notNull().default(0),
     failureCount: integer('failure_count').notNull().default(0),
-    dontStartBefore: timestamp('dont_start_before'),
+    dontStartBefore: timestamp('dont_start_before', { withTimezone: true }),
     systemLog: logJsonb<SystemLogEntry>('system_log').notNull().default([]),
     taskLog: logJsonb<TaskLogEntry>('task_log').notNull().default([]),
     storageAccessPolicy: jsonbBase64(
@@ -90,9 +90,9 @@ export const tasksTable = pgTable(
       message: string
       details?: JsonSerializableObject
     }>(),
-    createdAt: timestamp('created_at').notNull(),
-    updatedAt: timestamp('updated_at').notNull(),
-    latestHeartbeatAt: timestamp('latest_heartbeat_at'),
+    createdAt: timestamp('created_at', { withTimezone: true }).notNull(),
+    updatedAt: timestamp('updated_at', { withTimezone: true }).notNull(),
+    latestHeartbeatAt: timestamp('latest_heartbeat_at', { withTimezone: true }),
     handlerType: text('handler_type').notNull(),
     handlerIdentifier: text('handler_identifier'),
     progressReports: jsonb('progress_reports')

--- a/packages/api/src/task/services/core-task.service.ts
+++ b/packages/api/src/task/services/core-task.service.ts
@@ -5,7 +5,7 @@ import {
 } from '@lombokapp/types'
 import { AsyncWorkError, buildUnexpectedError } from '@lombokapp/worker-utils'
 import { forwardRef, Inject, Injectable, Logger } from '@nestjs/common'
-import { and, count, eq, isNull, lt, or, sql } from 'drizzle-orm'
+import { and, count, eq, isNull, lt, lte, or, sql } from 'drizzle-orm'
 import { AppService } from 'src/app/services/app.service'
 import { OrmService } from 'src/orm/orm.service'
 import { runWithThreadContext } from 'src/shared/thread-context'
@@ -75,6 +75,29 @@ export class CoreTaskService {
     }
   }
 
+  /**
+   * Predicate for core tasks that are eligible to start now.
+   *
+   * `dont_start_before` is compared against the Node clock (`new Date()`), NOT
+   * Postgres `NOW()`. Those columns are written from the Node clock, so the
+   * comparison must use the same clock — on hosts where the Postgres and Node
+   * clocks drift apart, `NOW()` lets tasks start before their
+   * `dont_start_before` delay. For self-requeuing batch tasks (e.g. event
+   * notifications) that turns the requeue delay into a no-op and the drain
+   * spins, producing dozens of redundant tasks per debounce window.
+   */
+  private startableCoreTaskWhere() {
+    return and(
+      isNull(tasksTable.startedAt),
+      lt(tasksTable.attemptCount, MAX_TASK_ATTEMPTS),
+      or(
+        isNull(tasksTable.dontStartBefore),
+        lte(tasksTable.dontStartBefore, new Date()),
+      ),
+      eq(tasksTable.ownerId, CORE_IDENTIFIER),
+    )
+  }
+
   private async _drainCoreTasks() {
     const taskExecutionLimit = Math.max(
       MAX_CONCURRENT_CORE_TASKS - this.runningTasksCount,
@@ -85,17 +108,7 @@ export class CoreTaskService {
       const coreTasksToExecute = await this.ormService.db
         .select({ taskId: tasksTable.id })
         .from(tasksTable)
-        .where(
-          and(
-            isNull(tasksTable.startedAt),
-            lt(tasksTable.attemptCount, MAX_TASK_ATTEMPTS),
-            or(
-              isNull(tasksTable.dontStartBefore),
-              sql`${tasksTable.dontStartBefore} <= NOW()`,
-            ),
-            eq(tasksTable.ownerId, CORE_IDENTIFIER),
-          ),
-        )
+        .where(this.startableCoreTaskWhere())
         .limit(taskExecutionLimit)
       for (const { taskId } of coreTasksToExecute) {
         await this.executeCoreTask(taskId)
@@ -114,17 +127,7 @@ export class CoreTaskService {
         count: count(),
       })
       .from(tasksTable)
-      .where(
-        and(
-          isNull(tasksTable.startedAt),
-          lt(tasksTable.attemptCount, MAX_TASK_ATTEMPTS),
-          or(
-            isNull(tasksTable.dontStartBefore),
-            sql`${tasksTable.dontStartBefore} <= NOW()`,
-          ),
-          eq(tasksTable.ownerId, CORE_IDENTIFIER),
-        ),
-      )
+      .where(this.startableCoreTaskWhere())
     // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
     return unstartedCoreTaskCountResult!.count
   }

--- a/packages/api/src/task/task.constants.ts
+++ b/packages/api/src/task/task.constants.ts
@@ -36,6 +36,7 @@ export interface CoreTaskData {
   }
   [CoreTaskName.CreateEventNotifications]: {
     aggregationKey: string
+    requeueCount?: number
   }
   [CoreTaskName.BuildNotificationDeliveries]: {
     notificationId: string

--- a/packages/api/src/users/entities/user.entity.ts
+++ b/packages/api/src/users/entities/user.entity.ts
@@ -23,9 +23,9 @@ export const usersTable = pgTable(
     permissions: jsonb('permissions').$type<string[]>().notNull().default([]),
     passwordHash: text('password_hash'),
     passwordSalt: text('password_salt'),
-    avatarUpdatedAt: timestamp('avatar_updated_at'),
-    createdAt: timestamp('created_at').notNull(),
-    updatedAt: timestamp('updated_at').notNull(),
+    avatarUpdatedAt: timestamp('avatar_updated_at', { withTimezone: true }),
+    createdAt: timestamp('created_at', { withTimezone: true }).notNull(),
+    updatedAt: timestamp('updated_at', { withTimezone: true }).notNull(),
   },
   (table) => [
     // Case-insensitive unique index on username


### PR DESCRIPTION
## Summary

Two fixes for the same time-drift root cause, shipped together:

- **Notification task timing guards** (LOM-348) — `create_event_notifications` could requeue itself indefinitely under PG `NOW()` vs Node clock drift, spamming the task queue. Carry a `requeueCount` through the task data and enforce an `ABSOLUTE_MAX_REQUEUES` ceiling; gate `dontStartBefore` on the Node clock. (`create-event-notifications.processor`, `notification-batching.service` + unit spec, `core-task.service`, `task.constants`.)
- **Timezone-aware timestamp columns** (LOM-349) — timestamp columns were stored without a timezone, so postgres interpreted them in a different tz than Node, surfacing as spurious current-time skew. Switch entity timestamp columns to `{ withTimezone: true }` across all entities, with the drizzle migration regenerated.

## Test plan

- `./dx check all` — green.
- `packages/api` unit tests — 246 pass / 0 fail (notification-batching spec exercises the `ABSOLUTE_MAX_REQUEUES` ceiling).
- Full API e2e — **589 pass / 0 fail across 65 files** (exercises the regenerated migration across all entities).

Closes LOM-348
Closes LOM-349
