### PR TITLE
fix(LOM-354): core-worker loopback URL — correct internal port + make it injectable

### DIFF
--- a/packages/api/src/core-worker/core-worker.module.ts
+++ b/packages/api/src/core-worker/core-worker.module.ts
@@ -20,6 +20,9 @@ import { RunServerlessWorkerTaskProcessor } from './processors/run-serverless-wo
     forwardRef(() => NotificationModule),
   ],
   providers: [
+    // Port the core worker calls back into our own HTTP server on (loopback).
+    // Prod always listens on 3000; tests override this to their server port.
+    { provide: 'INTERNAL_API_PORT', useValue: 3000 },
     CoreWorkerService,
     RunServerlessWorkerTaskProcessor,
     AnalyzeObjectProcessor,

--- a/packages/api/src/core-worker/core-worker.service.ts
+++ b/packages/api/src/core-worker/core-worker.service.ts
@@ -58,6 +58,8 @@ export class CoreWorkerService {
   constructor(
     @Inject(coreConfig.KEY)
     private readonly _coreConfig: nestjsConfig.ConfigType<typeof coreConfig>,
+    @Inject('INTERNAL_API_PORT')
+    private readonly internalApiPort: number,
     private readonly keyDerivationService: KeyDerivationService,
     private readonly ormService: OrmService,
     @Inject(forwardRef(() => AppService))
@@ -95,9 +97,10 @@ export class CoreWorkerService {
   }
 
   private getServerBaseUrl() {
-    // Loopback call back into our own HTTP server, which always listens on
-    // plain http :3000. TLS is terminated by the upstream proxy, not here.
-    return 'http://127.0.0.1:3000'
+    // Loopback call back into our own HTTP server (plain http; TLS is
+    // terminated by the upstream proxy, not here). Port is injected so tests
+    // can override it to their own server's port.
+    return `http://127.0.0.1:${this.internalApiPort}`
   }
 
   isReady() {

--- a/packages/api/src/core-worker/core-worker.service.ts
+++ b/packages/api/src/core-worker/core-worker.service.ts
@@ -95,9 +95,9 @@ export class CoreWorkerService {
   }
 
   private getServerBaseUrl() {
-    const port = this._coreConfig.platformPort ?? 3000
-    const protocol = this._coreConfig.platformHttps ? 'https' : 'http'
-    return `${protocol}://127.0.0.1:${port}`
+    // Loopback call back into our own HTTP server, which always listens on
+    // plain http :3000. TLS is terminated by the upstream proxy, not here.
+    return 'http://127.0.0.1:3000'
   }
 
   isReady() {

--- a/packages/api/src/test/test.util.ts
+++ b/packages/api/src/test/test.util.ts
@@ -115,6 +115,11 @@ export async function buildTestModule({
         token: coreConfig.KEY,
         value: { ...coreConfig(), disableCoreWorker: !startCoreWorker },
       },
+      // Point the core worker's loopback at the port this suite listens on,
+      // so its callbacks reach the test server rather than the prod default.
+      ...(typeof startServerOnPort === 'number'
+        ? [{ token: 'INTERNAL_API_PORT', value: startServerOnPort }]
+        : []),
     ]
 
   const logger = new NoPrefixConsoleLogger({

--- a/packages/core-worker/src/worker-scripts/run-worker.ts
+++ b/packages/core-worker/src/worker-scripts/run-worker.ts
@@ -188,7 +188,15 @@ class SocketServer {
 
     // eslint-disable-next-line promise/param-names
     const timeoutPromise = new Promise<never>((_, reject) => {
-      setTimeout(() => reject(new Error('Connection timeout')), timeoutMs)
+      setTimeout(
+        () =>
+          reject(
+            new Error(
+              `Timed out after ${timeoutMs}ms waiting for worker daemon on ${this.socketPath}`,
+            ),
+          ),
+        timeoutMs,
+      )
     })
 
     return Promise.race([this.connectionPromise, timeoutPromise])
@@ -1396,7 +1404,8 @@ async function createWorkerProcess(
     stderr: 'inherit',
   })
 
-  // Wait for the worker daemon to connect to our socket server
+  // Wait for the worker daemon to connect, failing fast if the process exits
+  // first rather than waiting out the full connection timeout.
   if (LOMBOK_SOCKET_DEBUG) {
     // eslint-disable-next-line no-console
     console.log(
@@ -1405,7 +1414,31 @@ async function createWorkerProcess(
     )
   }
 
-  const clientSocket = await socketServer.waitForConnection(30000)
+  let daemonExitCode: number | null = null
+  const daemonExited = proc.exited.then((code) => {
+    daemonExitCode = code
+    return code
+  })
+
+  const clientSocket = await Promise.race<Socket | null>([
+    socketServer.waitForConnection(30000),
+    daemonExited.then(() => null).catch(() => null),
+  ])
+
+  if (clientSocket === null) {
+    shuttingDownWorkers.add(workerId)
+    try {
+      if (!proc.killed) {
+        proc.kill()
+      }
+    } catch {
+      // ignore
+    }
+    await socketServer.close().catch(() => undefined)
+    throw new Error(
+      `Worker daemon ${workerId} exited (code=${daemonExitCode}) before connecting on ${socketPath}`,
+    )
+  }
 
   if (LOMBOK_SOCKET_DEBUG) {
     // eslint-disable-next-line no-console


### PR DESCRIPTION
## Summary

Two commits fixing the core worker's platform loopback URL (they ship together — the first is the prod fix, the second makes it testable):

- **Correct the server URL** (`getServerBaseUrl`) — it derived the loopback port from `platformPort` (the public-facing port) rather than the internal HTTP server port. Point it at the internal port (plain http; TLS terminated upstream). Also adds fail-fast detection in `run-worker` when the worker daemon exits before connecting (clearer than the old 30s timeout).
- **Make the port injectable** — declare `'INTERNAL_API_PORT'` (`useValue: 3000`) in `CoreWorkerModule`, inject into `CoreWorkerService`, and have `buildTestModule` override it from the suite's `startServerOnPort`. Without this the core-worker e2e fails (the test server runs on a non-3000 port).

## Test plan

- `./dx check all` — green.
- Core-worker e2e — **12 pass / 0 fail** (with the prod hardcode alone these would fail; the DI override fixes them).

Closes LOM-354
