### PR TITLE
fix(LOM-375): persist stack trace and cause chain on task error records

### DIFF
--- a/packages/api/src/task/entities/task.entity.ts
+++ b/packages/api/src/task/entities/task.entity.ts
@@ -88,6 +88,14 @@ export const tasksTable = pgTable(
       code: string
       name: string
       message: string
+      stack?: string
+      cause?: {
+        code: string
+        name: string
+        message: string
+        stack?: string
+        details?: JsonSerializableObject
+      }
       details?: JsonSerializableObject
     }>(),
     createdAt: timestamp('created_at', { withTimezone: true }).notNull(),

--- a/packages/api/src/task/services/task.service.ts
+++ b/packages/api/src/task/services/task.service.ts
@@ -1185,6 +1185,12 @@ export class TaskService {
                   code: completion.error.code,
                   name: completion.error.name ?? 'Error',
                   message: completion.error.message,
+                  ...(completion.error.stack
+                    ? { stack: completion.error.stack }
+                    : {}),
+                  ...(completion.error.cause
+                    ? { cause: completion.error.cause }
+                    : {}),
                   details: completion.error.details,
                 },
                 ...(shouldRequeue

--- a/packages/core-worker/core-worker.ts
+++ b/packages/core-worker/core-worker.ts
@@ -389,7 +389,7 @@ const handleCoreRequest = async (message: CoreWorkerIncomingRequestMessage) => {
     }
     throw buildUnexpectedError({
       code: 'UNEXPECTED_ERROR_DURING_CORE_REQUEST_HANDLING',
-      message: 'Unexpected error during core reuqest handling',
+      message: 'Unexpected error during core request handling',
       error,
       details: {
         action: message.action,

--- a/packages/types/src/task.types.ts
+++ b/packages/types/src/task.types.ts
@@ -548,6 +548,16 @@ export const taskErrorResponseSchema = z.object({
     name: z.string().optional(),
     code: z.string(),
     message: z.string(),
+    stack: z.string().optional(),
+    cause: z
+      .object({
+        code: z.string(),
+        name: z.string(),
+        message: z.string(),
+        stack: z.string().optional(),
+        details: jsonSerializableObjectSchema.optional(),
+      })
+      .optional(),
     details: jsonSerializableObjectSchema.optional(),
   }),
   requeueDelayMs: requeueSchema.optional(),


### PR DESCRIPTION
## Summary

When a background task fails, the task record only captured the top-level error `code`, `name`, `message`, and `details`. The stack trace and the underlying **cause chain** were discarded — so when a worker wraps a low-level failure and exposes the real reason under `error.cause`, that root cause never reached the persisted record. Operators investigating a failed task were left with a generic outer message, no stack, and no path to the actual failure.

This threads `stack` and `cause` through the task error path so both are captured when present.

## Changes

- **`packages/types`** — add optional `stack` and a structured `cause` object (`code`, `name`, `message`, optional `stack`, optional `details`) to the task error response schema.
- **`packages/api` (task entity)** — extend the task entity error column type to match.
- **`packages/api` (TaskService)** — persist `stack` and `cause` when recording task completion errors, spreading each only when present.
- **`packages/core-worker`** — correct a typo in an error message ("reuqest" → "request").

Both new fields are optional and additive, so existing task error records remain valid.

## Testing

- `./dx check all` — passed (prettier + tsc + eslint).
- `./dx e2e api` — full suite, **613 pass / 0 fail** across 68 files.
- `./dx unit core-worker` — passed.

Closes LOM-375