### PR TITLE
fix(LOM-357): share one pg.Pool per worker daemon

### DIFF
--- a/packages/app-worker-sdk/src/app-worker-sdk.ts
+++ b/packages/app-worker-sdk/src/app-worker-sdk.ts
@@ -329,6 +329,9 @@ export class LombokAppPgClient {
         // helper that uses the pool client instead of the tx) hangs
         // forever; with it, the second checkout throws after 10s.
         connectionTimeoutMillis: 10_000,
+        // Bound per-daemon pools so one app can't exhaust shared PG slots.
+        max: 5,
+        idleTimeoutMillis: 10_000,
       })
     }
 
@@ -404,6 +407,14 @@ export const createLombokAppPgDatabase = <TDb extends Record<string, unknown>>(
   const client = new LombokAppPgClient(server)
   return drizzle(client as unknown as NodePgClient, { schema })
 }
+
+// Bind drizzle to an existing client so callers share its pool.
+export const createLombokAppPgDatabaseForClient = <
+  TDb extends Record<string, unknown>,
+>(
+  client: LombokAppPgClient,
+  schema: TDb,
+): NodePgDatabase<TDb> => drizzle(client as unknown as NodePgClient, { schema })
 
 export interface SerializeableRequest {
   url: string

--- a/packages/core-worker/src/worker-scripts/worker-daemon/worker-daemon.ts
+++ b/packages/core-worker/src/worker-scripts/worker-daemon/worker-daemon.ts
@@ -7,7 +7,7 @@ import type {
 import {
   AppTaskError,
   buildAppClient,
-  createLombokAppPgDatabase,
+  createLombokAppPgDatabaseForClient,
   LombokAppPgClient,
   verifyAppToken,
 } from '@lombokapp/app-worker-sdk'
@@ -309,8 +309,9 @@ void (async () => {
       responseWriter,
     }
 
+    // Share the daemon's pool; a per-request client leaked a pool each call.
     const createDb: CreateDbFn = (schema) =>
-      createLombokAppPgDatabase(serverClient, schema)
+      createLombokAppPgDatabaseForClient(dbClient, schema)
 
     // Process the request within ALS context
     await requestContext.run(ctx, async () => {


### PR DESCRIPTION
## Problem

Postgres starts rejecting connections under sustained app-worker traffic:

```
FATAL: remaining connection slots are reserved for roles with the SUPERUSER attribute
```

Runtime worker requests that touch the DB then fail with 500s because they can't acquire a connection.

## Root cause

The core-worker worker daemon's per-request `createDb` factory called `createLombokAppPgDatabase(serverClient, schema)`, which constructs a **new `LombokAppPgClient` — and therefore a new `pg.Pool`** — on every invocation. App request/task handlers call `createDb(schema)` on every request, and that pool is never closed. A singleton `dbClient` already existed and was passed into each handler, but `createDb` ignored it.

`pg.Pool` defaults to `max: 10` and keeps idle connections briefly, so each leaked pool parks connections that accumulate faster than they're reclaimed until the non-superuser slots are exhausted.

## Fix

- Add `createLombokAppPgDatabaseForClient(client, schema)` to `app-worker-sdk` — binds drizzle to an existing client so callers share one pool.
- Worker daemon's `createDb` now reuses the daemon's singleton client → **one bounded pool per daemon process** instead of one pool per request.
- Bound the pool defensively in `LombokAppPgClient.ensurePool()`: `max: 5`, `idleTimeoutMillis: 10_000`.

Platform-wide change (affects every app's runtime workers). Takes effect after the core-worker process is rebuilt/restarted.

## Testing

- `./dx check all` — green across all packages
- `./dx e2e api` — 589 pass, 0 fail
- `./dx e2e ui` — 17/18 (the lone failure is the known flaky `file-upload` spec; confirmed passing standalone)

Closes LOM-357