### PR TITLE
fix(LOM-369): fix dev app UI proxy bug + add not-found feedback

### DIFF
--- a/dx
+++ b/dx
@@ -107,6 +107,7 @@ Commands:
   reload api           Reload the NestJS API (triggers bun watch reload)
   restart api          Restart the NestJS API (triggers restart of the app, which loads new env)
   restart ui           Restart the Vite frontend dev server
+  restart proxies      Regenerate app frontend proxy overrides and reload nginx
   restart bridge       Restart the docker bridge server
   db seed              Seed the database with dev data
   db reset             Drop all tables and re-migrate
@@ -183,12 +184,17 @@ case "${1:-help}" in
       ui)
         $DOCKER_EXEC_NOTTY sh /usr/src/app/packages/api/cmd/restart-ui.sh
         ;;
+      proxies)
+        # Regenerate app_frontend_proxies.json + reload nginx. Run as root (no
+        # su-exec bun) — the root-owned nginx master needs root to reload.
+        docker compose exec -T api sh /usr/src/app/packages/api/cmd/gen-app-proxies.sh
+        ;;
       bridge)
         $DOCKER_EXEC pkill -f 'bun run.*/docker-bridge/src/index.ts' || true
         echo "Sent kill signal to docker-bridge. The API service will restart it automatically."
         ;;
       *)
-        echo "Usage: ./dx restart (api|ui|bridge)" >&2
+        echo "Usage: ./dx restart (api|ui|proxies|bridge)" >&2
         exit 1
         ;;
     esac

--- a/packages/api/cmd/dev-entrypoint.sh
+++ b/packages/api/cmd/dev-entrypoint.sh
@@ -34,28 +34,9 @@ echo ""
 echo "================================================"
 echo "NGINX"
 echo "================================================"
-sed -e "s|{{PLATFORM_HOST}}|$PLATFORM_HOST|g" -e "s|{{APP_UI_HOST}}|$APP_UI_HOST|g" ./packages/api/nginx/dev-nginx.conf > /etc/nginx/http.d/default.conf
-cp ./packages/api/nginx/app_router.js /etc/nginx/app_router.js
-
-# Build app_frontend_proxies.json from LOMBOK_APP_FRONTEND_PROXY_HOST_* env vars
-APP_FRONTEND_PROXIES_ENV="./packages/ui/.env.development.local"
-if [ -f "$APP_FRONTEND_PROXIES_ENV" ]; then
-  # Extract active (uncommented) proxy host vars, build JSON
-  ENTRIES=$(grep -v '^\s*#' "$APP_FRONTEND_PROXIES_ENV" | grep 'LOMBOK_APP_FRONTEND_PROXY_HOST_' | sed 's/LOMBOK_APP_FRONTEND_PROXY_HOST_//' | awk -F= '{printf "\"%s\": \"%s\"", tolower($1), $2}' | paste -sd, -)
-  echo "{${ENTRIES}}" > /etc/nginx/app_frontend_proxies.json
-  echo "App frontend proxy overrides:"
-  cat /etc/nginx/app_frontend_proxies.json
-else
-  echo "{}" > /etc/nginx/app_frontend_proxies.json
-  echo "No app frontend proxy overrides (${APP_FRONTEND_PROXIES_ENV} not found)"
-fi
-
-if [ -f /run/nginx/nginx.pid ] && kill -0 $(cat /run/nginx/nginx.pid) 2>/dev/null; then
-    nginx -s reload
-else
-    nginx
-fi
-echo "NGINX started on port 8080"
+# Template the nginx conf, build app_frontend_proxies.json, start/reload nginx
+# (shared with `./dx restart proxies`).
+sh ./packages/api/cmd/gen-app-proxies.sh
 
 # ── PostgreSQL ──────────────────────────────────────────────
 echo ""

