### PR TITLE
chore(LOM-370): tighten code comments across recent platform changes

### DIFF
--- a/docker/docker-bridge/src/sessions/session-manager.ts
+++ b/docker/docker-bridge/src/sessions/session-manager.ts
@@ -21,10 +21,7 @@ export class SessionManager {
     return 'sess_' + crypto.randomUUID().replace(/-/g, '').slice(0, 21)
   }
 
-  // The `tn-` prefix puts a hyphen inside the publicId — that hyphen
-  // partitions publicIds from app/worker identifiers (which are [a-z0-9_]+),
-  // so tunnel hostnames cannot collide with api-server--{worker}--{app}
-  // or app-server--{name} patterns.
+  // The `tn-` hyphen partitions publicIds from app/worker identifiers ([a-z0-9_]+) so tunnel hostnames can't collide with api-server/app-server patterns.
   private generatePublicId(): string {
     for (let i = 0; i < 10; i++) {
       const id = 'tn-' + crypto.randomUUID().replace(/-/g, '').slice(0, 10)
@@ -35,8 +32,7 @@ export class SessionManager {
     throw new Error('Failed to generate unique public ID')
   }
 
-  // A caller-supplied (durable) publicId must match the same tunnel hostname
-  // shape generatePublicId() produces: a `tn-` prefix followed by [a-z0-9-].
+  // Caller-supplied (durable) publicIds must match the shape generatePublicId() produces.
   private static readonly PUBLIC_ID_SHAPE = /^tn-[a-z0-9-]+$/
 
   private resolvePublicId(opts: {
@@ -75,8 +71,7 @@ export class SessionManager {
   ): TunnelSession {
     const durable = options.durable ?? false
 
-    // Idempotent durable create: a repeated desiredPublicId returns the live
-    // session, making bridge-reconnect replay and concurrent ensureLive safe.
+    // Idempotent durable create: a repeated desiredPublicId returns the live session (safe for replay + concurrent ensureLive).
     if (durable && options.desiredPublicId) {
       const existing = this.getByPublicId(options.desiredPublicId)
       if (existing) {
@@ -157,16 +152,14 @@ export class SessionManager {
       return
     }
 
-    // Close exec stream if active
     if (session.execStream) {
       try {
         session.execStream.destroy()
       } catch {
-        // Ignore stream close errors
+        // Ignore stream close errors.
       }
     }
 
-    // Remove from tunnel index
     if (session.publicId) {
       this.tunnelIndex.delete(session.publicId)
     }
@@ -191,19 +184,17 @@ export class SessionManager {
       const toDelete: string[] = []
 
       for (const [id, session] of this.sessions) {
-        // Durable sessions self-heal only via the platform (reconnect replay /
-        // lazy re-bind); external traffic can't, so they are never swept.
+        // Durable sessions self-heal only via the platform, so they are never swept.
         if (session.durable) {
           continue
         }
 
-        // Remove sessions idle beyond timeout
         if (now - session.lastActivityAt > this.sessionIdleTimeout) {
           toDelete.push(id)
           continue
         }
 
-        // Remove sessions in 'created' state older than 60s (creation timeout)
+        // Creation timeout: drop sessions stuck in 'created' past 60s.
         if (session.state === 'created' && now - session.createdAt > 60_000) {
           toDelete.push(id)
         }

--- a/docker/docker-bridge/src/sessions/session.types.ts
+++ b/docker/docker-bridge/src/sessions/session.types.ts
@@ -22,9 +22,7 @@ export interface TunnelSession {
   publicId: string | null
   label: string
   appId: string | null
-  /** Durable sessions are exempt from the idle/creation sweep — they are torn
-   *  down only by explicit delete or bridge restart, and recreated by the
-   *  platform reconciler under their stable publicId. */
+  /** Exempt from the idle/creation sweep; torn down only by explicit delete or bridge restart, then recreated by the platform reconciler under the stable publicId. */
   durable: boolean
 }
 

--- a/packages/api/cmd/dev-entrypoint.sh
+++ b/packages/api/cmd/dev-entrypoint.sh
@@ -6,7 +6,7 @@ APP_UI_HOST="${APP_UI_HOST:-http://127.0.0.1:3001}"
 
 cd /usr/src/app || { echo "Error: Cannot cd to /usr/src/app"; exit 1; }
 
-# Clean up background processes on exit
+# Kill background processes on exit.
 cleanup() {
   kill $(jobs -p) 2>/dev/null
   wait
@@ -34,8 +34,7 @@ echo ""
 echo "================================================"
 echo "NGINX"
 echo "================================================"
-# Template the nginx conf, build app_frontend_proxies.json, start/reload nginx
-# (shared with `./dx restart proxies`).
+# Shared with `./dx restart proxies`.
 sh ./packages/api/cmd/gen-app-proxies.sh
 
 # ── PostgreSQL ──────────────────────────────────────────────
@@ -48,27 +47,23 @@ export PGDATA='/var/lib/postgresql/data'
 su-exec postgres mkdir -p "$PGDATA"
 su-exec postgres chmod 0700 "$PGDATA"
 
-# Initialize PostgreSQL data directory if not already initialized
 if ! su-exec postgres test -f "$PGDATA/PG_VERSION"; then
     echo "Initializing PostgreSQL data directory..."
     su-exec postgres initdb -D "$PGDATA" --auth-local=trust --auth-host=md5
     echo "PostgreSQL data directory initialized."
 fi
 
-# Allow connections from any IP (dev only — connections come via Docker bridge)
-# Must run as postgres because DAC_OVERRIDE is not in cap_add
+# Allow connections from any IP (dev only). Runs as postgres since DAC_OVERRIDE isn't in cap_add.
 su-exec postgres sh -c "grep -q '^host.*0\.0\.0\.0/0' '$PGDATA/pg_hba.conf' || echo 'host all all 0.0.0.0/0 trust' >> '$PGDATA/pg_hba.conf'"
 
-# Start PostgreSQL, listening on all interfaces so host port-mapping works
+# listen_addresses='*' so host port-mapping works.
 su-exec postgres postgres -D "$PGDATA" -c listen_addresses='*' > /dev/stdout 2>&1 &
 
-# Wait for PostgreSQL to become available
 until su-exec postgres pg_isready -q; do
   echo "Waiting for PostgreSQL to start..."
   sleep 1
 done
 
-# Create user if it doesn't exist
 USER_EXISTS=$(su-exec postgres psql -tAc "SELECT 1 FROM pg_roles WHERE rolname='${DB_USER}';")
 if [ "$USER_EXISTS" != "1" ]; then
     su-exec postgres psql -v ON_ERROR_STOP=1 --username postgres \
@@ -78,14 +73,12 @@ else
       -c "ALTER USER ${DB_USER} WITH CREATEROLE CREATEDB SUPERUSER;"
 fi
 
-# Create database if it doesn't exist
 DB_EXISTS=$(su-exec postgres psql -tAc "SELECT 1 FROM pg_database WHERE datname='${DB_NAME}';")
 if [ "$DB_EXISTS" != "1" ]; then
     su-exec postgres psql -v ON_ERROR_STOP=1 --username postgres \
       -c "CREATE DATABASE ${DB_NAME} OWNER ${DB_USER};"
 fi
 
-# Create extensions
 su-exec postgres psql -v ON_ERROR_STOP=1 --username postgres -d "${DB_NAME}" \
   -c "CREATE SCHEMA IF NOT EXISTS extensions;"
 su-exec postgres psql -v ON_ERROR_STOP=1 --username postgres -d "${DB_NAME}" \
@@ -119,7 +112,6 @@ until curl -sf http://127.0.0.1:9000/minio/health/live; do
 done
 echo "MinIO is ready."
 
-# Create bucket and dev user
 mc alias set localminio http://127.0.0.1:9000 "$MINIO_ROOT_USER" "$MINIO_ROOT_PASSWORD" --quiet
 mc mb --ignore-existing "localminio/${DEV_S3_BUCKET_NAME}"
 mc admin user add localminio "${DEV_S3_ACCESS_KEY_ID}" "${DEV_S3_SECRET_ACCESS_KEY}" 2>/dev/null || true
@@ -129,20 +121,17 @@ echo ""
 echo "================================================"
 echo "Install dependencies"
 echo "================================================"
-# ── Install dependencies ────────────────────────────────────
 su-exec "$APP_USER" bun install
 echo ""
 echo "================================================"
 echo "Database migrations and seed"
 echo "================================================"
-# ── Run migrations + idempotent seed ────────────────────────
 su-exec "$APP_USER" bun --cwd packages/api db:migrate
 su-exec "$APP_USER" bun --cwd packages/api db:seed --exit-0
 echo ""
 echo "================================================"
 echo "Vite frontend dev server"
 echo "================================================"
-# ── Start Vite frontend dev server ──────────────────────────
 su-exec "$APP_USER" bun --cwd packages/ui dev --host &
 echo "Vite dev server starting on port 5173..."
 echo ""
@@ -152,7 +141,7 @@ echo "================================================"
 
 mkdir -p /var/lib/lombok && chown "$APP_USER" /var/lib/lombok
 
-# ── Start the backend (foreground, auto-restart on exit) ────
+# Foreground, auto-restart on exit.
 while true; do
   su-exec "$APP_USER" bun --cwd packages/api dev
   echo "API process exited, restarting in 1s..."

--- a/packages/api/cmd/gen-app-proxies.sh
+++ b/packages/api/cmd/gen-app-proxies.sh
@@ -1,22 +1,18 @@
 #!/bin/sh
-# Build /etc/nginx/app_frontend_proxies.json from LOMBOK_APP_FRONTEND_PROXY_HOST_*
-# entries in packages/ui/.env.development.local, then reload nginx. app_router.js
-# reads this file to override the per-app UI proxy target in dev. Run as root —
-# the nginx master is root-owned, so `nginx -s reload` needs root.
+# Build app_frontend_proxies.json from LOMBOK_APP_FRONTEND_PROXY_HOST_* in packages/ui/.env.development.local, then reload nginx (app_router.js reads it to override per-app dev UI targets). Must run as root: `nginx -s reload` needs the root-owned master.
 
 cd /usr/src/app || { echo "Error: Cannot cd to /usr/src/app"; exit 1; }
 
 PLATFORM_HOST="${PLATFORM_HOST:-lombok.localhost}"
 APP_UI_HOST="${APP_UI_HOST:-http://127.0.0.1:3001}"
 
-# Template the nginx conf + copy the njs router so config edits apply on reload.
+# Template the conf + copy the njs router so config edits apply on reload.
 sed -e "s|{{PLATFORM_HOST}}|$PLATFORM_HOST|g" -e "s|{{APP_UI_HOST}}|$APP_UI_HOST|g" ./packages/api/nginx/dev-nginx.conf > /etc/nginx/http.d/default.conf
 cp ./packages/api/nginx/app_router.js /etc/nginx/app_router.js
 
 APP_FRONTEND_PROXIES_ENV="./packages/ui/.env.development.local"
 
-# Active (uncommented) overrides as lowercase `key=url` lines, e.g.
-#   homicle_7d940475=http://host.docker.internal:5177
+# Active (uncommented) overrides as lowercase `key=url` lines, e.g. myapp_7d940475=http://host.docker.internal:5177
 if [ -f "$APP_FRONTEND_PROXIES_ENV" ]; then
   PAIRS=$(grep -v '^\s*#' "$APP_FRONTEND_PROXIES_ENV" \
     | grep 'LOMBOK_APP_FRONTEND_PROXY_HOST_' \
@@ -27,14 +23,13 @@ else
 fi
 
 if [ -n "$PAIRS" ]; then
-  # Join the pairs into a JSON object. One pair per line is required so paste
-  # has lines to join — without the newline the commas are dropped (invalid JSON).
+  # One pair per line so paste has lines to join — without the newline commas are dropped (invalid JSON).
   ENTRIES=$(printf '%s\n' "$PAIRS" | awk -F= '{printf "\"%s\": \"%s\"\n", $1, $2}' | paste -sd, -)
   echo "{${ENTRIES}}" > /etc/nginx/app_frontend_proxies.json
   echo "App frontend proxy overrides:"
   cat /etc/nginx/app_frontend_proxies.json
 
-  # Probe each override; warn (don't fail) if nothing is listening on the port.
+  # Probe each override; warn (don't fail) if nothing is listening.
   printf '%s\n' "$PAIRS" | while IFS='=' read -r key url; do
     [ -z "$url" ] && continue
     if ! curl -s -o /dev/null --connect-timeout 2 "$url"; then

--- a/packages/api/cmd/restart-ui.sh
+++ b/packages/api/cmd/restart-ui.sh
@@ -1,27 +1,21 @@
 #!/usr/bin/env sh
 set -eu
 
-# Logs go to a file, not the exec session's stdout: this script runs as the
-# `bun` user via su-exec, which cannot open /dev/stdout (the exec pipe) nor
-# PID 1's fds, and that pipe closes when `./dx restart ui` returns anyway.
+# Log to a file: as the su-exec'd `bun` user we can't open the exec pipe's /dev/stdout, and it closes when `./dx restart ui` returns anyway.
 LOG_FILE=/tmp/vite-dev.log
 PORT=5173
 
-# Stop the dev runner. pkill only matches the parent `bun ... dev` process;
-# its `bun vite`/`node vite` children have a different command line, so they
-# orphan and keep holding the port. Free the port directly to reap them too —
-# otherwise the new vite can't bind 5173 and dies (the intermittent failure).
+# pkill only matches the parent `bun ... dev`; its vite children orphan and keep the port, so free the port directly too or the new vite can't bind.
 pkill -f "packages/ui dev" 2>/dev/null || true
 fuser -k "${PORT}/tcp" 2>/dev/null || true
 
-# Wait for the port to actually free before starting, instead of a fixed sleep.
+# Wait for the port to free rather than a fixed sleep.
 i=0
 while fuser "${PORT}/tcp" >/dev/null 2>&1 && [ "$i" -lt 50 ]; do
   sleep 0.1
   i=$((i + 1))
 done
 
-# setsid + </dev/null fully detaches from the transient exec session so vite
-# survives after `./dx restart ui` exits.
+# setsid + </dev/null detaches from the exec session so vite survives after `./dx restart ui` exits.
 setsid bun --cwd /usr/src/app/packages/ui dev --host </dev/null >>"$LOG_FILE" 2>&1 &
 echo "Vite dev server restarting on port 5173... (logs: $LOG_FILE)"

--- a/packages/api/nginx/dev-nginx.conf
+++ b/packages/api/nginx/dev-nginx.conf
@@ -1,8 +1,6 @@
 js_import app_router from app_router.js;
 
-# App worker API routing — api-server--<worker>--<app>.{{PLATFORM_HOST}}
-# Declared before the tunnel server block so regex matching prefers this
-# more specific pattern (literal `api-server--` prefix).
+# App worker API routing — api-server--<worker>--<app>. Declared before the tunnel block so the more specific `api-server--` regex wins.
 server {
     listen 0.0.0.0:8080;
     server_name "~^api-server--(?<worker_ident>[a-z0-9_]+)--(?<app_ident>[a-z0-9]+-[a-f0-9]{8})\.{{PLATFORM_HOST}}$";
@@ -33,18 +31,12 @@ server {
     error_log /var/log/nginx/api_worker_error.log;
 }
 
-# Tunnel traffic — route tunnel subdomains to bridge tunnel handler
-# Subdomain format: {label}--{publicId}--{appId}.{domain}
-# publicId is `tn-{hex}` — the embedded hyphen, combined with api-server's
-# worker segment being [a-z0-9_]+ (no hyphens), forbids collision with
-# api-server--{worker}--{app}.
-# appId is <slug>-<8hex>, matching the composed app identifier format.
+# Tunnel traffic — {label}--{publicId}--{appId}.{domain} to the bridge handler. publicId's `tn-` hyphen can't collide with api-server's hyphen-free worker segment.
 server {
     listen 0.0.0.0:8080;
     server_name "~^(?<tunnel_label>[a-z0-9][a-z0-9-]{0,30}[a-z0-9])--(?<tunnel_public_id>tn-[a-f0-9]+)--(?<tunnel_app>[a-z0-9]+-[a-f0-9]{8})\.{{PLATFORM_HOST}}$";
 
-    # Tunnel auth — route to platform API preserving full path
-    # (/-/tunnel-auth, /-/tunnel-auth/landing, /-/tunnel-auth/sw.js)
+    # Tunnel auth — route to platform API preserving the full path.
     location ^~ /-/tunnel-auth {
         proxy_pass http://127.0.0.1:3000;
         proxy_http_version 1.1;
@@ -116,8 +108,7 @@ server {
         proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
         proxy_set_header X-Forwarded-Proto $scheme;
 
-        # Upstream unreachable (e.g. the app's dev server isn't running on the
-        # overridden port) — show a readable warning instead of a bare 502.
+        # Show a readable warning instead of a bare 502 when the app's dev server is down.
         error_page 502 503 504 @app_dev_down;
     }
 
@@ -223,9 +214,7 @@ server {
         proxy_send_timeout 86400s;
     }
 
-    # Bridge path-based routing — session proxy (REST + SSE, streaming)
-    # Regex location, evaluated before the /_bridge/ prefix below. Buffering is
-    # disabled so SSE frames flush immediately; timeouts are long-lived.
+    # Bridge session proxy (REST + SSE). Regex, evaluated before the /_bridge/ prefix below; buffering off so SSE frames flush, long timeouts.
     location ~ ^/_bridge/sessions/[^/]+/proxy/ {
         rewrite ^/_bridge(/.*)$ $1 break;
         proxy_pass http://127.0.0.1:3100;

--- a/packages/api/src/app/controllers/user-apps.controller.ts
+++ b/packages/api/src/app/controllers/user-apps.controller.ts
@@ -46,9 +46,6 @@ export class UserAppsController {
     private readonly appCustomSettingsService: AppCustomSettingsService,
   ) {}
 
-  /**
-   * List enabled apps available for the current user
-   */
   @Get('/apps')
   async listApps(@Req() req: express.Request): Promise<UserAppListResponse> {
     if (!req.user) {
@@ -66,9 +63,6 @@ export class UserAppsController {
     }
   }
 
-  /**
-   * Get an enabled app by identifier for the current user
-   */
   @Get('/apps/:appIdentifier')
   async getApp(
     @Req() req: express.Request,
@@ -84,9 +78,6 @@ export class UserAppsController {
     }
   }
 
-  /**
-   * List objects in the current user's partition of an app's server storage
-   */
   @Get('/apps/:appIdentifier/storage/objects')
   async listAppStorageObjects(
     @Req() req: express.Request,
@@ -104,9 +95,6 @@ export class UserAppsController {
     })
   }
 
-  /**
-   * Presign read-only URLs for objects in the current user's app storage partition
-   */
   @Post('/apps/:appIdentifier/storage/presigned-urls')
   async createAppStoragePresignedUrls(
     @Req() req: express.Request,
@@ -124,9 +112,6 @@ export class UserAppsController {
     return { urls }
   }
 
-  /**
-   * Get app contributions
-   */
   @Get('/app-contributions')
   async getAppContributions(
     @Req() req: express.Request,
@@ -138,9 +123,6 @@ export class UserAppsController {
     return contributions
   }
 
-  /**
-   * Generate app user access token
-   */
   @Post('/apps/:appIdentifier/access-token')
   async generateAppUserAccessToken(
     @Req() req: express.Request,
@@ -164,9 +146,6 @@ export class UserAppsController {
     }
   }
 
-  /**
-   * Get app user settings for the current user
-   */
   @Get('/apps/:appIdentifier/settings')
   async getAppUserSettings(
     @Req() req: express.Request,
@@ -182,9 +161,6 @@ export class UserAppsController {
     return { settings }
   }
 
-  /**
-   * Create or update app user settings for the current user
-   */
   @Post('/apps/:appIdentifier/settings')
   async upsertAppUserSettings(
     @Req() req: express.Request,
@@ -205,9 +181,6 @@ export class UserAppsController {
     return { settings }
   }
 
-  /**
-   * Remove app user settings for the current user
-   */
   @Delete('/apps/:appIdentifier/settings')
   async removeAppUserSettings(
     @Req() req: express.Request,
@@ -219,9 +192,6 @@ export class UserAppsController {
     await this.appService.removeAppUserSettings(req.user, appIdentifier)
   }
 
-  /**
-   * Get resolved custom settings for the current user
-   */
   @Get('/apps/:appIdentifier/custom-settings')
   async getUserCustomSettings(
     @Req() req: express.Request,
@@ -238,11 +208,7 @@ export class UserAppsController {
     return { settings: result }
   }
 
-  /**
-   * Patch custom settings for the current user. Keys not present are
-   * preserved; explicit `null` values delete the key. Writes are atomic per
-   * key, so concurrent patches on disjoint keys do not race.
-   */
+  // Absent keys preserved, explicit `null` deletes; writes are per-key atomic so concurrent disjoint-key patches don't race.
   @Patch('/apps/:appIdentifier/custom-settings')
   async patchUserCustomSettings(
     @Req() req: express.Request,
@@ -261,9 +227,7 @@ export class UserAppsController {
     return { settings: result }
   }
 
-  /**
-   * Remove custom settings for the current user (revert to defaults)
-   */
+  // Revert the user's custom settings to defaults.
   @Delete('/apps/:appIdentifier/custom-settings')
   async deleteUserCustomSettings(
     @Req() req: express.Request,

--- a/packages/api/src/app/services/app.service.ts
+++ b/packages/api/src/app/services/app.service.ts
@@ -629,11 +629,7 @@ export class AppService {
     return urls
   }
 
-  /**
-   * List objects in the calling user's own partition of an app's server storage
-   * (`app-runtime-storage/{appId}/users/{userId}/`). Keys are returned relative
-   * to that partition. Scoped to `actor` — never another user's data.
-   */
+  // Lists the calling user's own app-storage partition; keys are partition-relative, scoped to `actor` only.
   async listUserAppStorage(
     actor: User,
     appIdentifier: string,
@@ -681,10 +677,7 @@ export class AppService {
     }
   }
 
-  /**
-   * Presign read-only (GET/HEAD) URLs within the calling user's own partition
-   * of an app's server storage. `objectKey`s are partition-relative.
-   */
+  // Presign read-only (GET/HEAD) URLs in the user's own app-storage partition; objectKeys are partition-relative.
   async createUserAppStoragePresignedUrls(
     actor: User,
     appIdentifier: string,

--- a/packages/api/src/app/utils/app-storage-keys.ts
+++ b/packages/api/src/app/utils/app-storage-keys.ts
@@ -1,5 +1,4 @@
-// Canonical layout for an app's server-storage partition. Both the signing path
-// and the user-facing listing path build keys through here so they can't diverge:
+// Canonical key layout for an app's server-storage partition; signing and listing paths both build through here so they can't diverge.
 //   app-runtime-storage/{appId}/shared/{objectKey}          (userId omitted)
 //   app-runtime-storage/{appId}/users/{userId}/{objectKey}  (userId present)
 

--- a/packages/api/src/app/utils/custom-settings-secrets.utils.ts
+++ b/packages/api/src/app/utils/custom-settings-secrets.utils.ts
@@ -1,8 +1,5 @@
 const MASKED_VALUE = '********'
 
-/**
- * Check if a key matches the secret key pattern.
- */
 export function isSecretKey(
   key: string,
   secretKeyPattern: string | undefined,
@@ -13,13 +10,7 @@ export function isSecretKey(
   return new RegExp(secretKeyPattern).test(key)
 }
 
-/**
- * Recursively mask a value, preserving structure. A leaf is masked when it sits
- * under a secret-matched key — either the top-level key, or any object key along
- * the way. Keeping the surrounding object/array shape intact (rather than
- * collapsing a secret object to a bare sentinel) lets the settings UI keep
- * rendering its editor and round-trip edits in the schema's expected shape.
- */
+// Masks leaves under a secret-matched key while preserving object/array shape, so the settings UI can still render and round-trip edits.
 function maskDeep(
   value: unknown,
   secret: boolean,
@@ -42,10 +33,7 @@ function maskDeep(
   return secret ? MASKED_VALUE : value
 }
 
-/**
- * Mask secret values in a settings object for GET responses. Handles top-level
- * secrets as well as secrets nested inside objects and arrays-of-objects.
- */
+// Masks secret values in a settings object for GET responses, including nested objects and arrays-of-objects.
 export function maskSecretValues(
   values: Record<string, unknown>,
   secretKeyPattern: string | undefined,

--- a/packages/api/src/docker/entities/docker-bridge-tunnel.entity.ts
+++ b/packages/api/src/docker/entities/docker-bridge-tunnel.entity.ts
@@ -21,11 +21,7 @@ export type DockerBridgeTunnelStatus =
   | 'unavailable'
   | 'error'
 
-/**
- * Durable tunnel desired state. The platform DB is the single source of truth;
- * the in-memory bridge session (`sessionId`) is the only ephemeral field and is
- * (re)created by the reconciler under the stable `publicId` to match this row.
- */
+/** Durable tunnel desired state (DB is source of truth); `sessionId` is the only ephemeral field, recreated by the reconciler under the stable `publicId`. */
 export const dockerBridgeTunnelsTable = pgTable(
   'docker_bridge_tunnels',
   {
@@ -41,8 +37,7 @@ export const dockerBridgeTunnelsTable = pgTable(
       .references(() => dockerHostsTable.id),
     // App-chosen stable key for cheap per-scope listing (e.g. a workspace id).
     selectorKey: text('selector_key').notNull(),
-    // Snapshot of identifying container labels used to re-resolve the live
-    // container id (APP_ID / USER_ID / ISOLATION_KEY / PROFILE_ID).
+    // Snapshot of identifying labels used to re-resolve the live container id.
     containerSelector: jsonb('container_selector')
       .$type<Record<string, string>>()
       .notNull(),
@@ -52,7 +47,7 @@ export const dockerBridgeTunnelsTable = pgTable(
     publicId: text('public_id').notNull().unique(),
     // Agent spawn command, replayed verbatim on recreation.
     command: jsonb('command').$type<string[]>().notNull(),
-    // Current live bridge session id — the only ephemeral field (null when down).
+    // Live bridge session id — the only ephemeral field (null when down).
     sessionId: text('session_id'),
     status: text('status')
       .notNull()

--- a/packages/api/src/docker/services/client/docker-client.service.ts
+++ b/packages/api/src/docker/services/client/docker-client.service.ts
@@ -234,9 +234,7 @@ export class DockerClientService {
     const result = await this.bridgeRequest<BridgeContainerInfo>(
       'POST',
       `/docker/${hostId}/containers`,
-      // Options contain typed nested objects (mounts, ports, gpus, …) that
-      // don't satisfy `JsonSerializableValue`'s index-signature requirement,
-      // but are structurally JSON-serializable at runtime.
+      // Typed nested objects (mounts, ports, gpus) are JSON-serializable at runtime but don't satisfy JsonSerializableValue's index signature.
       createPayload,
     )
     return toBridgeContainerInfo(result)
@@ -466,7 +464,7 @@ export class DockerClientService {
     const secret = this.dockerBridgeService.getSecret()
     const env = options?.env ?? {}
 
-    // Create a raw tunnel session with tty=false for demuxed stdout/stderr
+    // tty=false yields demuxed stdout/stderr.
     const session = await this.bridgeRequest<{ id: string }>(
       'POST',
       '/sessions/tunnel',
@@ -483,7 +481,6 @@ export class DockerClientService {
       },
     )
 
-    // Connect via WebSocket for bidirectional streaming
     const ws = new WebSocket(
       `${BRIDGE_WS_URL}/sessions/${session.id}/attach?token=${encodeURIComponent(secret)}`,
     )
@@ -526,7 +523,7 @@ export class DockerClientService {
         return
       }
 
-      // First byte is stream type: 0x01=stdout, 0x02=stderr
+      // First byte is stream type: 0x01=stdout, 0x02=stderr.
       const streamType = buf[0]
       const payload = buf.subarray(1)
 
@@ -599,10 +596,7 @@ export class DockerClientService {
     }
   }
 
-  /**
-   * Look up registry credentials for an image. Returns auth config if the
-   * image's registry matches a stored credential, otherwise undefined.
-   */
+  /** Look up registry credentials for an image; undefined if no stored credential matches its registry. */
   private async resolveRegistryAuth(
     image: string,
   ): Promise<
@@ -613,8 +607,7 @@ export class DockerClientService {
       return undefined
     }
 
-    // Extract registry from image (e.g. "ghcr.io/org/img:tag" → "ghcr.io")
-    // Images without a registry prefix (e.g. "nginx:latest") use Docker Hub
+    // Registry is the first path segment if it looks like a host; else Docker Hub.
     const firstSegment = image.split('/')[0] ?? ''
     const hasRegistry = firstSegment.includes('.') || firstSegment.includes(':')
     const registry = hasRegistry ? firstSegment : 'docker.io'
@@ -729,9 +722,7 @@ export class DockerClientService {
       },
     )
 
-    // Filter containers by userId and isolationKey labels: if a label was not
-    // requested, exclude containers that have one set. When a label is requested,
-    // Docker's label filter already ensures an exact match.
+    // Exclude containers carrying a userId/isolationKey label the request didn't ask for (requested labels are already exact-matched by Docker's filter).
     const requestedUserId = options.labels[DOCKER_LABELS.USER_ID]
     const requestedIsolationKey = options.labels[DOCKER_LABELS.ISOLATION_KEY]
 
@@ -748,7 +739,6 @@ export class DockerClientService {
       return true
     })
 
-    // Find a running container
     const runningContainer = matchingContainers.find(
       (container) => container.state === 'running',
     )
@@ -757,7 +747,6 @@ export class DockerClientService {
       return runningContainer
     }
 
-    // Find a stopped container we can restart
     const stoppedContainer = matchingContainers.find(
       (container) =>
         container.state === 'exited' || container.state === 'created',
@@ -770,7 +759,7 @@ export class DockerClientService {
       return stoppedContainer
     }
 
-    // No suitable container found, create a new one with labels as env vars
+    // No reusable container: create one, exposing labels as env vars.
     const createOptions = {
       ...options,
       env: {
@@ -786,7 +775,6 @@ export class DockerClientService {
 
     return this.withErrorGuard(
       async () => {
-        // Pull image with registry auth if configured
         const registryAuth = await this.resolveRegistryAuth(createOptions.image)
         if (registryAuth) {
           await this.pullImage(hostId, createOptions.image, registryAuth)
@@ -895,10 +883,7 @@ export class DockerClientService {
   // Tunnel / session management
   // ---------------------------------------------------------------------------
 
-  /**
-   * Create a raw tunnel session and return a DockerTtyStream for server-side relay.
-   * Used by Socket.IO terminal relay (backend attaches to terminal, not browser).
-   */
+  /** Create a raw tunnel session and return a DockerTtyStream for server-side relay (Socket.IO terminal relay; backend attaches, not the browser). */
   async execTty(
     containerId: string,
     command: string[],
@@ -911,7 +896,6 @@ export class DockerClientService {
   ): Promise<DockerTtyStream> {
     const backendToken = this.dockerBridgeService.getSecret()
 
-    // 1. Create raw tunnel session via HTTP
     const createResponse = await fetch(`${BRIDGE_HTTP_URL}/sessions/tunnel`, {
       method: 'POST',
       headers: {
@@ -946,7 +930,6 @@ export class DockerClientService {
       `Bridge raw tunnel created: ${session.id} for container ${containerId}`,
     )
 
-    // 2. Attach via WebSocket for bidirectional I/O
     const ws = new WebSocket(
       `${BRIDGE_WS_URL}/sessions/${session.id}/attach?token=${encodeURIComponent(backendToken)}`,
     )
@@ -1008,7 +991,6 @@ export class DockerClientService {
       )
     })
 
-    // 3. Return DockerTtyStream interface
     const stream: DockerTtyStream = {
       write: (data: string | Buffer) => {
         if (destroyed || ws.readyState !== WebSocket.OPEN) {
@@ -1062,11 +1044,7 @@ export class DockerClientService {
     return stream
   }
 
-  /**
-   * Create a tunnel session and return credentials for direct client access.
-   * For raw protocol: used for terminal sessions (browser connects via WS).
-   * For framed protocol: used for HTTP tunnel-agent proxying.
-   */
+  /** Create a tunnel session and return credentials for direct client access (raw = terminal WS, framed = HTTP tunnel-agent proxying). */
   async createTunnelSession(
     hostId: string,
     containerId: string,
@@ -1144,11 +1122,7 @@ export class DockerClientService {
     }
   }
 
-  /**
-   * Create (or idempotently reuse) a durable tunnel session under a stable,
-   * caller-supplied publicId. Always persistent/framed/public. Asserts the
-   * bridge echoed back the same publicId, then mints a fresh token bound to it.
-   */
+  /** Create (or idempotently reuse) a durable tunnel session under a caller-supplied publicId (always persistent/framed/public); asserts the bridge echoed it back, then mints a token bound to it. */
   async createDurableTunnelSession(
     hostId: string,
     containerId: string,
@@ -1238,10 +1212,7 @@ export class DockerClientService {
     return this.buildTunnelUrl(publicId, label, appIdentifier)
   }
 
-  /**
-   * Fetch a single bridge session by id (drives the durable health check).
-   * Returns null when the session no longer exists (404).
-   */
+  /** Fetch a single bridge session by id (drives the durable health check); null on 404. */
   async getSessionById(sessionId: string): Promise<BridgeSessionFull | null> {
     try {
       return await this.bridgeRequest<BridgeSessionFull>(
@@ -1256,10 +1227,7 @@ export class DockerClientService {
     }
   }
 
-  /**
-   * List all bridge tunnel sessions (admin observability), optionally filtered.
-   * Maps the bridge's snake_case payload to the camelCase DTO.
-   */
+  /** List bridge tunnel sessions (admin observability), optionally filtered; maps snake_case to the camelCase DTO. */
   async listSessions(filter?: {
     appId?: string
     containerId?: string
@@ -1280,9 +1248,7 @@ export class DockerClientService {
     return sessions.map(toDockerSessionDTO)
   }
 
-  /**
-   * List tunnel sessions belonging to an app. Returns session IDs only.
-   */
+  /** List tunnel sessions belonging to an app (session IDs only). */
   async listTunnelSessionsByApp(
     appIdentifier: string,
   ): Promise<{ sessionId: string }[]> {
@@ -1298,16 +1264,13 @@ export class DockerClientService {
     return sessions.map((s) => ({ sessionId: s.id }))
   }
 
-  /**
-   * Delete a tunnel session, optionally validating ownership by app identifier.
-   */
+  /** Delete a tunnel session, optionally validating ownership by app identifier. */
   async deleteTunnelSession(
     sessionId: string,
     appIdentifier?: string,
   ): Promise<void> {
     const backendToken = this.dockerBridgeService.getSecret()
 
-    // If appIdentifier provided, validate ownership first
     if (appIdentifier) {
       const getResponse = await fetch(
         `${BRIDGE_HTTP_URL}/sessions/${sessionId}`,
@@ -1349,10 +1312,7 @@ export class DockerClientService {
       protocol?: 'framed' | 'raw'
     },
   ): Promise<string> {
-    // Framed sessions auth per-request over their active life (kept alive by
-    // touch() on a live SSE) and must outlive the 30-min idle window, so they
-    // get the long TTL — as do public sessions. Raw/PTY sessions auth once at
-    // attach and stay at the short TTL.
+    // Framed and public sessions get the long TTL (framed auth per-request and must outlive the 30-min idle window); raw/PTY auth once at attach and keep the short TTL.
     const ttlSeconds =
       options?.publicId || options?.protocol === 'framed'
         ? PUBLIC_SESSION_TOKEN_TTL_SECONDS

--- a/packages/api/src/docker/services/docker-bridge.service.ts
+++ b/packages/api/src/docker/services/docker-bridge.service.ts
@@ -72,11 +72,7 @@ export class DockerBridgeService {
     return this.ready
   }
 
-  /**
-   * Register a callback fired each time the bridge (re)connects and is ready —
-   * first boot and every auto-restart. Drives durable-tunnel replay. Returns an
-   * idempotent unsubscribe.
-   */
+  /** Register a callback fired on each bridge (re)connect (first boot + every restart); drives durable-tunnel replay. Returns an idempotent unsubscribe. */
   onReady(cb: () => void): () => void {
     this.readyCallbacks.add(cb)
     return () => this.readyCallbacks.delete(cb)
@@ -115,7 +111,6 @@ export class DockerBridgeService {
     const instanceId = crypto.randomUUID()
     const socketPath = `/tmp/lombok-docker-bridge-${instanceId}.sock`
 
-    // Create IPC server
     const { server, cleanup } = await createSocketServer(
       socketPath,
       (message: string, _socket: Socket) => {
@@ -150,7 +145,7 @@ export class DockerBridgeService {
 
     this.logger.debug(`Starting bridge: ${cmd.join(' ')}`)
 
-    // Build NODE_PATH for compiled binary's runtime deps
+    // NODE_PATH for the compiled binary's runtime deps.
     const bridgeNodeModules = path.join(bridgeDir, 'node_modules')
     const nodePath = fs.existsSync(bridgeNodeModules)
       ? bridgeNodeModules
@@ -188,17 +183,13 @@ export class DockerBridgeService {
       }, 1000)
     })
 
-    // Wait for bridge to connect then send init
     await this.waitForConnection(server, 10000)
-
-    // Send init config
     await this.sendInit(hosts)
 
     this.ready = true
     this.logger.log('Docker bridge started and ready')
 
-    // Fire ready callbacks (fire-and-forget) so durable tunnels are replayed on
-    // first boot and every auto-restart. A callback must never block startup.
+    // Fire-and-forget; a ready callback must never block startup.
     for (const cb of this.readyCallbacks) {
       try {
         cb()
@@ -220,7 +211,7 @@ export class DockerBridgeService {
     }
 
     if (!this.ready) {
-      // Bridge not running yet — start it if we now have hosts
+      // Bridge not running yet: start it if we now have hosts.
       if (Object.keys(hosts).length > 0) {
         await this.startBridge()
       }
@@ -373,9 +364,7 @@ export class DockerBridgeService {
       }
       const reader = stream.getReader()
       const decoder = new TextDecoder()
-      // Per-child carry: a chunk may hold several newline-delimited JSON lines
-      // or a partial trailing line. Reset per invocation so a killed child's
-      // dangling bytes can't corrupt the next child's first line.
+      // Per-child carry for partial trailing lines; reset per invocation so a killed child's dangling bytes can't corrupt the next child.
       let carry = ''
       try {
         // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
@@ -455,7 +444,7 @@ export class DockerBridgeService {
       try {
         sub(entry)
       } catch {
-        // A subscriber must never break ingestion or other subscribers.
+        // One subscriber must not break ingestion or others.
       }
     }
   }
@@ -499,7 +488,7 @@ export class DockerBridgeService {
         return existing
       }
     } catch {
-      // File doesn't exist or is unreadable — generate a new one
+      // Missing or unreadable: generate a new one.
     }
 
     const secret = crypto.randomBytes(32).toString('base64url')

--- a/packages/api/src/docker/services/durable-tunnel.service.ts
+++ b/packages/api/src/docker/services/durable-tunnel.service.ts
@@ -60,8 +60,7 @@ const SELECTOR_LABELS = [
 export class DurableTunnelService {
   private readonly logger = new Logger(DurableTunnelService.name)
 
-  // Coalesce concurrent ensureLive per tunnel id — a single in-flight rebind is
-  // shared by all callers (replay + lazy open racing on the same row).
+  // Coalesce concurrent ensureLive per tunnel id so racing callers share one rebind.
   private readonly inFlight = new Map<string, Promise<DurableTunnelView>>()
 
   constructor(
@@ -69,10 +68,7 @@ export class DurableTunnelService {
     private readonly dockerClientService: DockerClientService,
   ) {}
 
-  /**
-   * Create (or idempotently reuse) a durable tunnel for the unique
-   * (app, user, selectorKey, port) tuple, then bind it live.
-   */
+  /** Create (or idempotently reuse) a durable tunnel for the unique (app, user, selectorKey, port) tuple, then bind it live. */
   async create(input: CreateDurableTunnelInput): Promise<DurableTunnelView> {
     const container = await this.dockerClientService.findContainerById(
       input.hostId,
@@ -151,11 +147,7 @@ export class DurableTunnelService {
     return this.ensureLive(row.id)
   }
 
-  /**
-   * The self-heal core. Re-resolves the live container by labels, reuses a
-   * healthy bridge session or (re)creates one under the stable publicId, and
-   * mints a fresh token. Never starts a container.
-   */
+  /** Self-heal: re-resolve the container by labels, reuse or recreate the bridge session under the stable publicId, mint a fresh token. Never starts a container. */
   async ensureLive(tunnelId: string): Promise<DurableTunnelView> {
     const pending = this.inFlight.get(tunnelId)
     if (pending) {
@@ -178,7 +170,6 @@ export class DurableTunnelService {
     }
 
     try {
-      // Re-resolve the live container by its identifying labels.
       const container = await this.resolveRunningContainer(row)
       if (!container) {
         const updated = await this.patch(row.id, {
@@ -211,7 +202,7 @@ export class DurableTunnelService {
           })
           return this.toView(updated, token)
         }
-        // Stale session (gone, wrong container, or not ready) — drop and rebind.
+        // Stale session (gone, wrong container, or not ready): drop and rebind.
         if (session) {
           await this.dockerClientService
             .deleteTunnelSession(row.sessionId, row.appId)
@@ -219,7 +210,6 @@ export class DurableTunnelService {
         }
       }
 
-      // Otherwise (re)create the bridge session under the stable publicId.
       const created = await this.dockerClientService.createDurableTunnelSession(
         row.hostId,
         container.id,
@@ -326,8 +316,7 @@ export class DurableTunnelService {
       row.hostId,
       row.containerSelector,
     )
-    // Exclude containers carrying an identifying label the selector did not
-    // request (mirrors findOrCreateContainer's not-requested-label exclusion).
+    // Exclude containers carrying an identifying label the selector did not request (mirrors findOrCreateContainer).
     const hasIsolationKey = DOCKER_LABELS.ISOLATION_KEY in row.containerSelector
     const matching = containers.filter((container) => {
       if (!hasIsolationKey && container.labels[DOCKER_LABELS.ISOLATION_KEY]) {

--- a/packages/api/src/docker/services/tunnel-reconciler.service.ts
+++ b/packages/api/src/docker/services/tunnel-reconciler.service.ts
@@ -6,12 +6,7 @@ import { DurableTunnelService } from './durable-tunnel.service'
 /** Max concurrent ensureLive calls during a bulk replay. */
 const REPLAY_CONCURRENCY = 6
 
-/**
- * Replays durable tunnels into live bridge sessions whenever the bridge
- * (re)connects. A thin layer over DurableTunnelService that registers itself on
- * the bridge's onReady hook — kept separate to avoid a
- * DockerBridgeService → DurableTunnelService import cycle.
- */
+/** Replays durable tunnels into live bridge sessions on each bridge (re)connect; separate from DurableTunnelService to avoid a DockerBridgeService import cycle. */
 @Injectable()
 export class TunnelReconcilerService implements OnApplicationBootstrap {
   private readonly logger = new Logger(TunnelReconcilerService.name)
@@ -28,10 +23,7 @@ export class TunnelReconcilerService implements OnApplicationBootstrap {
     })
   }
 
-  /**
-   * Re-bind every durable tunnel under its stable publicId. Bounded concurrency,
-   * per-row error isolation; guarded against overlapping replays.
-   */
+  /** Re-bind every durable tunnel under its stable publicId; bounded concurrency, per-row error isolation, guarded against overlapping replays. */
   async replayAll(): Promise<void> {
     if (this.replaying) {
       this.logger.debug('Replay already in progress, skipping')

--- a/packages/api/src/docker/tests/durable-bridge-tunnel.e2e-spec.ts
+++ b/packages/api/src/docker/tests/durable-bridge-tunnel.e2e-spec.ts
@@ -21,12 +21,7 @@ const TEST_MODULE_KEY = 'durable_bridge_tunnel'
 const TEST_APP_SLUG = 'testapp'
 const HOST_ID = TEST_DOCKER_HOST_ID
 
-/**
- * A controllable stand-in for the bridge-facing half of DockerClientService.
- * Tests drive which container is "running" and what the bridge reports for a
- * session; the world records the durable create/delete calls. App/user ids are
- * read live from the closed-over refs so a single instance survives re-install.
- */
+/** Controllable stand-in for the bridge-facing half of DockerClientService; app/user ids are read live from closed-over refs so one instance survives re-install. */
 function buildBridgeWorld(getAppId: () => string, getUserId: () => string) {
   const world = {
     container: { id: 'container-1', state: 'running' as 'running' | 'exited' },
@@ -221,7 +216,7 @@ describe('Durable bridge tunnels', () => {
     const created = await createOne()
     const oldSessionId = world.sessions.keys().next().value!
 
-    // Container recreated with a new id; the old session is now stale.
+    // Container recreated with a new id, so the old session is stale.
     world.container = { id: 'container-2', state: 'running' }
 
     const reBound = await durableTunnelService.get(created.id, {

--- a/packages/api/src/folders/controllers/folders.controller.ts
+++ b/packages/api/src/folders/controllers/folders.controller.ts
@@ -94,12 +94,7 @@ export class FoldersController {
     private readonly folderIconService: FolderIconService,
   ) {}
 
-  /**
-   * List the current user's starred folders.
-   *
-   * Declared before `/:folderId` so the literal `starred` segment is not
-   * captured by the UUID-parsed folder route.
-   */
+  // Declared before `/:folderId` so `starred` isn't captured by the UUID-parsed folder route.
   @Get('/starred')
   @AuthGuardConfig({
     allowedActors: [AllowedActor.USER, AllowedActor.APP_USER],
@@ -114,9 +109,6 @@ export class FoldersController {
     return { folders }
   }
 
-  /**
-   * Get a folder by id.
-   */
   @Get('/:folderId')
   @AuthGuardConfig({
     allowedActors: [AllowedActor.USER, AllowedActor.APP_USER],
@@ -137,9 +129,6 @@ export class FoldersController {
     }
   }
 
-  /**
-   * Star or unstar a folder for the current user.
-   */
   @Put('/:folderId/starred')
   @AuthGuardConfig({
     allowedActors: [AllowedActor.USER, AllowedActor.APP_USER],
@@ -160,9 +149,6 @@ export class FoldersController {
     return { starred }
   }
 
-  /**
-   * Check S3 access and update folder accessError
-   */
   @Post('/:folderId/check-access')
   async checkFolderAccess(
     @Req() req: express.Request,
@@ -183,9 +169,6 @@ export class FoldersController {
     return { ok: true }
   }
 
-  /**
-   * Get the metadata for a folder by id.
-   */
   @Get('/:folderId/metadata')
   @AuthGuardConfig({
     allowedActors: [AllowedActor.USER, AllowedActor.APP_USER],
@@ -204,9 +187,6 @@ export class FoldersController {
     return result
   }
 
-  /**
-   * List folders.
-   */
   @Get()
   @AuthGuardConfig({
     allowedActors: [AllowedActor.USER, AllowedActor.APP_USER],
@@ -235,9 +215,6 @@ export class FoldersController {
     }
   }
 
-  /**
-   * Create a folder.
-   */
   @Post()
   async createFolder(
     @Req() req: express.Request,
@@ -256,9 +233,6 @@ export class FoldersController {
     }
   }
 
-  /**
-   * Delete a folder by id.
-   */
   @Delete('/:folderId')
   async deleteFolder(
     @Req() req: express.Request,
@@ -270,9 +244,6 @@ export class FoldersController {
     await this.folderService.deleteFolderAsUser(req.user, folderId)
   }
 
-  /**
-   * Scan the underlying S3 location and update our local representation of it.
-   */
   @Post('/:folderId/reindex')
   async reindexFolder(
     @Req() req: express.Request,
@@ -294,9 +265,6 @@ export class FoldersController {
     }
   }
 
-  /**
-   * List folder objects by folderId.
-   */
   @Get('/:folderId/objects')
   @AuthGuardConfig({
     allowedActors: [AllowedActor.USER, AllowedActor.APP_USER],
@@ -324,9 +292,6 @@ export class FoldersController {
     }
   }
 
-  /**
-   * Get a folder object by folderId and objectKey.
-   */
   @Get('/:folderId/objects/:objectKey')
   @AuthGuardConfig({
     allowedActors: [AllowedActor.USER, AllowedActor.APP_USER],
@@ -348,9 +313,6 @@ export class FoldersController {
     }
   }
 
-  /**
-   * Delete a folder object by folderId and objectKey.
-   */
   @Delete('/:folderId/objects/:objectKey')
   async deleteFolderObject(
     @Req() req: express.Request,
@@ -366,9 +328,6 @@ export class FoldersController {
     })
   }
 
-  /**
-   * Create presigned urls for objects in a folder.
-   */
   @Post('/:folderId/presigned-urls')
   @AuthGuardConfig({
     allowedActors: [AllowedActor.USER, AllowedActor.APP_USER],
@@ -388,9 +347,6 @@ export class FoldersController {
     return { urls }
   }
 
-  /**
-   * Scan the object again in the underlying storage, and update its state in our db.
-   */
   @Post('/:folderId/objects/:objectKey/refresh')
   @AuthGuardConfig({
     allowedActors: [AllowedActor.USER, AllowedActor.APP_USER],
@@ -414,9 +370,6 @@ export class FoldersController {
     }
   }
 
-  /**
-   * Get folder share for a user
-   */
   @Get('/:folderId/shares/:userId')
   async getFolderShares(
     @Req() req: express.Request,
@@ -434,9 +387,6 @@ export class FoldersController {
     return { share }
   }
 
-  /**
-   * List folder shares
-   */
   @Get('/:folderId/shares')
   async listFolderShares(
     @Req() req: express.Request,
@@ -450,9 +400,6 @@ export class FoldersController {
     return shares
   }
 
-  /**
-   * List prospective folder share users
-   */
   @Get('/:folderId/user-share-options')
   async listFolderShareUsers(
     @Req() req: express.Request,
@@ -470,9 +417,6 @@ export class FoldersController {
     return shares
   }
 
-  /**
-   * Add or update a folder share
-   */
   @Post('/:folderId/shares/:userId')
   async upsertFolderShare(
     @Req() req: express.Request,
@@ -493,9 +437,6 @@ export class FoldersController {
     }
   }
 
-  /**
-   * Remove a folder share
-   */
   @Delete('/:folderId/shares/:userId')
   async removeFolderShare(
     @Req() req: express.Request,
@@ -508,9 +449,6 @@ export class FoldersController {
     await this.folderService.removeFolderShare(req.user, folderId, userId)
   }
 
-  /**
-   * Update a folder by id.
-   */
   @Put('/:folderId')
   async updateFolder(
     @Req() req: express.Request,
@@ -530,9 +468,6 @@ export class FoldersController {
     }
   }
 
-  /**
-   * Upload (or replace) a folder icon image.
-   */
   @Post('/:folderId/icon')
   @UseInterceptors(
     FileInterceptor('file', { limits: { fileSize: MAX_IMAGE_UPLOAD_BYTES } }),
@@ -565,9 +500,6 @@ export class FoldersController {
     return { folder: transformFolderToDTO(folder) }
   }
 
-  /**
-   * Remove a folder icon.
-   */
   @Delete('/:folderId/icon')
   @HttpCode(204)
   async deleteFolderIcon(
@@ -580,9 +512,6 @@ export class FoldersController {
     await this.folderIconService.deleteIcon(req.user, folderId)
   }
 
-  /**
-   * Get all app settings for a folder
-   */
   @Get('/:folderId/app-settings')
   async getFolderAppSettings(
     @Req() req: express.Request,
@@ -598,9 +527,6 @@ export class FoldersController {
     return { settings }
   }
 
-  /**
-   * Bulk update app settings for a folder
-   */
   @Patch('/:folderId/app-settings')
   async updateFolderAppSettings(
     @Req() req: express.Request,
@@ -618,9 +544,6 @@ export class FoldersController {
     return { settings }
   }
 
-  /**
-   * Get resolved custom settings for an app on a folder
-   */
   @Get('/:folderId/apps/:appIdentifier/custom-settings')
   async getFolderCustomSettings(
     @Req() req: express.Request,
@@ -639,11 +562,7 @@ export class FoldersController {
     return { settings: result }
   }
 
-  /**
-   * Patch custom settings for an app on a folder. Keys not present are
-   * preserved; explicit `null` values delete the key. Writes are atomic per
-   * key, so concurrent patches on disjoint keys do not race.
-   */
+  // Absent keys preserved, explicit `null` deletes; writes are per-key atomic so concurrent disjoint-key patches don't race.
   @Patch('/:folderId/apps/:appIdentifier/custom-settings')
   async patchFolderCustomSettings(
     @Req() req: express.Request,
@@ -668,9 +587,7 @@ export class FoldersController {
     return { settings: result }
   }
 
-  /**
-   * Remove custom settings for an app on a folder (revert to user-level)
-   */
+  // Revert folder custom settings to user-level.
   @Delete('/:folderId/apps/:appIdentifier/custom-settings')
   async deleteFolderCustomSettings(
     @Req() req: express.Request,

--- a/packages/api/src/orm/orm.service.ts
+++ b/packages/api/src/orm/orm.service.ts
@@ -155,30 +155,19 @@ export class OrmService {
         user: this._ormConfig.dbUser,
         password: this._ormConfig.dbPassword,
         database: this._ormConfig.dbName,
-        // Surface deadlocks loudly instead of hanging forever. If a caller
-        // can't get a connection within 10s, throw — better a noisy error
-        // than a silent freeze.
+        // Fail fast instead of hanging forever when the pool is exhausted.
         connectionTimeoutMillis: 10_000,
       })
     }
     return this._client
   }
 
-  /**
-   * Per-app Postgres schema name. Embeds slug + canonical id so the schema
-   * stays diagnosable when inspecting the cluster and unique across reinstalls
-   * (id changes on every fresh install).
-   */
+  // slug + id: diagnosable in the cluster, unique across reinstalls (id changes per fresh install).
   private getAppSchemaName(app: App): string {
     return `app_${app.slug}_${app.id}`
   }
 
-  /**
-   * Per-app Postgres role name. `${slug}_${id}` keeps it diagnosable while
-   * id makes it unique across Lombok deployments sharing a PG cluster and
-   * across uninstall→reinstall cycles. Without it, `DROP ROLE` would fail
-   * if any other DB still grants permissions to the same name.
-   */
+  // slug + id: unique across deployments sharing a PG cluster and across reinstalls (roles are cluster-level).
   private getAppRoleName(app: App): string {
     return `app_role_${app.slug}_${app.id}`
   }
@@ -234,19 +223,14 @@ export class OrmService {
     }
   }
 
-  /**
-   * Generate a consistent advisory lock ID from an app identifier
-   * Uses a simple hash to convert the string identifier to a number
-   */
   private getAdvisoryLockId(appIdentifier: string): number {
     let hash = 0
     for (let i = 0; i < appIdentifier.length; i++) {
       const char = appIdentifier.charCodeAt(i)
       hash = (hash << 5) - hash + char
-      hash = hash & hash // Convert to 32-bit integer
+      hash = hash & hash // 32-bit
     }
-    // Use a namespace prefix to avoid conflicts with other advisory locks
-    // PostgreSQL advisory locks use 64-bit integers, so we can use a high bit
+    // High-bit namespace prefix to avoid colliding with other advisory locks.
     return Math.abs(hash) | 0x40000000
   }
 
@@ -257,12 +241,10 @@ export class OrmService {
     const platformRole = this._ormConfig.dbUser
     const lockId = this.getAdvisoryLockId(app.id)
 
-    // Use a dedicated connection from the pool to ensure advisory locks work correctly
-    // Advisory locks are session-scoped, so we need the same connection for lock/unlock
+    // Advisory locks are session-scoped: lock/unlock must use the same connection.
     const client = await this.client.connect()
 
     try {
-      // Acquire advisory lock to prevent concurrent privilege grants
       await client.query('SELECT pg_advisory_lock($1)', [lockId])
 
       try {
@@ -317,11 +299,9 @@ export class OrmService {
           throw error
         }
       } finally {
-        // Always release the advisory lock, even if an error occurred
         await client.query('SELECT pg_advisory_unlock($1)', [lockId])
       }
     } finally {
-      // Always release the connection back to the pool
       client.release()
     }
   }
@@ -372,7 +352,7 @@ export class OrmService {
       })
     }
 
-    // Ensure extensions and schemas exist BEFORE running migrations
+    // Extensions and schemas must exist before migrations run.
     await this.ensureExtensionsSchema()
     await this.ensureVectorExtension()
 
@@ -492,10 +472,7 @@ export class OrmService {
               (t) => `"${t}"`,
             ).join(', ')
             const truncateTablesQuery = `TRUNCATE TABLE ${tableNames} RESTART IDENTITY CASCADE;`
-            // Retry on deadlock/lock-timeout: fire-and-forget writes (e.g. task
-            // activity telemetry) can still be in flight when a test truncates,
-            // producing a transient TRUNCATE/INSERT lock cycle. lock_timeout
-            // fails fast instead of blocking, then we back off and retry.
+            // Retry on deadlock/lock-timeout: in-flight fire-and-forget writes (e.g. task telemetry) can cause a transient TRUNCATE/INSERT lock cycle.
             const maxAttempts = 5
             for (let attempt = 1; ; attempt++) {
               const client = await this.client.connect()
@@ -566,7 +543,6 @@ export class OrmService {
   }
 
   async ensureExtensionsSchema(): Promise<void> {
-    // Create extensions schema if it doesn't exist
     await this.client.query(`CREATE SCHEMA IF NOT EXISTS ${EXTENSIONS_SCHEMA};`)
     await this.client.query(
       `GRANT USAGE ON SCHEMA ${EXTENSIONS_SCHEMA} TO ${this._ormConfig.dbUser};`,
@@ -574,43 +550,27 @@ export class OrmService {
     await this.client.query(`SET search_path TO public, ${EXTENSIONS_SCHEMA};`)
   }
 
-  /**
-   * Ensure app schema exists
-   */
   async ensureAppSchemaAndRole(app: App): Promise<void> {
     const schemaName = this.getAppSchemaName(app)
 
-    // Check if schema exists
     const schemaExists = await this.client.query<{ exists: number }>(
       'SELECT 1 as exists FROM information_schema.schemata WHERE schema_name = $1',
       [schemaName],
     )
 
     if (schemaExists.rows.length === 0) {
-      // Create the schema
       await this.client.query(`CREATE SCHEMA IF NOT EXISTS ${schemaName}`)
     }
 
     await this.ensureAppRole(app)
   }
 
-  /**
-   * Drop app schema (for cleanup/testing)
-   */
   async dropAppSchema(app: App): Promise<void> {
     const schemaName = this.getAppSchemaName(app)
     await this.client.query(`DROP SCHEMA IF EXISTS ${schemaName} CASCADE`)
   }
 
-  /**
-   * Drop the per-app Postgres role and forget its KV password. Schema must be
-   * dropped first (the role owns objects in it). DROP OWNED BY revokes every
-   * grant given to the role *in the current database* — roles are cluster-
-   * level in Postgres, so if the same role name is referenced from another
-   * database (rare in production but defensible), the role is left in place.
-   * Best-effort: a leaked role is harmless since the next install gets a
-   * fresh canonical id (and therefore a fresh role name).
-   */
+  // Schema must be dropped first (the role owns objects in it). Best-effort: a leaked role is harmless since reinstall gets a fresh role name.
   async dropAppRole(app: App): Promise<void> {
     const appRoleName = this.getAppRoleName(app)
     const roleExists = await this.client.query<{ exists: number }>(
@@ -650,9 +610,6 @@ export class OrmService {
     )
   }
 
-  /**
-   * Run migrations for a specific app
-   */
   async runAppMigrations(
     app: App,
     migrationFiles: { filename: string; content: string }[],
@@ -663,7 +620,6 @@ export class OrmService {
       return
     }
 
-    // Create migration tracking table if it doesn't exist
     await this.client.query(`
       CREATE TABLE IF NOT EXISTS ${schemaName}.__migrations__ (
         id SERIAL PRIMARY KEY,
@@ -674,7 +630,6 @@ export class OrmService {
       )
     `)
 
-    // Get list of executed migrations
     const executedMigrationsResult = await this.client.query(
       `SELECT filename FROM ${schemaName}.__migrations__ ORDER BY id`,
     )
@@ -684,7 +639,6 @@ export class OrmService {
 
     const executedFilenames = new Set(executedMigrations.map((m) => m.filename))
 
-    // Execute pending migrations in order
     for (const migrationFile of migrationFiles) {
       if (!executedFilenames.has(migrationFile.filename)) {
         await this.executeAppMigration(app, migrationFile)
@@ -692,32 +646,25 @@ export class OrmService {
     }
   }
 
-  /**
-   * Remove schema references from migration content
-   * Strips schema prefixes from table references and removes CREATE SCHEMA statements
-   */
+  // App migrations are authored with schema prefixes; strip them so the SQL runs inside the app's own schema via search_path.
   private removeSchemaReferencesFromMigration(content: string): string {
     let processedContent = content
 
-    // Remove CREATE SCHEMA statements entirely
     processedContent = processedContent.replace(
       /CREATE\s+SCHEMA\s+[^;]+;/gi,
       '',
     )
 
-    // Remove SET search_path statements
     processedContent = processedContent.replace(
       /SET\s+search_path\s+TO\s+[^;]+;/gi,
       '',
     )
 
-    // Remove WITH SCHEMA clauses from CREATE EXTENSION statements
     processedContent = processedContent.replace(
       /CREATE\s+EXTENSION\s+[^;]+WITH\s+SCHEMA\s+[^;]+;/gi,
       (match) => match.replace(/\s+WITH\s+SCHEMA\s+[^;]+/gi, ''),
     )
 
-    // Remove IN SCHEMA clauses from ALTER DEFAULT PRIVILEGES
     processedContent = processedContent.replace(
       /ALTER\s+DEFAULT\s+PRIVILEGES\s+IN\s+SCHEMA\s+"[^"]+"\s+/gi,
       'ALTER DEFAULT PRIVILEGES ',
@@ -727,15 +674,12 @@ export class OrmService {
       'ALTER DEFAULT PRIVILEGES ',
     )
 
-    // Remove schema prefixes from quoted identifiers like "public"."table_name"
-    // But preserve system schemas like pg_catalog, information_schema, etc.
+    // Strip schema prefixes from identifiers (quoted, mixed, unquoted) but preserve system schemas (pg_catalog, information_schema, …).
     processedContent = processedContent.replace(
       /"(?!pg_catalog|information_schema|pg_toast|pg_temp)([^"]+)"\."([^"]+)"/g,
       '"$2"',
     )
 
-    // Remove schema prefixes from mixed identifiers like public."table_name" or "schema".table_name
-    // But preserve system schemas like pg_catalog, information_schema, etc.
     processedContent = processedContent.replace(
       /\b(?!pg_catalog|information_schema|pg_toast|pg_temp)([a-zA-Z_][a-zA-Z0-9_]*)\.("([^"]+)")/g,
       '$2',
@@ -745,23 +689,16 @@ export class OrmService {
       '$2',
     )
 
-    // Remove schema prefixes from unquoted identifiers like public.table_name
-    // But preserve system schemas like pg_catalog, information_schema, etc.
     processedContent = processedContent.replace(
       /\b(?!pg_catalog|information_schema|pg_toast|pg_temp)([a-zA-Z_][a-zA-Z0-9_]*)\.([a-zA-Z_][a-zA-Z0-9_]*)\b/g,
       '$2',
     )
 
-    // Clean up any extra whitespace that might be left
     processedContent = processedContent.replace(/\n\s*\n\s*\n/g, '\n\n')
 
     return processedContent.trim()
   }
 
-  /**
-   * Execute a single migration file for an app
-   * Uses transaction-scoped search path to avoid affecting other queries
-   */
   private async executeAppMigration(
     app: App,
     migrationFile: { filename: string; content: string },
@@ -772,7 +709,6 @@ export class OrmService {
       const migrationFileContent = this.removeSchemaReferencesFromMigration(
         migrationFile.content,
       )
-      // Calculate checksum for migration integrity
       const checksum = this.calculateChecksum(migrationFile.content)
 
       const client: PoolClient = await this.client.connect()
@@ -780,7 +716,7 @@ export class OrmService {
       try {
         await client.query('BEGIN')
         await client.query(`SET LOCAL ROLE ${appRoleName}`)
-        // Explicitly set search_path since SET ROLE doesn't apply role defaults
+        // SET ROLE doesn't apply role default search_path, so set it explicitly.
         await client.query(
           `SET LOCAL search_path = ${schemaName}, ${EXTENSIONS_SCHEMA}`,
         )
@@ -816,23 +752,16 @@ export class OrmService {
     }
   }
 
-  /**
-   * Calculate checksum for migration content
-   */
   private calculateChecksum(content: string): string {
-    // Simple checksum implementation - in production you might want to use crypto
     let hash = 0
     for (let i = 0; i < content.length; i++) {
       const char = content.charCodeAt(i)
       hash = (hash << 5) - hash + char
-      hash = hash & hash // Convert to 32-bit integer
+      hash = hash & hash // 32-bit
     }
     return Math.abs(hash).toString(16)
   }
 
-  /**
-   * Get migration status for an app
-   */
   async getAppMigrationStatus(app: App): Promise<{
     executed: string[]
     pending: string[]
@@ -840,7 +769,6 @@ export class OrmService {
     const schemaName = this.getAppSchemaName(app)
 
     try {
-      // Get executed migrations
       const executedMigrationsResult = await this.client.query(
         `SELECT filename FROM ${schemaName}.__migrations__ ORDER BY id`,
       )
@@ -850,10 +778,10 @@ export class OrmService {
 
       return {
         executed: executedMigrations.map((m) => m.filename),
-        pending: [], // Would be populated by comparing with available migration files
+        pending: [],
       }
     } catch {
-      // If migration table doesn't exist, return empty status
+      // Missing migration table → no migrations run yet.
       return {
         executed: [],
         pending: [],
@@ -861,11 +789,7 @@ export class OrmService {
     }
   }
 
-  /**
-   * Ensure the main app's search path is set correctly
-   * This should be called after any app-specific operations to ensure
-   * subsequent main app queries work correctly
-   */
+  // Call after app-specific operations so subsequent main-app queries see the public search_path.
   async ensureMainAppSearchPath(): Promise<void> {
     await this.client.query('SET search_path TO public')
   }

--- a/packages/api/src/server/controllers/server.controller.ts
+++ b/packages/api/src/server/controllers/server.controller.ts
@@ -50,9 +50,6 @@ export class ServerController {
     private readonly serverIconService: ServerIconService,
   ) {}
 
-  /**
-   * Get the server settings object.
-   */
   @Get('/settings')
   async getServerSettings(
     @Req() req: express.Request,
@@ -67,9 +64,6 @@ export class ServerController {
     }
   }
 
-  /**
-   * Set a setting in the server settings objects.
-   */
   @Put('/settings/:settingKey')
   async setServerSetting(
     @Req() req: express.Request,
@@ -90,9 +84,6 @@ export class ServerController {
     }
   }
 
-  /**
-   * Reset a setting in the server settings objects.
-   */
   @Delete('/settings/:settingKey')
   async resetServerSetting(
     @Req() req: express.Request,
@@ -111,9 +102,6 @@ export class ServerController {
     return { settingKey, settingValue: newSettings[settingKey] as never }
   }
 
-  /**
-   * Get server metrics including user counts, folder counts, and storage statistics.
-   */
   @Get('/metrics')
   async getServerMetrics(
     @Req() req: express.Request,
@@ -125,10 +113,6 @@ export class ServerController {
     return transformServerMetricsToDTO(metrics)
   }
 
-  /**
-   * Get a unified activity time-series (events, tasks, task duration, or logs),
-   * fixed-bucketed over a rolling window and optionally partitioned by app.
-   */
   @Get('/metrics/activity')
   async getServerActivityMetrics(
     @Req() req: express.Request,
@@ -147,9 +131,6 @@ export class ServerController {
     })
   }
 
-  /**
-   * Upload (or replace) the server icon shown across the platform.
-   */
   @Post('/icon')
   @UseInterceptors(
     FileInterceptor('file', { limits: { fileSize: MAX_IMAGE_UPLOAD_BYTES } }),
@@ -177,9 +158,6 @@ export class ServerController {
     return { updatedAt: updatedAt.toISOString() }
   }
 
-  /**
-   * Remove the server icon.
-   */
   @Delete('/icon')
   @HttpCode(204)
   async deleteServerIcon(@Req() req: express.Request): Promise<void> {

--- a/packages/api/src/server/services/activity-metrics.service.ts
+++ b/packages/api/src/server/services/activity-metrics.service.ts
@@ -165,13 +165,7 @@ export function shapeSeries(
 export class ActivityMetricsService {
   constructor(private readonly ormService: OrmService) {}
 
-  /**
-   * Unified activity time-series. Counts come from the events table
-   * (`events`/`tasks`) and the log_entries table (`logs`); `task_duration` is
-   * an average derived from the tasks table because event `data` is
-   * base64-wrapped and not SQL-queryable. All metrics share the same
-   * fixed-bucket, zero-filled output shape.
-   */
+  // `task_duration` derives from the tasks table because event `data` is base64-wrapped and not SQL-queryable.
   async getActivityTimeseries({
     actor,
     metric,
@@ -222,11 +216,7 @@ export class ActivityMetricsService {
     }
   }
 
-  /**
-   * Prune synthetic task telemetry older than the retention window. Only
-   * `task_completed`/`task_failed` rows are removed — domain events are never
-   * touched. Returns the number of rows deleted.
-   */
+  // Only task_completed/task_failed rows are pruned — domain events are never touched.
   async pruneTaskTelemetry(
     olderThanDays = TASK_TELEMETRY_RETENTION_DAYS,
   ): Promise<number> {
@@ -348,12 +338,7 @@ export class ActivityMetricsService {
     wheres: (SQL | undefined)[]
   }): Promise<BucketRow[]> {
     const bucket = bucketExpr(timeColumn, granularity)
-    // Group/order by ordinal position (1 = bucket, 2 = dim). Re-rendering the
-    // same parameterized `sql` object in GROUP BY renumbers its bind params, so
-    // Postgres wouldn't match it to the SELECT expression ("created_at must
-    // appear in the GROUP BY clause"); and Drizzle doesn't emit SQL aliases for
-    // raw `sql` select columns, so grouping by name fails too. Ordinals avoid
-    // both.
+    // Group/order by ordinal (1=bucket, 2=dim): re-rendering the `sql` object renumbers its bind params, and Drizzle emits no aliases for raw `sql` columns.
     return this.ormService.db
       .select({ bucket, dim: dimExpr, value: valueExpr })
       .from(table)

--- a/packages/api/src/task/services/task.service.ts
+++ b/packages/api/src/task/services/task.service.ts
@@ -354,18 +354,7 @@ export class TaskService {
     }
   }
 
-  /**
-   * Used to trigger a platform task on request from a user.
-   *
-   * @param userId - The user ID triggering the task.
-   * @param taskIdentifier - The identifier of the core task to trigger.
-   * @param taskData - The data to pass to the task (must be serializable).
-   * @param targetUserId - The user ID to relate the task to.
-   * @param targetLocation - The folderId and possibly objectKey to relate the task to.
-   * @param storageAccessPolicy - The policy regarding governing the storage locations accessible to the task.
-   *
-   ** @returns The created task record.
-   */
+  // Trigger a platform (core) task on request from a user.
   async triggerCoreUserActionTask({
     userId,
     taskIdentifier,
@@ -412,19 +401,7 @@ export class TaskService {
     return task
   }
 
-  /**
-   * Used to trigger an app's task on request from a user.
-   *
-   * @param userId - The user ID triggering the task.
-   * @param appIdentifier - The identifier of the app that owns the task.
-   * @param taskIdentifier - The identifier of the task to trigger (must be defined in the app's config).
-   * @param taskData - The data to pass to the task (must be serializable).
-   * @param targetUserId - The user ID to relate the task to.
-   * @param targetLocation - The folderId and possibly objectKey to relate the task to.
-   * @param storageAccessPolicy - The policy regarding governing the storage locations accessible to the task.
-   *
-   ** @returns The created task record.
-   */
+  // Trigger an app's task on request from a user.
   async triggerAppUserActionTask({
     userId,
     appIdentifier,
@@ -488,19 +465,7 @@ export class TaskService {
     })
   }
 
-  /**
-   * Used to trigger an app's own tasks.
-   *
-   * @param appIdentifier - The identifier of the app triggering the task.
-   * @param taskIdentifier - The identifier of the task to trigger (must be defined in the app's config).
-   * @param taskData - The data to pass to the task (must be serializable).
-   * @param dontStartBefore - The time before which the task should not start.
-   * @param targetUserId - The user ID to relate the task to.
-   * @param targetLocation - The folderId and possibly objectKey to relate the task to.
-   * @param storageAccessPolicy - The storage access policy to use for the task.
-   * @param onComplete - Optional onComplete handler(s) to trigger when this task completes.
-   * @returns The created task record.
-   */
+  // Trigger an app's own task.
   async triggerAppActionTask({
     appIdentifier,
     taskIdentifier,
@@ -537,7 +502,6 @@ export class TaskService {
       )
     }
 
-    // validate user and folder access if task is scoped as such
     if (targetUserId) {
       await this.appService.validateAppUserAccess({
         appIdentifier,
@@ -552,7 +516,6 @@ export class TaskService {
       })
     }
 
-    // validate the entire storage access policy if one is provided
     if (storageAccessPolicy) {
       await this.appService.validateAppStorageAccessPolicy({
         appIdentifier,
@@ -600,18 +563,7 @@ export class TaskService {
     })
   }
 
-  /**
-   * Used to trigger an task as a completion handler for another task.
-   *
-   * @param appIdentifier - The identifier of the app triggering the task.
-   * @param taskIdentifier - The identifier of the task to trigger (must be defined in the app's config).
-   * @param taskData - The data to pass to the task (must be serializable).
-   * @param dontStartBefore - The time before which the task should not start.
-   * @param targetUserId - The user ID to relate the task to.
-   * @param targetLocation - The folderId and possibly objectKey to relate the task to.
-   * @param storageAccessPolicy - The storage access policy to use for the task.
-   * @returns The created task record.
-   */
+  // Trigger a task as a completion handler for another task.
   async executeOnCompleteHandler({
     parentTask,
     parentTaskSuccess,
@@ -631,7 +583,7 @@ export class TaskService {
     parentTask: Task
     correlationKey?: string
     taskIdentifier: string
-    taskDataTemplate?: JsonSerializableObject // parse this to interpolate variables, e.g. {{task.result.someKey}} or {{task.error.someKey}}
+    taskDataTemplate?: JsonSerializableObject // interpolated, e.g. {{task.result.someKey}}
     dontStartBefore?: { timestamp: Date } | { delayMs: number }
     targetUserId?: string
     targetLocation?: { folderId: string; objectKey?: string }
@@ -773,19 +725,7 @@ export class TaskService {
     }
   }
 
-  /**
-   * Used to trigger a task as an onProgress handler for another task.
-   *
-   * @param parentTask - The parent task that experienced the progress report.
-   * @param parentProgressReport - The worker-originated progress report.
-   * @param taskIdentifier - The identifier of the task to trigger (must be defined in the app's config).
-   * @param taskData - The data to pass to the task (must be serializable).
-   * @param dontStartBefore - The time before which the task should not start.
-   * @param targetUserId - The user ID to relate the task to.
-   * @param targetLocation - The folderId and possibly objectKey to relate the task to.
-   * @param storageAccessPolicy - The storage access policy to use for the task.
-   * @returns The created task record.
-   */
+  // Trigger a task as an onProgress handler for another task.
   async executeOnProgressHandler({
     parentTask,
     parentProgressReport,
@@ -803,7 +743,7 @@ export class TaskService {
     parentProgressReport: TaskProgressReport
     correlationKey?: string
     taskIdentifier: string
-    taskDataTemplate?: JsonSerializableObject // parse this to interpolate variables, e.g. {{task.result.someKey}} or {{task.error.someKey}}
+    taskDataTemplate?: JsonSerializableObject // interpolated, e.g. {{task.result.someKey}}
     dontStartBefore?: { timestamp: Date } | { delayMs: number }
     targetUserId?: string
     targetLocation?: { folderId: string; objectKey?: string }
@@ -1003,13 +943,7 @@ export class TaskService {
       message: string
       payload?: JsonSerializableObject
     }
-    /**
-     * Full executor metadata observed at runtime (e.g. docker containerId
-     * and hostId once the container has started). When provided on the
-     * first heartbeat, the `started` system log entry is upgraded so its
-     * payload carries the full ExecutorMetadata instead of the
-     * ExecutorStartMetadata written at task start.
-     */
+    // Runtime-observed metadata (e.g. containerId, hostId); on the first heartbeat it upgrades the `started` log's ExecutorStartMetadata to full ExecutorMetadata.
     executorMetadata?: ExecutorMetadata
     options?: { tx?: OrmService['db'] }
   }) {
@@ -1057,11 +991,7 @@ export class TaskService {
         }
       : undefined
 
-    // On the first heartbeat with full executor metadata, upgrade the
-    // `started` system log entry in place so the payload reflects the
-    // runtime-observed fields (containerId, hostId, …). We rebuild the
-    // whole systemLog array — heartbeats are serialized per task and
-    // this column is otherwise append-only while the task is running.
+    // First heartbeat with full metadata upgrades the `started` log in place; safe to rebuild the array since heartbeats are serialized per task.
     const shouldUpgradeStartLog =
       executorMetadata !== undefined && task.latestHeartbeatAt === null
     const upgradedSystemLog = shouldUpgradeStartLog
@@ -1130,20 +1060,12 @@ export class TaskService {
       : await this.ormService.db.transaction(async (tx) => {
           return this._registerTaskCompletedInTx(args, tx)
         })
-    // Activity telemetry — fire-and-forget so a failure here can never break
-    // task completion. Emitted after the completion write (outside the inner
-    // tx) for the same reason.
+    // Fire-and-forget, outside the tx, so telemetry failure can't break task completion.
     void this.emitTaskCompletionTelemetry(updatedTask)
     return updatedTask
   }
 
-  /**
-   * Emits a synthetic `task_completed`/`task_failed` event for activity charts.
-   * Only terminal outcomes are counted — requeues (`success === null`) are
-   * skipped so a retried task isn't recorded as failed. Duration lives in
-   * `data` for drill-down only; the duration metric reads it from the tasks
-   * table since event `data` is base64-wrapped and not SQL-queryable.
-   */
+  // Synthetic task_completed/task_failed event for activity charts; requeues (success === null) are skipped so retries aren't recorded as failures.
   private async emitTaskCompletionTelemetry(task: Task) {
     if (task.success === null) {
       return
@@ -1198,8 +1120,6 @@ export class TaskService {
       throw new Error(`Task "${taskId}"  has already been completed.`)
     }
 
-    // build the task system log — typed payload keeps the shape
-    // consumable by onComplete handlers without runtime casts.
     const completionPayload:
       | TaskSuccessSystemLogPayload
       | TaskErrorSystemLogPayload = completion.success
@@ -1304,10 +1224,7 @@ export class TaskService {
       throw new ConflictException('Failed to register task completion task.')
     }
 
-    // Enqueue the completion handler task if one was configured for this task.
-    // `onComplete` is present on every invocation kind via the base trigger
-    // shape, but the discriminated union means we need the `in` check to
-    // narrow away `task_update_child` (which has no onComplete slot).
+    // `in` check narrows away invocation kinds (task_update_child) that have no onComplete slot.
     if ('onComplete' in task.invocation && task.invocation.onComplete?.length) {
       for (let i = 0; i < task.invocation.onComplete.length; i++) {
         // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
@@ -1361,7 +1278,6 @@ export class TaskService {
       }
     }
 
-    // Broadcast success/failure update
     this.asyncTaskUpdateBroadcasterService.handleTaskUpdate(
       updatedTask,
       completion.success
@@ -1371,7 +1287,6 @@ export class TaskService {
     )
 
     if (shouldRequeue) {
-      // Broadcast requeue update
       this.asyncTaskUpdateBroadcasterService.handleTaskUpdate(
         updatedTask,
         TaskUpdateType.task_requeued,
@@ -1419,8 +1334,8 @@ export class TaskService {
     )[0]
 
     if (!updatedTask) {
-      return null
-    } // task not in running state
+      return null // task not in running state
+    }
 
     this.asyncTaskUpdateBroadcasterService.handleTaskUpdate(
       updatedTask,
@@ -1429,7 +1344,6 @@ export class TaskService {
       storedProgressReport,
     )
 
-    // Evaluate and dispatch onProgress handlers
     const onProgressHandlers =
       'onProgress' in updatedTask.invocation
         ? (updatedTask.invocation.onProgress ?? [])

--- a/packages/types/src/docker.types.ts
+++ b/packages/types/src/docker.types.ts
@@ -3,32 +3,15 @@ import { z } from 'zod'
 import type { JsonSerializableObject } from './json.types'
 import type { StorageAccessPolicy } from './task.types'
 
-// ─── Mount schema
-//
-// Docker's Mount API declares every field on VolumeOptions, BindOptions,
-// and TmpfsOptions as optional (each has a runtime default), which means
-// `{}` is accepted by the API but does nothing. To keep our schema
-// accurate to *effective* surface area (configs that actually change
-// behaviour), each options object is modelled as a oneOf: at least one
-// field must be present, so the empty-object shape is unrepresentable
-// at both the type and runtime-validation layers.
+// Mount schema: each options object requires at least one field so the
+// no-op empty-object shape is unrepresentable in both types and validation.
 
 const driverConfigSchema = z.object({
-  // Name identifies the driver — a DriverConfig without it is meaningless,
-  // so this is the one genuinely required field inside the options tree.
   name: z.string().nonempty(),
   options: z.record(z.string(), z.string()).optional(),
-  // Lombok-managed: a path segment that must be created under the volume's
-  // root before the real container starts, then appended to the driver's
-  // `device` path. Not forwarded to Docker — the mount helper strips it
-  // and rewrites `device` to `device + "/" + createSubpath`.
+  // Lombok-managed: subpath created under the volume root pre-start, then appended to the driver's `device`; stripped before forwarding to Docker.
   createSubpath: z.string().nonempty().optional(),
 })
-
-// Each options object is a union of partial shapes, one per field, with
-// that field promoted to required. Zod's `.required({ key: true })`
-// preserves field-level types in the inferred output, so `z.infer`
-// produces a properly-narrowed TS union where `{}` is unrepresentable.
 
 const volumeOptionsSchema = z.object({
   noCopy: z.boolean().optional(),
@@ -58,11 +41,7 @@ const tmpfsOptionsSchema = z.object({
   options: z.array(z.array(z.string())).nonempty().optional(),
 })
 
-// Fields common to every mount type. `source` lives on each variant
-// because its nullability is type-dependent:
-//   • volume — optional (omitted = anonymous volume, the NFS use case)
-//   • bind   — required (must name a host path)
-//   • tmpfs  — forbidden (no backing path; in-memory filesystem)
+// Common mount fields; `source` lives per-variant since its nullability is type-dependent (volume: optional, bind: required, tmpfs: forbidden).
 const mountBase = {
   target: z.string().nonempty(),
   readOnly: z.boolean().optional(),
@@ -82,8 +61,7 @@ export const mountSchema = z
       source: z.string().nonempty(),
       bindOptions: bindOptionsSchema.optional(),
     }),
-    // `z.never().optional()` → field must be undefined/absent; any value is
-    // a parse error and the inferred type is `source?: undefined`.
+    // tmpfs: `source` must be absent (any value is a parse error).
     z.object({
       ...mountBase,
       type: z.literal('tmpfs'),

--- a/packages/ui-toolkit/components/badge/badge.util.ts
+++ b/packages/ui-toolkit/components/badge/badge.util.ts
@@ -1,7 +1,4 @@
-/*
- * Badge — same additive color model as Button (UI_TOOLKIT_ALIGNMENT.md §4.6).
- * `variant` (solid|soft|outline) × `tone`/`color` × `size`. Derives from `--badge-color`.
- */
+// Same additive color model as Button; every state derives from --badge-color (UI_TOOLKIT_ALIGNMENT.md §4.6).
 
 import { cva } from 'class-variance-authority'
 
@@ -36,8 +33,7 @@ export const badgeVariants = cva(
       },
     },
     compoundVariants: [
-      // Neutral outline border = foreground at low opacity (adapts to light/dark; % is the
-      // visibility knob, unlike opacity of the near-white --border token).
+      // Neutral outline border = foreground at low opacity; % is the visibility knob (adapts to light/dark).
       {
         variant: 'outline',
         tone: 'neutral',

--- a/packages/ui-toolkit/components/button-group/button-group.tsx
+++ b/packages/ui-toolkit/components/button-group/button-group.tsx
@@ -2,12 +2,7 @@ import * as React from 'react'
 
 import { cn } from '../../utils'
 
-/*
- * ButtonGroup — joins adjacent controls into one unit. Pure container: it squares the
- * inner corners and overlaps shared borders via child selectors, so it works with any
- * children (Buttons, dividers, etc.) without mutating their props. Children keep their
- * own rounding on the outer edges.
- */
+// Joins adjacent controls: squares inner corners and overlaps shared borders via child selectors, without mutating child props.
 interface ButtonGroupProps extends React.HTMLAttributes<HTMLDivElement> {
   orientation?: 'horizontal' | 'vertical'
 }

--- a/packages/ui-toolkit/components/button/button.stories.tsx
+++ b/packages/ui-toolkit/components/button/button.stories.tsx
@@ -153,10 +153,7 @@ export const Dim: Story = {
   ),
 }
 
-/**
- * Single-base override: pass any CSS `color` and every state (hover/active/border/
- * soft/ghost) is derived from it — no token needed.
- */
+/** Single-base override: any CSS `color` derives every state, no token needed. */
 export const SingleBaseColor: Story = {
   render: () => {
     const colors = ['#7c3aed', '#0ea5e9', '#e11d48', '#16a34a', '#f59e0b']

--- a/packages/ui-toolkit/components/button/button.util.ts
+++ b/packages/ui-toolkit/components/button/button.util.ts
@@ -1,13 +1,4 @@
-/*
- * Button — additive color model (UI_TOOLKIT_ALIGNMENT.md §4.6). Two orthogonal axes:
- *   • color : `tone` (named token) or `color` (one-shot base; derives every state)
- *   • style : `variant` (solid|soft|outline|ghost|link) + feature flag `gradient`
- *
- * Every state derives from `--button-color` via color-mix. Solid foreground uses
- * `contrast-color()` (auto black/white) with the `fg` prop / `--button-fg` as override.
- * Tone is a cva variant (static `[--button-color:…]` classes) so it also works through the
- * `buttonVariants()` helper. Literal class strings — Tailwind only emits what it can see.
- */
+// Additive color model: every state derives from --button-color via color-mix; tone is a static cva variant so it works through buttonVariants() (UI_TOOLKIT_ALIGNMENT.md §4.6).
 
 import { cva } from 'class-variance-authority'
 
@@ -26,8 +17,7 @@ export const buttonVariants = cva(
           'bg-[color-mix(in_srgb,var(--button-color)_14%,transparent)] text-[var(--button-color)] ' +
           'not-disabled:hover:bg-[color-mix(in_srgb,var(--button-color)_22%,transparent)]',
         outline:
-          // Colored tones tint the border toward the --border token; the neutral tone uses
-          // --border directly (compound below) since its base is the near-white/black --primary.
+          // Colored tones tint the border toward --border; neutral uses --border directly (compound below).
           'border border-[color-mix(in_srgb,var(--button-color)_25%,var(--border))] text-[var(--button-color)] ' +
           'not-disabled:hover:bg-[color-mix(in_srgb,var(--button-color)_5%,transparent)]',
         ghost:
@@ -35,9 +25,7 @@ export const buttonVariants = cva(
         link: 'text-[var(--button-color)] underline-offset-4 not-disabled:hover:underline',
       },
       tone: {
-        // Each tone sets its solid foreground (--button-fg) explicitly so solids don't depend
-        // on contrast-color() support. neutral omits it → falls back to contrast-color (its
-        // base is --primary, which flips light/dark). soft/outline/ghost ignore --button-fg.
+        // Each tone sets --button-fg explicitly so solids don't depend on contrast-color(); neutral omits it (base --primary flips light/dark).
         neutral: '[--button-color:var(--primary)]',
         blue: '[--button-color:var(--color-tone-blue)] [--button-fg:#fff]',
         green: '[--button-color:var(--color-tone-green)] [--button-fg:#fff]',
@@ -60,16 +48,14 @@ export const buttonVariants = cva(
         icon: 'size-10',
       },
       gradient: { true: '', false: '' },
-      // Dimmed at rest, brightens to full on hover — for low-emphasis affordances (e.g. icon links).
-      // `transition` (over the base `transition-colors`) so the brightness filter animates too.
+      // Dimmed at rest, brightens on hover; `transition` (over base transition-colors) so brightness animates too.
       dim: {
         true: 'transition not-disabled:brightness-70 not-disabled:hover:brightness-100',
         false: '',
       },
     },
     compoundVariants: [
-      // Neutral outline border = foreground at low opacity — adapts to light/dark and the
-      // % is a meaningful visibility knob (unlike opacity of the near-white --border token).
+      // Neutral outline border = foreground at low opacity; % is the visibility knob (adapts to light/dark).
       {
         variant: 'outline',
         tone: 'neutral',

--- a/packages/ui-toolkit/components/dropdown-menu/dropdown-menu.tsx
+++ b/packages/ui-toolkit/components/dropdown-menu/dropdown-menu.tsx
@@ -85,7 +85,7 @@ const DropdownMenuItem = React.forwardRef<
     description?: React.ReactNode
   }
 >(({ className, inset, icon, title, description, children, ...props }, ref) => {
-  // Rich layout: icon + title + description, ported from the codicle launch menu.
+  // Rich layout: icon + title + description.
   if (title !== undefined) {
     return (
       <DropdownMenuPrimitive.Item

--- a/packages/ui-toolkit/components/spinner/spinner.tsx
+++ b/packages/ui-toolkit/components/spinner/spinner.tsx
@@ -3,10 +3,7 @@ import * as React from 'react'
 
 import { cn } from '../../utils'
 
-/**
- * Spinner — the design-system loading indicator (same glyph as Button's `loading`).
- * Inherits `currentColor`; set color/size via `className` or the `size` prop.
- */
+// Loading indicator (same glyph as Button's `loading`); inherits currentColor.
 const Spinner = React.forwardRef<SVGSVGElement, LucideProps>(
   ({ className, size = 16, ...props }, ref) => (
     <Loader2

--- a/packages/ui-toolkit/components/split-button/split-button.tsx
+++ b/packages/ui-toolkit/components/split-button/split-button.tsx
@@ -24,10 +24,7 @@ export interface SplitButtonProps {
   fg?: string
   /** Apply the solid gradient treatment. */
   gradient?: boolean
-  /**
-   * Primary action. When `null`, the primary button opens the menu instead of
-   * running an action (e.g. nothing sensible to launch by default).
-   */
+  /** Primary action; `null` makes the primary button open the menu instead. */
   onPrimaryAction?: (() => void) | null
   /** Disables the whole control. */
   disabled?: boolean
@@ -41,11 +38,7 @@ export interface SplitButtonProps {
   contentClassName?: string
 }
 
-/**
- * A split button: a primary action joined to a chevron that opens a dropdown
- * menu of alternative actions. Built on the Radix `DropdownMenu` (keyboard nav,
- * focus management, portal/collision) and the toolkit `Button` color system.
- */
+// Primary action joined to a chevron that opens a dropdown of alternatives; built on Radix DropdownMenu + toolkit Button.
 export function SplitButton({
   label,
   icon,

--- a/packages/ui-toolkit/components/tooltip/tooltip.tsx
+++ b/packages/ui-toolkit/components/tooltip/tooltip.tsx
@@ -9,10 +9,7 @@ const Tooltip = TooltipPrimitive.Root
 
 const TooltipTrigger = TooltipPrimitive.Trigger
 
-// Portal the content so its position:fixed popper wrapper escapes any
-// transformed/overflow ancestor (e.g. the collapsible sidebar's translate-x
-// aside + overflow-y-auto), which otherwise traps it in the scroll subtree
-// and nudges the container's scroll height on open.
+// Portal the content so its fixed popper escapes transformed/overflow ancestors that would otherwise trap it in their scroll subtree.
 const TooltipContent = React.forwardRef<
   React.ElementRef<typeof TooltipPrimitive.Content>,
   React.ComponentPropsWithoutRef<typeof TooltipPrimitive.Content>

--- a/packages/ui-toolkit/utils/tone.ts
+++ b/packages/ui-toolkit/utils/tone.ts
@@ -1,12 +1,6 @@
 import type { CSSProperties } from 'react'
 
-/**
- * Named additive tones — seed colors mapped to `--color-tone-*` tokens (theme.css).
- * Applied as a cva `tone` variant on Button/Badge (static `[--*-color:…]` classes), so
- * tone works through both the component and the `*Variants()` className helpers.
- * The `color` prop is the one-shot escape hatch (inline style). See §4.6 of
- * packages/demo-apps/coder/UI_TOOLKIT_ALIGNMENT.md.
- */
+// Named additive tones mapped to `--color-tone-*` tokens; `color` prop is the one-shot escape hatch (UI_TOOLKIT_ALIGNMENT.md §4.6).
 export type Tone =
   | 'neutral'
   | 'blue'
@@ -51,11 +45,7 @@ function parseRgb(color: string): [number, number, number] | null {
   return null
 }
 
-/**
- * A readable (black/white) foreground for a solid swatch of `color`, via YIQ brightness.
- * Returns undefined for colors we can't parse (named, var(), oklch, …) — callers then let
- * CSS `contrast-color()` handle it.
- */
+// Readable black/white foreground for a solid `color` via YIQ; undefined for unparseable colors (caller falls back to CSS contrast-color()).
 export function readableForeground(color: string): string | undefined {
   const rgb = parseRgb(color)
   if (!rgb) {
@@ -66,13 +56,7 @@ export function readableForeground(color: string): string | undefined {
   return yiq >= 140 ? '#1c1917' : '#fff'
 }
 
-/**
- * Inline style for the one-shot `color`/`fg` overrides on a toned component.
- * `scope` is the component prefix, e.g. `'button'` → sets `--button-color` / `--button-fg`.
- * When `color` is set without an explicit `fg`, a readable fg is computed for hex/rgb colors
- * (so solid text doesn't depend on `contrast-color()` support); unparseable colors fall
- * through to the CSS `contrast-color()` default. Merges any caller `style` last.
- */
+// Inline style for one-shot `color`/`fg` overrides; `scope` is the var prefix (e.g. 'button' → --button-color). Computes a readable fg for hex/rgb when none given.
 export function toneStyle(
   scope: string,
   color?: string,

--- a/packages/ui/src/components/app-icon/app-icon.util.ts
+++ b/packages/ui/src/components/app-icon/app-icon.util.ts
@@ -1,9 +1,6 @@
 import type { Icon } from '@lombokapp/types'
 
-// True when the icon is a monochromatic glyph (built-in lucide icon or a
-// tinted SVG) — those look best on a neutral tile background. PNGs and
-// `rendering: "original"` SVGs supply their own treatment and should render
-// raw without a wrapping border.
+// True for monochromatic glyphs (builtin or tinted SVG) that want a neutral tile; PNGs and original-rendering SVGs render raw.
 export function iconRendersAsGlyph(icon: Icon | undefined): boolean {
   if (!icon) {
     return true

--- a/packages/ui/src/components/app-storage-panel/app-storage-panel.tsx
+++ b/packages/ui/src/components/app-storage-panel/app-storage-panel.tsx
@@ -74,8 +74,7 @@ export function AppStoragePanel({ appIdentifier }: { appIdentifier: string }) {
     },
   )
 
-  // Append each fetched page; a page with no token is the first/only one.
-  // Dedupe by key so a background refetch of the current page can't duplicate rows.
+  // Append each page, deduping by key so a background refetch can't duplicate rows.
   const pageData = listQuery.data
   React.useEffect(() => {
     if (!pageData) {

--- a/packages/ui/src/components/custom-settings-form/custom-settings-form.tsx
+++ b/packages/ui/src/components/custom-settings-form/custom-settings-form.tsx
@@ -149,9 +149,7 @@ function ArrayFieldInput({
     </div>
   )
 }
-// `type` can now be either the canonical literal (`"string"`) or the JSON
-// Schema tuple form (`["string", "null"]`) — collapse to the base literal
-// for switch-narrowing.
+// Collapse the JSON Schema tuple form (`["string","null"]`) to its base literal for switch-narrowing.
 function primitiveBase(
   t: JsonSchema07PrimitiveProperty['type'],
 ): 'string' | 'number' | 'integer' | 'boolean' {
@@ -206,13 +204,7 @@ function PrimitiveFieldInput({
   property: JsonSchema07PrimitiveProperty
   value: unknown
   isSecret: boolean
-  /**
-   * Whether the user has edited this secret in the current session. Stored
-   * secrets are never echoed by the server, so until it's edited we render an
-   * empty input with a hint instead of binding the (masked) value. Undefined
-   * in contexts without edit tracking (nested object fields) — there we bind
-   * the value directly.
-   */
+  // Stored secrets are never echoed; until edited we show an empty hinted input. Undefined (nested fields) binds the value directly.
   isSecretModified?: boolean
   onChange: (value: unknown) => void
 }) {
@@ -348,8 +340,7 @@ function ObjectItemPropertyInput({
     )
   }
   if (property.type === 'object') {
-    // Nested object settings are not yet supported in the UI
-    return null
+    return null // nested object settings not yet supported in the UI
   }
   return (
     <PrimitiveFieldInput
@@ -428,7 +419,7 @@ function ObjectItemCard({
       </div>
       <div className="space-y-2">
         {propertyEntries.map(([propKey, propDef]) => {
-          // Hide the discriminator field — it's shown in the card header
+          // Discriminator is shown in the card header instead.
           if (propKey === discriminatorKey) {
             return null
           }
@@ -547,7 +538,6 @@ function DiscriminatedObjectArrayFieldInput({
     : []
   const { discriminator, oneOf } = itemSchema
 
-  // Build a map from discriminator value to its variant schema
   const variantMap = React.useMemo(() => {
     const map = new Map<string, JsonSchema07ObjectItem>()
     for (const variant of oneOf) {
@@ -656,7 +646,6 @@ function DiscriminatedObjectArrayFieldInput({
             variant="outline"
             size="sm"
             onClick={() => {
-              // If only one variant, add it directly
               if (variantKeys.length === 1) {
                 handleAdd(variantKeys[0] ?? '')
               } else {
@@ -674,12 +663,7 @@ function DiscriminatedObjectArrayFieldInput({
   )
 }
 
-/**
- * When a whole key is secret but its schema wraps the value in a single-string
- * object (e.g. `{ value: string }`), return that field name so a secret can be
- * edited as one opaque value and saved back in the expected shape. Otherwise
- * null — the value is treated as a plain string secret.
- */
+// For a secret key whose schema wraps the value in a single-string object, returns that field name; else null (plain string secret).
 function singleSecretObjectField(
   property: CustomSettingsSchemaProperty,
 ): string | null {
@@ -769,9 +753,7 @@ function FieldInput({
   onChange: (value: unknown) => void
 }) {
   if (isSecret) {
-    // The whole value is masked opaque by the server, so edit it as a single
-    // secret. If the schema wraps it in a single-string object, marshal to and
-    // from that field; otherwise treat the value as a plain string.
+    // Value is server-masked: edit as one secret, marshalling through the wrapped field when the schema wraps it.
     const wrapField = singleSecretObjectField(property)
     const objValue =
       value != null && typeof value === 'object' && !Array.isArray(value)
@@ -936,12 +918,7 @@ function FieldRenderer({
   )
 }
 
-/**
- * Add-control for a `patternProperties` entry. The pattern is a literal
- * lowercase prefix regex (e.g. `^provider_`), so we surface the prefix as a
- * fixed adornment and let the user type the remaining suffix. The assembled
- * key is validated against both the platform key format and the pattern.
- */
+// Add-control for a `patternProperties` entry: prefix (e.g. `^provider_`) is a fixed adornment, user types the suffix; the assembled key is validated against the key format and the pattern.
 function AddPatternKeyRow({
   pattern,
   existingKeys,
@@ -1057,10 +1034,7 @@ function AddPatternKeyRow({
   )
 }
 
-/**
- * Renders one `patternProperties` entry: every stored key matching the pattern
- * as an editable, removable field, plus a control to add new matching keys.
- */
+// Renders one `patternProperties` entry: each matching key as an editable/removable field, plus an add control.
 function PatternPropertyGroup({
   pattern,
   property,
@@ -1129,19 +1103,15 @@ export function CustomSettingsForm({
   onReset,
   onResetField,
 }: CustomSettingsFormProps) {
-  // Track local edits — start from the server values
   const [localValues, setLocalValues] = React.useState<Record<string, unknown>>(
     () => ({ ...values }),
   )
-  // Track which secret fields the user touched. Secrets arrive from the
-  // server as masked placeholders; only keys the user actually edited should
-  // be included in the PATCH body. Untouched secrets are omitted and remain
-  // as stored.
+  // Only touched secrets go in the PATCH body; untouched (masked) ones are omitted and stay as stored.
   const [modifiedSecrets, setModifiedSecrets] = React.useState<Set<string>>(
     () => new Set(),
   )
 
-  // Re-sync local state when server values change (after save/reset)
+  // Re-sync local state when server values change (after save/reset).
   const prevValuesRef = React.useRef(values)
   React.useEffect(() => {
     if (prevValuesRef.current !== values) {
@@ -1158,8 +1128,7 @@ export function CustomSettingsForm({
     [schema.properties],
   )
 
-  // Compile each patternProperties entry once. Keys are assigned to the first
-  // matching pattern so a key is never rendered twice.
+  // Each key is assigned to the first matching pattern so it's never rendered twice.
   const compiledPatterns = React.useMemo(
     () =>
       Object.entries(schema.patternProperties ?? {}).map(
@@ -1181,7 +1150,6 @@ export function CustomSettingsForm({
   const matchesAnyPattern = (key: string) =>
     compiledPatterns.some(({ regex }) => regex?.test(key))
 
-  // Group the dynamic (pattern-matched) keys currently held in local state.
   const assigned = new Set<string>()
   const patternGroups = compiledPatterns.map(({ pattern, property, regex }) => {
     const keys = regex
@@ -1196,8 +1164,7 @@ export function CustomSettingsForm({
   })
   const patternKeys = [...assigned]
 
-  // Pattern keys that existed on the server but were removed locally — these
-  // must be sent as `null` to delete them.
+  // Server keys removed locally must be sent as `null` to delete them.
   const removedPatternKeys = Object.keys(values).filter(
     (key) =>
       !propertyKeySet.has(key) &&
@@ -1249,8 +1216,7 @@ export function CustomSettingsForm({
   }
 
   const handleSave = () => {
-    // PATCH semantics: only send keys the user actually changed. Untouched
-    // keys (including untouched secrets) are preserved server-side.
+    // PATCH: only send changed keys; untouched ones are preserved server-side.
     const submitValues: Record<string, unknown> = {}
     for (const [key] of propertyEntries) {
       if (isDirty(key)) {

--- a/packages/ui/src/views/server/analytics/activity-chart.tsx
+++ b/packages/ui/src/views/server/analytics/activity-chart.tsx
@@ -114,8 +114,7 @@ export function ActivityChart({
   }
   const formatTick = (value: string) =>
     safeFormat(value, granularity === 'hour' ? 'HH:mm' : 'MMM d')
-  // This fork's ChartTooltipContent only forwards the x-value to labelFormatter
-  // when it's a config key, so resolve the bucket from the hovered row instead.
+  // ChartTooltipContent only forwards the x-value when it's a config key, so resolve the bucket from the hovered row.
   const formatLabel = (
     items: { payload?: { bucket?: string } }[] | undefined,
   ) =>

--- a/packages/ui/src/views/server/docker/container-config-form/container-config.util.ts
+++ b/packages/ui/src/views/server/docker/container-config-form/container-config.util.ts
@@ -48,11 +48,7 @@ function mountsToJson(val: ConfigMount[] | undefined): string {
 
 type ConfigMount = NonNullable<DockerContainerResourceConfig['mounts']>[number]
 
-// Parse the textarea contents. Returns undefined for empty/whitespace
-// (meaning "no mounts configured"). Returns the parsed array for well-
-// formed JSON. Returns the error string itself so the caller can preserve
-// the user's in-progress input on the server round-trip — the server will
-// still reject it via Zod validation, which is the source of truth.
+// Parse the mounts textarea; on invalid JSON returns the error so the caller can preserve in-progress input (the server's Zod validation is the source of truth).
 export function mountsFromJson(
   s: string,
 ):
@@ -79,9 +75,7 @@ export function mountsFromJson(
 
 // ─── Public API ───────────────────────────────────────────────────────────
 
-/**
- * Load a config object into the form-friendly state shape used by useContainerConfigForm.
- */
+/** Load a config object into the form-friendly state shape used by useContainerConfigForm. */
 export function loadConfigState(
   cfg: DockerContainerResourceConfig,
 ): ContainerConfigState {
@@ -149,16 +143,13 @@ export function loadConfigState(
   }
 }
 
-/**
- * Serialize form state back to a config object for the API.
- */
+/** Serialize form state back to a config object for the API. */
 export function buildConfigFromState(
   s: ContainerConfigState,
 ): DockerContainerResourceConfig {
   const config: DockerContainerResourceConfig = {}
 
-  // Mounts is a JSON textarea. Well-formed JSON wins; invalid / in-progress
-  // input drops the field (server would reject it anyway). Empty = omit.
+  // Invalid/in-progress mounts JSON drops the field (server would reject it anyway).
   const parsedMounts = mountsFromJson(s.mounts)
   if (parsedMounts.kind === 'valid') {
     config.mounts = parsedMounts.value

--- a/packages/utils/src/object-id.util.ts
+++ b/packages/utils/src/object-id.util.ts
@@ -1,8 +1,6 @@
 import { z } from 'zod'
 
-// A folder object can be addressed by its content or by one of its metadata
-// variants. This is a discriminated union, validated at the API boundary —
-// there is no string encoding to parse.
+// A folder object is addressed by content or by a metadata variant; validated at the API boundary, not string-encoded.
 export const objectIdentifierSchema = z.discriminatedUnion('kind', [
   z.object({ kind: z.literal('content'), objectKey: z.string().min(1) }),
   z.object({
@@ -24,14 +22,12 @@ export const metadataIdentifier = (
   metadataHash: string,
 ): ObjectIdentifier => ({ kind: 'metadata', objectKey, metadataHash })
 
-// Stable string key for an identifier, for use as a cache/map key. Not a wire
-// format — the wire payload is the ObjectIdentifier object itself.
+// Stable cache/map key, not a wire format (the wire payload is the ObjectIdentifier object).
 export const objectIdentifierKey = (id: ObjectIdentifier): string =>
   id.kind === 'metadata'
     ? `metadata:${id.objectKey}:${id.metadataHash}`
     : `content:${id.objectKey}`
 
-// Joins a storage-location prefix with a relative key, normalising the slash.
 export const joinStoragePrefix = (prefix: string, key: string): string =>
   prefix.length === 0 || prefix.endsWith('/')
     ? `${prefix}${key}`


### PR DESCRIPTION
## Summary

Comment-only cleanup across the recently-landed platform work. Condense verbose comments — multi-line essays, step-by-step narration, and restatements of the obvious — to terse one-liners that state only the non-obvious why. Also genericized a few stray demo-app names left in comments/examples.

**No code, logic, types, or behaviour changes** — comments only.

## Scope

37 files across `ui-toolkit`, `api`, `types`, `ui`, `docker-bridge`, and dev tooling. Net ~−590 lines of comment verbosity.

## Test plan

- `./dx check all` — all checks pass.
- `./dx e2e api` — **603 pass, 0 fail** (run locally).
- `docker-bridge` typecheck + prettier clean on edited files.

Linear: [LOM-370](https://linear.app/lombokapp/issue/LOM-370/tighten-code-comments-across-recent-platform-changes)