### PR TITLE
fix(LOM-371): relay forward navigation to app iframe after back

### DIFF
--- a/packages/ui/src/views/app-ui/app-ui.view.tsx
+++ b/packages/ui/src/views/app-ui/app-ui.view.tsx
@@ -34,17 +34,21 @@ export function AppUI({
   React.useEffect(() => {
     const latestParentPathAndQuery = `${window.location.pathname.slice(`/apps/${appIdentifier}`.length)}${window.location.search}`
     if (latestParentPathAndQuery !== paths.child) {
+      const willRelay = Boolean(
+        shouldRelayNavigation && iframeRef.current?.contentWindow,
+      )
       setPaths({
-        child: paths.child,
+        // Only advance `child` when we actually relay the change to the iframe —
+        // after a relay the child IS at the new path, so a later parent nav back
+        // to it (e.g. browser Forward after Back) is correctly seen as a change
+        // and re-relayed. Without this the child stays stale and Forward is
+        // dropped. If we don't relay, the child hasn't moved, so keep it stale.
+        child: willRelay ? latestParentPathAndQuery : paths.child,
         initial: paths.initial,
         parent: latestParentPathAndQuery,
       })
-      if (shouldRelayNavigation && iframeRef.current?.contentWindow) {
-        console.log(
-          'Parent URL changed, relaying navigation reset to iframe:',
-          `"${latestParentPathAndQuery}"`,
-        )
-        iframeRef.current.contentWindow.postMessage(
+      if (willRelay) {
+        iframeRef.current?.contentWindow?.postMessage(
           {
             type: 'PARENT_NAVIGATE_TO',
             payload: { pathAndQuery: latestParentPathAndQuery },


### PR DESCRIPTION
Linear: [LOM-371](https://linear.app/lombokapp/issue/LOM-371) · Closes LOM-371

## Problem

The app-iframe host (`AppUI`, `packages/ui/src/views/app-ui/app-ui.view.tsx`) keeps the embedded app's route in sync with the parent address bar by relaying a `PARENT_NAVIGATE_TO` message whenever the parent URL changes to a path the child isn't already on.

It tracked the child's current route in `paths.child`, but after relaying a navigation it left `paths.child` stale (set to the old value). As a result, when the parent URL changed back to a path the child had **previously** reported, the relay was incorrectly skipped.

User-visible symptom: **browser Back worked, but Forward (after a Back) was dropped** — the address bar advanced to the new route while the embedded app stayed on the prior screen. This affects every app embedded in the platform iframe.

## Fix

Advance `paths.child` to the relayed path **only when a relay actually happens** (i.e. `shouldRelayNavigation` is on and the iframe is mounted). After a relay the child IS at the new path, so a later parent navigation back to it is correctly seen as a change and re-relayed. When no relay happens, the child hasn't moved, so its tracked path is left unchanged.

## Verification

- `./dx check all` — all checks pass.
- Browser-verified against a running platform with an embedded app: New screen → Back → Overview → **Forward now restores the screen** (previously stuck on Overview). Back, deep-link boot, and in-app navigation all continue to work.