--- a/packages/api/cmd/gen-app-proxies.sh
+++ b/packages/api/cmd/gen-app-proxies.sh
@@ -1,0 +1,54 @@
+#!/bin/sh
+# Build /etc/nginx/app_frontend_proxies.json from LOMBOK_APP_FRONTEND_PROXY_HOST_*
+# entries in packages/ui/.env.development.local, then reload nginx. app_router.js
+# reads this file to override the per-app UI proxy target in dev. Run as root —
+# the nginx master is root-owned, so `nginx -s reload` needs root.
+
+cd /usr/src/app || { echo "Error: Cannot cd to /usr/src/app"; exit 1; }
+
+PLATFORM_HOST="${PLATFORM_HOST:-lombok.localhost}"
+APP_UI_HOST="${APP_UI_HOST:-http://127.0.0.1:3001}"
+
+# Template the nginx conf + copy the njs router so config edits apply on reload.
+sed -e "s|{{PLATFORM_HOST}}|$PLATFORM_HOST|g" -e "s|{{APP_UI_HOST}}|$APP_UI_HOST|g" ./packages/api/nginx/dev-nginx.conf > /etc/nginx/http.d/default.conf
+cp ./packages/api/nginx/app_router.js /etc/nginx/app_router.js
+
+APP_FRONTEND_PROXIES_ENV="./packages/ui/.env.development.local"
+
+# Active (uncommented) overrides as lowercase `key=url` lines, e.g.
+#   homicle_7d940475=http://host.docker.internal:5177
+if [ -f "$APP_FRONTEND_PROXIES_ENV" ]; then
+  PAIRS=$(grep -v '^\s*#' "$APP_FRONTEND_PROXIES_ENV" \
+    | grep 'LOMBOK_APP_FRONTEND_PROXY_HOST_' \
+    | sed 's/LOMBOK_APP_FRONTEND_PROXY_HOST_//' \
+    | awk -F= '{printf "%s=%s\n", tolower($1), $2}')
+else
+  PAIRS=""
+fi
+
+if [ -n "$PAIRS" ]; then
+  # Join the pairs into a JSON object. One pair per line is required so paste
+  # has lines to join — without the newline the commas are dropped (invalid JSON).
+  ENTRIES=$(printf '%s\n' "$PAIRS" | awk -F= '{printf "\"%s\": \"%s\"\n", $1, $2}' | paste -sd, -)
+  echo "{${ENTRIES}}" > /etc/nginx/app_frontend_proxies.json
+  echo "App frontend proxy overrides:"
+  cat /etc/nginx/app_frontend_proxies.json
+
+  # Probe each override; warn (don't fail) if nothing is listening on the port.
+  printf '%s\n' "$PAIRS" | while IFS='=' read -r key url; do
+    [ -z "$url" ] && continue
+    if ! curl -s -o /dev/null --connect-timeout 2 "$url"; then
+      echo "WARNING: ${key} -> ${url} not reachable (is the app's dev server running on that port?)"
+    fi
+  done
+else
+  echo "{}" > /etc/nginx/app_frontend_proxies.json
+  echo "No app frontend proxy overrides (${APP_FRONTEND_PROXIES_ENV} not found or has no active entries)"
+fi
+
+if [ -f /run/nginx/nginx.pid ] && kill -0 $(cat /run/nginx/nginx.pid) 2>/dev/null; then
+    nginx -s reload
+else
+    nginx
+fi
+echo "NGINX started on port 8080"

