### PR TITLE
ui(LOM-363): move user profile menu into the sidebar

### DIFF
--- a/packages/ui/src/components/sidebar/components/menu.tsx
+++ b/packages/ui/src/components/sidebar/components/menu.tsx
@@ -1,7 +1,6 @@
 import type { IAuthContext } from '@lombokapp/auth-utils'
 import { ScrollArea } from '@lombokapp/ui-toolkit/components/scroll-area'
 import type { LucideIcon } from 'lucide-react'
-import { LogOut } from 'lucide-react'
 import { useLocation } from 'react-router'
 
 import type { AppPathContribution } from '@/src/contexts/server'
@@ -12,6 +11,7 @@ import { NotificationsTrigger } from './notifications-trigger'
 import { SidebarGroup } from './sidebar-group'
 import { SidebarItem } from './sidebar-item'
 import { ThemeToggleTrigger } from './theme-toggle-trigger'
+import { UserNav } from './user-nav'
 
 interface MenuProps {
   isOpen: boolean | undefined
@@ -80,12 +80,7 @@ export function Menu({
       <div className="space-y-1 border-t px-3 pb-2 pt-2">
         <NotificationsTrigger isOpen={isOpen} />
         <ThemeToggleTrigger isOpen={isOpen} />
-        <SidebarItem
-          icon={LogOut}
-          label="Sign out"
-          isOpen={isOpen}
-          onClick={() => void onSignOut()}
-        />
+        <UserNav viewer={viewer} onSignout={onSignOut} isOpen={isOpen} />
       </div>
     </div>
   )

--- a/packages/ui/src/components/sidebar/components/navbar.tsx
+++ b/packages/ui/src/components/sidebar/components/navbar.tsx
@@ -12,7 +12,6 @@ import React from 'react'
 import { Link } from 'react-router'
 
 import { SheetMenu } from './sheet-menu'
-import { UserNav } from './user-nav'
 
 interface NavbarProps {
   breadcrumbs?: { href?: string; label: string }[]
@@ -65,14 +64,6 @@ export function Navbar({ breadcrumbs }: NavbarProps) {
             )}
           </div>
         </div>
-        {authContext.viewer && (
-          <div className="flex shrink-0 items-center justify-end gap-2 px-2">
-            <UserNav
-              onSignout={() => authContext.logout()}
-              viewer={authContext.viewer}
-            />
-          </div>
-        )}
       </div>
     </header>
   )

--- a/packages/ui/src/components/sidebar/components/user-nav.tsx
+++ b/packages/ui/src/components/sidebar/components/user-nav.tsx
@@ -9,11 +9,7 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from '@lombokapp/ui-toolkit/components/dropdown-menu'
-import {
-  Tooltip,
-  TooltipProvider,
-  TooltipTrigger,
-} from '@lombokapp/ui-toolkit/components/tooltip'
+import { cn } from '@lombokapp/ui-toolkit/utils/tailwind'
 import { LayoutGrid, LogOut, UserIcon } from 'lucide-react'
 import { Link } from 'react-router'
 
@@ -22,34 +18,38 @@ import { EntityAvatar } from '@/src/components/entity-avatar/entity-avatar'
 export function UserNav({
   onSignout,
   viewer,
+  isOpen,
 }: {
   onSignout: () => Promise<void>
   viewer: UserDTO
+  isOpen?: boolean
 }) {
   return (
     <DropdownMenu>
-      <TooltipProvider disableHoverableContent>
-        <Tooltip delayDuration={100}>
-          <TooltipTrigger asChild>
-            <DropdownMenuTrigger asChild>
-              <Button
-                variant="outline"
-                className="relative size-8 rounded-full p-0"
-              >
-                <EntityAvatar
-                  kind="user"
-                  name={viewer.name ?? viewer.username}
-                  image={viewer.avatar}
-                  size="sm"
-                  className="size-8"
-                />
-              </Button>
-            </DropdownMenuTrigger>
-          </TooltipTrigger>
-        </Tooltip>
-      </TooltipProvider>
+      <DropdownMenuTrigger asChild>
+        <Button
+          variant="ghost"
+          className={cn(
+            'h-10 w-full justify-start gap-2 px-1.5',
+            !isOpen && 'justify-center px-0',
+          )}
+        >
+          <EntityAvatar
+            kind="user"
+            name={viewer.name ?? viewer.username}
+            image={viewer.avatar}
+            size="sm"
+            className="size-7 shrink-0"
+          />
+          {isOpen && (
+            <span className="min-w-0 flex-1 truncate text-left text-sm font-medium">
+              {viewer.name ?? viewer.username}
+            </span>
+          )}
+        </Button>
+      </DropdownMenuTrigger>
 
-      <DropdownMenuContent className="w-56" align="end" forceMount>
+      <DropdownMenuContent className="w-56" align="start" side="top" forceMount>
         <DropdownMenuLabel className="font-normal">
           <div className="flex flex-col space-y-1">
             <p className="text-sm font-medium leading-none">


### PR DESCRIPTION
## Summary

Relocate the user profile menu from the top navbar into the sidebar (consistent with the earlier theme-switch move). Removes the navbar profile control and surfaces the user-nav menu within the sidebar.

## Test plan

- `./dx check all` — all checks pass.
- e2e via CI.

Linear: [LOM-363](https://linear.app/lombokapp/issue/LOM-363/move-user-profile-menu-into-the-sidebar)