### PR TITLE
feat(LOM-362): app custom settings patternProperties (dynamic keys) UI + secret masking

### DIFF
--- a/packages/api/src/app/services/app-custom-settings.service.ts
+++ b/packages/api/src/app/services/app-custom-settings.service.ts
@@ -22,6 +22,7 @@ import {
 } from '../utils/format-zod-issues'
 import { jsonSchemaPropertyToZod } from '../utils/json-schema-to-zod.util'
 import {
+  matchesPatternProperty,
   resolveCustomSettings,
   type ResolvedCustomSettings,
 } from '../utils/resolve-custom-settings.utils'
@@ -458,10 +459,11 @@ export class AppCustomSettingsService {
     if (!values) {
       return undefined
     }
+    const propertyKeys = new Set(Object.keys(schema.properties))
     const filtered: Record<string, unknown> = {}
-    for (const key of Object.keys(schema.properties)) {
-      if (key in values) {
-        filtered[key] = values[key]
+    for (const [key, value] of Object.entries(values)) {
+      if (propertyKeys.has(key) || matchesPatternProperty(schema, key)) {
+        filtered[key] = value
       }
     }
     return Object.keys(filtered).length > 0 ? filtered : undefined

--- a/packages/api/src/app/utils/custom-settings-secrets.util.unit-spec.ts
+++ b/packages/api/src/app/utils/custom-settings-secrets.util.unit-spec.ts
@@ -34,4 +34,37 @@ describe('maskSecretValues', () => {
     const values = { api_key: 'sk-123' }
     expect(maskSecretValues(values, undefined)).toEqual(values)
   })
+
+  it('should mask leaves of a secret-keyed object, preserving structure', () => {
+    // Unanchored (substring) pattern: a variable whose name contains "api_key"
+    // is secret, so its whole object value is masked leaf-by-leaf while keeping
+    // the { value } shape intact.
+    const result = maskSecretValues(
+      {
+        variable_ci_api_key: { value: 'sk-123' },
+        variable_region: { value: 'eu' },
+      },
+      '(token|api_key)',
+    )
+    expect(result).toEqual({
+      variable_ci_api_key: { value: '********' },
+      variable_region: { value: 'eu' },
+    })
+  })
+
+  it('should mask secret sub-keys within a non-secret object', () => {
+    const result = maskSecretValues(
+      { config: { token: 't-1', name: 'prod' } },
+      pattern,
+    )
+    expect(result).toEqual({ config: { token: '********', name: 'prod' } })
+  })
+
+  it('should mask secret sub-keys within arrays of objects', () => {
+    const result = maskSecretValues(
+      { providers: [{ token: 't-1', label: 'a' }] },
+      pattern,
+    )
+    expect(result).toEqual({ providers: [{ token: '********', label: 'a' }] })
+  })
 })

--- a/packages/api/src/app/utils/custom-settings-secrets.utils.ts
+++ b/packages/api/src/app/utils/custom-settings-secrets.utils.ts
@@ -13,42 +13,38 @@ export function isSecretKey(
   return new RegExp(secretKeyPattern).test(key)
 }
 
-function maskObjectItem(
-  item: Record<string, unknown>,
-  secretKeyPattern: string,
-): Record<string, unknown> {
-  const result: Record<string, unknown> = {}
-  for (const [key, value] of Object.entries(item)) {
-    result[key] = isSecretKey(key, secretKeyPattern) ? MASKED_VALUE : value
-  }
-  return result
-}
-
 /**
- * Mask a single value — if it's an array of objects, mask secret keys within each item.
+ * Recursively mask a value, preserving structure. A leaf is masked when it sits
+ * under a secret-matched key — either the top-level key, or any object key along
+ * the way. Keeping the surrounding object/array shape intact (rather than
+ * collapsing a secret object to a bare sentinel) lets the settings UI keep
+ * rendering its editor and round-trip edits in the schema's expected shape.
  */
-function maskValue(
-  key: string,
+function maskDeep(
   value: unknown,
+  secret: boolean,
   secretKeyPattern: string,
 ): unknown {
-  if (isSecretKey(key, secretKeyPattern)) {
-    return MASKED_VALUE
-  }
   if (Array.isArray(value)) {
-    return value.map((item: unknown) => {
-      if (item != null && typeof item === 'object' && !Array.isArray(item)) {
-        return maskObjectItem(item as Record<string, unknown>, secretKeyPattern)
-      }
-      return item
-    })
+    return value.map((item) => maskDeep(item, secret, secretKeyPattern))
   }
-  return value
+  if (value != null && typeof value === 'object') {
+    const result: Record<string, unknown> = {}
+    for (const [key, child] of Object.entries(value)) {
+      result[key] = maskDeep(
+        child,
+        secret || isSecretKey(key, secretKeyPattern),
+        secretKeyPattern,
+      )
+    }
+    return result
+  }
+  return secret ? MASKED_VALUE : value
 }
 
 /**
- * Mask secret values in a settings object for GET responses.
- * Handles top-level secrets and secrets nested inside array-of-objects.
+ * Mask secret values in a settings object for GET responses. Handles top-level
+ * secrets as well as secrets nested inside objects and arrays-of-objects.
  */
 export function maskSecretValues(
   values: Record<string, unknown>,
@@ -59,7 +55,11 @@ export function maskSecretValues(
   }
   const result: Record<string, unknown> = {}
   for (const [key, value] of Object.entries(values)) {
-    result[key] = maskValue(key, value, secretKeyPattern)
+    result[key] = maskDeep(
+      value,
+      isSecretKey(key, secretKeyPattern),
+      secretKeyPattern,
+    )
   }
   return result
 }

--- a/packages/api/src/app/utils/resolve-custom-settings.utils.ts
+++ b/packages/api/src/app/utils/resolve-custom-settings.utils.ts
@@ -12,7 +12,7 @@ export interface ResolvedCustomSettings {
 /**
  * Check whether a key matches any pattern in the schema's patternProperties.
  */
-function matchesPatternProperty(
+export function matchesPatternProperty(
   schema: JsonSchema07Object,
   key: string,
 ): boolean {

--- a/packages/ui/src/components/custom-settings-form/custom-settings-form.tsx
+++ b/packages/ui/src/components/custom-settings-form/custom-settings-form.tsx
@@ -7,6 +7,7 @@ import type {
   JsonSchema07ObjectItemProperty,
   JsonSchema07PrimitiveProperty,
 } from '@lombokapp/types'
+import { SETTINGS_KEY_REGEX } from '@lombokapp/types'
 import { Badge } from '@lombokapp/ui-toolkit/components/badge'
 import { Button } from '@lombokapp/ui-toolkit/components/button'
 import {
@@ -157,17 +158,62 @@ function primitiveBase(
   return Array.isArray(t) ? t[0] : t
 }
 
+/** Build a sensible empty value for a freshly-added top-level property. */
+function buildDefaultValue(property: CustomSettingsSchemaProperty): unknown {
+  if (property.type === 'array') {
+    return property.default ?? []
+  }
+  if (property.type === 'object') {
+    const obj = property as Extract<
+      JsonSchema07ObjectItemProperty,
+      { type: 'object' }
+    >
+    if (obj.default !== undefined) {
+      return obj.default
+    }
+    const result: Record<string, unknown> = {}
+    for (const [key, prop] of Object.entries(obj.properties ?? {})) {
+      if (prop.default !== undefined) {
+        result[key] = prop.default
+      }
+    }
+    return result
+  }
+  const prim = property as JsonSchema07PrimitiveProperty
+  if (prim.default !== undefined) {
+    return prim.default
+  }
+  switch (primitiveBase(prim.type)) {
+    case 'string':
+      return ''
+    case 'number':
+    case 'integer':
+      return 0
+    case 'boolean':
+      return false
+  }
+}
+
 function PrimitiveFieldInput({
   id,
   property,
   value,
   isSecret,
+  isSecretModified,
   onChange,
 }: {
   id: string
   property: JsonSchema07PrimitiveProperty
   value: unknown
   isSecret: boolean
+  /**
+   * Whether the user has edited this secret in the current session. Stored
+   * secrets are never echoed by the server, so until it's edited we render an
+   * empty input with a hint instead of binding the (masked) value. Undefined
+   * in contexts without edit tracking (nested object fields) — there we bind
+   * the value directly.
+   */
+  isSecretModified?: boolean
   onChange: (value: unknown) => void
 }) {
   const base = primitiveBase(property.type)
@@ -177,6 +223,25 @@ function PrimitiveFieldInput({
         JsonSchema07PrimitiveProperty,
         { type: 'string' | ['string', 'null'] }
       >
+      if (isSecret) {
+        const edited = isSecretModified ?? true
+        const hasStoredValue = value != null && value !== ''
+        return (
+          <Input
+            id={id}
+            type="password"
+            autoComplete="off"
+            // eslint-disable-next-line @typescript-eslint/no-base-to-string
+            value={edited ? String(value ?? '') : ''}
+            onChange={(e) => onChange(e.target.value)}
+            placeholder={
+              !edited && hasStoredValue
+                ? 'Secret set — leave blank to keep'
+                : 'Enter secret value'
+            }
+          />
+        )
+      }
       if (stringProp.enum) {
         return (
           <Select
@@ -200,7 +265,7 @@ function PrimitiveFieldInput({
       return (
         <Input
           id={id}
-          type={isSecret ? 'password' : 'text'}
+          type="text"
           // eslint-disable-next-line @typescript-eslint/no-base-to-string
           value={String(value ?? '')}
           onChange={(e) => onChange(e.target.value)}
@@ -609,11 +674,89 @@ function DiscriminatedObjectArrayFieldInput({
   )
 }
 
+/**
+ * When a whole key is secret but its schema wraps the value in a single-string
+ * object (e.g. `{ value: string }`), return that field name so a secret can be
+ * edited as one opaque value and saved back in the expected shape. Otherwise
+ * null — the value is treated as a plain string secret.
+ */
+function singleSecretObjectField(
+  property: CustomSettingsSchemaProperty,
+): string | null {
+  if (property.type !== 'object') {
+    return null
+  }
+  const objectProp = property as Extract<
+    JsonSchema07ObjectItemProperty,
+    { type: 'object' }
+  >
+  const entries = Object.entries(objectProp.properties ?? {})
+  const entry = entries[0]
+  if (entries.length !== 1 || !entry) {
+    return null
+  }
+  const [key, sub] = entry
+  if (sub.type === 'array' || sub.type === 'object') {
+    return null
+  }
+  return primitiveBase(sub.type) === 'string' ? key : null
+}
+
+/** Input for an object-typed property — renders each sub-field one level deep. */
+function ObjectFieldInput({
+  fieldId,
+  property,
+  value,
+  secretKeyPattern,
+  onChange,
+}: {
+  fieldId: string
+  property: Extract<JsonSchema07ObjectItemProperty, { type: 'object' }>
+  value: unknown
+  secretKeyPattern: string | null
+  onChange: (value: unknown) => void
+}) {
+  const obj =
+    value && typeof value === 'object' && !Array.isArray(value)
+      ? (value as Record<string, unknown>)
+      : {}
+  const propertyEntries = Object.entries(property.properties ?? {})
+  const requiredKeys = new Set(property.required ?? [])
+
+  return (
+    <div className="space-y-2 rounded-md border bg-muted/30 p-3">
+      {propertyEntries.map(([propKey, propDef]) => (
+        <div key={propKey} className="space-y-1">
+          <Label htmlFor={`${fieldId}-${propKey}`} className="text-xs">
+            {propKey}
+            {requiredKeys.has(propKey) && (
+              <span className="ml-0.5 text-destructive">*</span>
+            )}
+          </Label>
+          {propDef.description && (
+            <p className="text-[10px] text-muted-foreground">
+              {propDef.description}
+            </p>
+          )}
+          <ObjectItemPropertyInput
+            id={`${fieldId}-${propKey}`}
+            property={propDef}
+            value={obj[propKey]}
+            isSecret={isSecretKey(propKey, secretKeyPattern)}
+            onChange={(v) => onChange({ ...obj, [propKey]: v })}
+          />
+        </div>
+      ))}
+    </div>
+  )
+}
+
 function FieldInput({
   fieldId,
   property,
   value,
   isSecret,
+  isSecretModified,
   secretKeyPattern,
   onChange,
 }: {
@@ -621,9 +764,50 @@ function FieldInput({
   property: CustomSettingsSchemaProperty
   value: unknown
   isSecret: boolean
+  isSecretModified?: boolean
   secretKeyPattern: string | null
   onChange: (value: unknown) => void
 }) {
+  if (isSecret) {
+    // The whole value is masked opaque by the server, so edit it as a single
+    // secret. If the schema wraps it in a single-string object, marshal to and
+    // from that field; otherwise treat the value as a plain string.
+    const wrapField = singleSecretObjectField(property)
+    const objValue =
+      value != null && typeof value === 'object' && !Array.isArray(value)
+        ? (value as Record<string, unknown>)
+        : undefined
+    return (
+      <PrimitiveFieldInput
+        id={fieldId}
+        property={{ type: 'string' } as JsonSchema07PrimitiveProperty}
+        value={wrapField ? objValue?.[wrapField] : value}
+        isSecret
+        isSecretModified={isSecretModified}
+        onChange={(v) =>
+          onChange(wrapField ? { ...(objValue ?? {}), [wrapField]: v } : v)
+        }
+      />
+    )
+  }
+
+  if (property.type === 'object') {
+    return (
+      <ObjectFieldInput
+        fieldId={fieldId}
+        property={
+          property as Extract<
+            JsonSchema07ObjectItemProperty,
+            { type: 'object' }
+          >
+        }
+        value={value}
+        secretKeyPattern={secretKeyPattern}
+        onChange={onChange}
+      />
+    )
+  }
+
   if (property.type !== 'array') {
     return (
       <PrimitiveFieldInput
@@ -631,6 +815,7 @@ function FieldInput({
         property={property as JsonSchema07PrimitiveProperty}
         value={value}
         isSecret={isSecret}
+        isSecretModified={isSecretModified}
         onChange={onChange}
       />
     )
@@ -678,22 +863,27 @@ function FieldRenderer({
   value,
   source,
   isSecret,
+  isSecretModified,
   isRequired,
   secretKeyPattern,
   onChange,
   level,
   onResetField,
+  onRemove,
 }: {
   fieldKey: string
   property: CustomSettingsSchemaProperty
   value: unknown
   source: CustomSettingsSource
   isSecret: boolean
+  isSecretModified?: boolean
   isRequired: boolean
   secretKeyPattern: string | null
   onChange: (value: unknown) => void
   level: 'user' | 'folder'
   onResetField?: (key: string) => void
+  /** When set, renders a remove control (for dynamic patternProperties keys). */
+  onRemove?: () => void
 }) {
   const fieldId = `custom-setting-${fieldKey}`
   const canResetField =
@@ -718,6 +908,17 @@ function FieldRenderer({
             Reset
           </button>
         )}
+        {onRemove && (
+          <button
+            type="button"
+            onClick={onRemove}
+            className="ml-auto inline-flex items-center gap-1 text-xs text-muted-foreground hover:text-destructive"
+            title="Remove setting"
+          >
+            <Trash2 className="size-3" />
+            Remove
+          </button>
+        )}
       </div>
       {property.description && (
         <p className="text-xs text-muted-foreground">{property.description}</p>
@@ -727,8 +928,191 @@ function FieldRenderer({
         property={property}
         value={value}
         isSecret={isSecret}
+        isSecretModified={isSecretModified}
         secretKeyPattern={secretKeyPattern}
         onChange={onChange}
+      />
+    </div>
+  )
+}
+
+/**
+ * Add-control for a `patternProperties` entry. The pattern is a literal
+ * lowercase prefix regex (e.g. `^provider_`), so we surface the prefix as a
+ * fixed adornment and let the user type the remaining suffix. The assembled
+ * key is validated against both the platform key format and the pattern.
+ */
+function AddPatternKeyRow({
+  pattern,
+  existingKeys,
+  onAdd,
+}: {
+  pattern: string
+  existingKeys: Set<string>
+  onAdd: (key: string) => void
+}) {
+  const [isAdding, setIsAdding] = React.useState(false)
+  const [suffix, setSuffix] = React.useState('')
+
+  const prefix = pattern.startsWith('^') ? pattern.slice(1) : ''
+  const fullKey = `${prefix}${suffix}`
+  const regex = React.useMemo(() => {
+    try {
+      return new RegExp(pattern)
+    } catch {
+      return null
+    }
+  }, [pattern])
+
+  const error = React.useMemo(() => {
+    if (!suffix) {
+      return null
+    }
+    if (!SETTINGS_KEY_REGEX.test(fullKey)) {
+      return 'Use lowercase a-z, 0-9, or _ — no leading or trailing _'
+    }
+    if (regex && !regex.test(fullKey)) {
+      return 'Key does not match the required pattern'
+    }
+    if (existingKeys.has(fullKey)) {
+      return 'A setting with this key already exists'
+    }
+    return null
+  }, [suffix, fullKey, regex, existingKeys])
+
+  const canAdd = suffix.length > 0 && !error
+
+  const reset = () => {
+    setSuffix('')
+    setIsAdding(false)
+  }
+
+  const commit = () => {
+    if (!canAdd) {
+      return
+    }
+    onAdd(fullKey)
+    reset()
+  }
+
+  if (!isAdding) {
+    return (
+      <Button
+        type="button"
+        variant="outline"
+        size="sm"
+        onClick={() => setIsAdding(true)}
+        className="gap-1"
+      >
+        <Plus className="size-3.5" />
+        Add {prefix ? `${prefix}…` : 'setting'}
+      </Button>
+    )
+  }
+
+  return (
+    <div className="space-y-1">
+      <div className="flex items-center gap-2">
+        <div className="focus-within:ring-ring flex flex-1 items-center rounded-md border focus-within:ring-1">
+          {prefix && (
+            <span className="pl-2 text-sm text-muted-foreground">{prefix}</span>
+          )}
+          <Input
+            autoFocus
+            value={suffix}
+            onChange={(e) => setSuffix(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter') {
+                e.preventDefault()
+                commit()
+              } else if (e.key === 'Escape') {
+                reset()
+              }
+            }}
+            placeholder="key"
+            className="border-0 pl-0 shadow-none focus-visible:ring-0"
+          />
+        </div>
+        <Button
+          type="button"
+          variant="outline"
+          size="sm"
+          disabled={!canAdd}
+          onClick={commit}
+        >
+          Add
+        </Button>
+        <Button
+          type="button"
+          variant="ghost"
+          size="sm"
+          onClick={reset}
+          className="text-muted-foreground"
+        >
+          Cancel
+        </Button>
+      </div>
+      {error && <p className="text-xs text-destructive">{error}</p>}
+    </div>
+  )
+}
+
+/**
+ * Renders one `patternProperties` entry: every stored key matching the pattern
+ * as an editable, removable field, plus a control to add new matching keys.
+ */
+function PatternPropertyGroup({
+  pattern,
+  property,
+  keys,
+  localValues,
+  sources,
+  secretKeyPattern,
+  modifiedSecrets,
+  level,
+  existingKeys,
+  onChange,
+  onRemove,
+  onAdd,
+}: {
+  pattern: string
+  property: CustomSettingsSchemaProperty
+  keys: string[]
+  localValues: Record<string, unknown>
+  sources: Record<string, CustomSettingsSource>
+  secretKeyPattern: string | null
+  modifiedSecrets: Set<string>
+  level: 'user' | 'folder'
+  existingKeys: Set<string>
+  onChange: (key: string, value: unknown) => void
+  onRemove: (key: string) => void
+  onAdd: (key: string) => void
+}) {
+  return (
+    <div className="space-y-3 rounded-md border border-dashed p-3">
+      {property.description && (
+        <p className="text-xs text-muted-foreground">{property.description}</p>
+      )}
+      {keys.map((key) => (
+        <FieldRenderer
+          key={key}
+          fieldKey={key}
+          property={property}
+          value={localValues[key]}
+          source={sources[key] ?? (level === 'folder' ? 'folder' : 'user')}
+          isSecret={isSecretKey(key, secretKeyPattern)}
+          isSecretModified={modifiedSecrets.has(key)}
+          isRequired={false}
+          secretKeyPattern={secretKeyPattern}
+          onChange={(value) => onChange(key, value)}
+          level={level}
+          onRemove={() => onRemove(key)}
+        />
+      ))}
+      <AddPatternKeyRow
+        pattern={pattern}
+        existingKeys={existingKeys}
+        onAdd={onAdd}
       />
     </div>
   )
@@ -769,12 +1153,92 @@ export function CustomSettingsForm({
 
   const propertyEntries = Object.entries(schema.properties)
   const requiredKeys = new Set(schema.required ?? [])
+  const propertyKeySet = React.useMemo(
+    () => new Set(Object.keys(schema.properties)),
+    [schema.properties],
+  )
+
+  // Compile each patternProperties entry once. Keys are assigned to the first
+  // matching pattern so a key is never rendered twice.
+  const compiledPatterns = React.useMemo(
+    () =>
+      Object.entries(schema.patternProperties ?? {}).map(
+        ([pattern, property]) => ({
+          pattern,
+          property,
+          regex: (() => {
+            try {
+              return new RegExp(pattern)
+            } catch {
+              return null
+            }
+          })(),
+        }),
+      ),
+    [schema.patternProperties],
+  )
+
+  const matchesAnyPattern = (key: string) =>
+    compiledPatterns.some(({ regex }) => regex?.test(key))
+
+  // Group the dynamic (pattern-matched) keys currently held in local state.
+  const assigned = new Set<string>()
+  const patternGroups = compiledPatterns.map(({ pattern, property, regex }) => {
+    const keys = regex
+      ? Object.keys(localValues)
+          .filter(
+            (k) => !propertyKeySet.has(k) && !assigned.has(k) && regex.test(k),
+          )
+          .sort()
+      : []
+    keys.forEach((k) => assigned.add(k))
+    return { pattern, property, keys }
+  })
+  const patternKeys = [...assigned]
+
+  // Pattern keys that existed on the server but were removed locally — these
+  // must be sent as `null` to delete them.
+  const removedPatternKeys = Object.keys(values).filter(
+    (key) =>
+      !propertyKeySet.has(key) &&
+      !(key in localValues) &&
+      matchesAnyPattern(key),
+  )
+
+  const allExistingKeys = new Set([
+    ...propertyKeySet,
+    ...Object.keys(localValues),
+  ])
 
   const handleFieldChange = (key: string, value: unknown) => {
     setLocalValues((prev) => ({ ...prev, [key]: value }))
     if (isSecretKey(key, secretKeyPattern)) {
       setModifiedSecrets((prev) => new Set(prev).add(key))
     }
+  }
+
+  const handleAddPatternKey = (
+    key: string,
+    property: CustomSettingsSchemaProperty,
+  ) => {
+    setLocalValues((prev) => ({ ...prev, [key]: buildDefaultValue(property) }))
+    if (isSecretKey(key, secretKeyPattern)) {
+      setModifiedSecrets((prev) => new Set(prev).add(key))
+    }
+  }
+
+  const handleRemovePatternKey = (key: string) => {
+    setLocalValues((prev) =>
+      Object.fromEntries(Object.entries(prev).filter(([k]) => k !== key)),
+    )
+    setModifiedSecrets((prev) => {
+      if (!prev.has(key)) {
+        return prev
+      }
+      const next = new Set(prev)
+      next.delete(key)
+      return next
+    })
   }
 
   const isDirty = (key: string) => {
@@ -789,17 +1253,26 @@ export function CustomSettingsForm({
     // keys (including untouched secrets) are preserved server-side.
     const submitValues: Record<string, unknown> = {}
     for (const [key] of propertyEntries) {
-      if (!isDirty(key)) {
-        continue
+      if (isDirty(key)) {
+        submitValues[key] = localValues[key] ?? null
       }
-      const localVal = localValues[key]
-      submitValues[key] = localVal ?? null
+    }
+    for (const key of patternKeys) {
+      if (isDirty(key)) {
+        submitValues[key] = localValues[key] ?? null
+      }
+    }
+    for (const key of removedPatternKeys) {
+      submitValues[key] = null
     }
     onSave(submitValues)
   }
 
   // Check if anything changed from server values
-  const hasChanges = propertyEntries.some(([key]) => isDirty(key))
+  const hasChanges =
+    propertyEntries.some(([key]) => isDirty(key)) ||
+    patternKeys.some((key) => isDirty(key)) ||
+    removedPatternKeys.length > 0
 
   // Check if any values are explicitly set (not all defaults)
   const hasCustomValues = Object.values(sources).some((s) => s !== 'default')
@@ -824,11 +1297,29 @@ export function CustomSettingsForm({
               value={localValues[key]}
               source={sources[key] ?? 'default'}
               isSecret={isSecretKey(key, secretKeyPattern)}
+              isSecretModified={modifiedSecrets.has(key)}
               isRequired={requiredKeys.has(key)}
               secretKeyPattern={secretKeyPattern}
               onChange={(value) => handleFieldChange(key, value)}
               level={level}
               onResetField={onResetField}
+            />
+          ))}
+          {patternGroups.map(({ pattern, property, keys }) => (
+            <PatternPropertyGroup
+              key={pattern}
+              pattern={pattern}
+              property={property}
+              keys={keys}
+              localValues={localValues}
+              sources={sources}
+              secretKeyPattern={secretKeyPattern}
+              modifiedSecrets={modifiedSecrets}
+              level={level}
+              existingKeys={allExistingKeys}
+              onChange={handleFieldChange}
+              onRemove={handleRemovePatternKey}
+              onAdd={(key) => handleAddPatternKey(key, property)}
             />
           ))}
         </div>


### PR DESCRIPTION
## Summary

Extend app custom settings with `patternProperties` support: apps declare dynamic-key settings whose keys match a regex pattern, and the UI renders add/remove/edit for each matching entry. Secret masking is hardened to handle nested and pattern-matched keys.

- **UI** — render each `patternProperties` entry one level deep with add/remove controls for dynamic keys.
- **Backend** — recursive secret masking that preserves structure, masking leaves under a secret-matched key (top-level or anywhere along the path), including the `{ value: string }` single-string wrapper case; resolve/secrets utils + unit tests.

## Test plan

- `./dx check all` — all checks pass.
- e2e via CI.

Linear: [LOM-362](https://linear.app/lombokapp/issue/LOM-362/app-custom-settings-patternproperties-dynamic-keys-ui-secret-masking)