--- a/packages/api/nginx/dev-nginx.conf
+++ b/packages/api/nginx/dev-nginx.conf
@@ -115,6 +115,86 @@ server {
         proxy_set_header X-Real-IP $remote_addr;
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
+
+        # Upstream unreachable (e.g. the app's dev server isn't running on the
+        # overridden port) — show a readable warning instead of a bare 502.
+        error_page 502 503 504 @app_dev_down;
+    }
+
+    location @app_dev_down {
+        default_type text/html;
+        return 502 '<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1">
+<title>App backend unreachable</title>
+<style>
+  :root {
+    color-scheme: light dark;
+    --bg: #f4f4f5; --card: #ffffff; --border: #e4e4e7;
+    --text: #18181b; --muted: #52525b;
+    --chip-bg: #f4f4f5; --chip-text: #3f3f46;
+    --accent: #b45309; --accent-bg: #fef3c7; --accent-border: #fcd34d;
+    --bar: #f59e0b;
+  }
+  @media (prefers-color-scheme: dark) {
+    :root {
+      --bg: #09090b; --card: #18181b; --border: #27272a;
+      --text: #fafafa; --muted: #a1a1aa;
+      --chip-bg: #27272a; --chip-text: #e4e4e7;
+      --accent: #fbbf24; --accent-bg: #2a2012; --accent-border: #5b4514;
+      --bar: #f59e0b;
+    }
+  }
+  * { box-sizing: border-box; }
+  body {
+    margin: 0; min-height: 100vh; padding: 1.5rem;
+    display: flex; align-items: center; justify-content: center;
+    background: var(--bg); color: var(--text);
+    font-family: ui-sans-serif, system-ui, -apple-system, "Segoe UI", Roboto, sans-serif;
+    line-height: 1.55;
+  }
+  .card {
+    width: 100%; max-width: 32rem; overflow: hidden;
+    background: var(--card); border: 1px solid var(--border);
+    border-radius: 14px;
+    box-shadow: 0 1px 2px rgba(0,0,0,.05), 0 12px 32px rgba(0,0,0,.12);
+  }
+  .bar { height: 4px; background: var(--bar); }
+  .body { padding: 1.75rem; }
+  .badge {
+    display: inline-flex; align-items: center; gap: .45rem;
+    font-size: .72rem; font-weight: 600; letter-spacing: .03em; text-transform: uppercase;
+    color: var(--accent); background: var(--accent-bg);
+    border: 1px solid var(--accent-border);
+    padding: .3rem .6rem; border-radius: 999px;
+  }
+  h1 { font-size: 1.2rem; margin: 1rem 0 .35rem; }
+  p { margin: .55rem 0; color: var(--muted); font-size: .95rem; }
+  code {
+    font-family: ui-monospace, SFMono-Regular, Menlo, monospace; font-size: .85em;
+    background: var(--chip-bg); color: var(--chip-text);
+    padding: .15em .45em; border-radius: 6px; word-break: break-all;
+  }
+  .hint {
+    margin-top: 1.25rem; padding-top: 1.1rem;
+    border-top: 1px solid var(--border); font-size: .9rem;
+  }
+</style>
+</head>
+<body>
+<div class="card">
+  <div class="bar"></div>
+  <div class="body">
+    <span class="badge">&#9888; 502 &middot; Backend unreachable</span>
+    <h1>App dev server is not responding</h1>
+    <p>nginx could not reach the backend for <code>$host</code> at <code>$app_backend</code>.</p>
+    <p class="hint">If this app points at a local dev server, make sure it is running on that port. After editing <code>packages/ui/.env.development.local</code>, run <code>./dx restart proxies</code> to apply the change.</p>
+  </div>
+</div>
+</body>
+</html>';
     }
 
     access_log /var/log/nginx/subdomain_access.log;


### PR DESCRIPTION
## Summary

Fix a bug in the dev-environment app UI proxy and add clearer feedback when a dev app UI proxy target isn't found. Dev-tooling only — no runtime API or schema changes.

- `dx`, `packages/api/cmd/dev-entrypoint.sh`, `packages/api/cmd/gen-app-proxies.sh` (new), `packages/api/nginx/dev-nginx.conf`.

## Test plan

- `./dx check all` — all checks pass.
- `./dx e2e api` — **602 pass, 0 fail** (run locally).

Linear: [LOM-369](https://linear.app/lombokapp/issue/LOM-369/fix-dev-app-ui-proxy-bug-add-not-found-feedback)