### PR TITLE
improve(LOM-376): robust media type classification + folder object preview/rendering

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -17,6 +17,9 @@ Run `./dx` or `./dx help` to see all available commands. Most commands execute i
 ./dx reload api           # Reload the NestJS API (triggers bun watch reload)
 ./dx restart api          # Fully restart the NestJS API (loads new env)
 ./dx restart ui           # Restart the Vite frontend dev server
+./dx restart proxies      # Regenerate app frontend proxy overrides and reload nginx
+./dx restart bridge       # Restart the docker bridge server
+./dx restart container    # Restart the whole container (Postgres, MinIO, Vite, API)
 ./dx db seed              # Seed the database with dev data
 ./dx db reset             # Drop all tables and re-migrate
 ./dx db reset:seed        # Drop all tables, re-migrate, and re-seed
@@ -27,6 +30,7 @@ Run `./dx` or `./dx help` to see all available commands. Most commands execute i
 ./dx e2e api              # Run API end-to-end tests
 ./dx e2e ui               # Run UI end-to-end tests
 ./dx e2e core-worker      # Run core worker end-to-end tests
+./dx integration core-worker  # Run core worker integration tests
 ./dx e2e down             # Stop the e2e container (docker compose down)
 ./dx e2e kill             # Force-kill the e2e container
 ./dx e2e purge            # Tear down and remove all e2e docker resources
@@ -42,11 +46,13 @@ Run `./dx` or `./dx help` to see all available commands. Most commands execute i
 ```bash
 ./dx up                   # Start the dev environment (docker compose up)
 ./dx up -d                # Start in detached/daemon mode
+./dx up:rebuild           # Start the dev environment, rebuilding the image
 ./dx down                 # Stop the dev environment (docker compose down)
 ./dx kill                 # Force-kill the dev environment
 ./dx install              # Force-reinstall deps on host and in container
 ./dx purge db             # Tear down and remove the Postgres data volume
 ./dx purge minio          # Tear down and remove the MinIO data volume
+./dx purge minio:truncate # Empty the MinIO object data in place (no teardown, no restart)
 ./dx purge all            # Tear down and remove all volumes, images, and orphans
 ```
 
@@ -62,8 +68,8 @@ Run `./dx` or `./dx help` to see all available commands. Most commands execute i
 ## Code lint auto-fix
 
 ```bash
-./dx check eslint fix     # Run eslint fix across all packages
-./dx check prettier fix   # Run prettier fix across all packages
+./dx fix eslint           # Run eslint fix across all packages
+./dx fix prettier         # Run prettier fix across all packages
 ```
 
 ## Environment
@@ -74,14 +80,16 @@ The `DEV_SEED_FILE` env var controls which seed file runs on first startup (defa
 
 ## Building release images
 
+A version argument is required (e.g. `1.2.1-beta-rc3`).
+
 ### Standalone image (includes postgres)
 
 ```bash
-./dx release standalone
+./dx release standalone <version>
 ```
 
 ### Separate DB image (does not include postgres)
 
 ```bash
-./dx release separate-db
+./dx release separate-db <version>
 ```

--- a/dx
+++ b/dx
@@ -109,6 +109,7 @@ Commands:
   restart ui           Restart the Vite frontend dev server
   restart proxies      Regenerate app frontend proxy overrides and reload nginx
   restart bridge       Restart the docker bridge server
+  restart container    Restart the whole container (Postgres, MinIO, Vite, API)
   db seed              Seed the database with dev data
   db reset             Drop all tables and re-migrate
   db reset:seed        Drop all tables, re-migrate, and re-seed
@@ -128,6 +129,7 @@ Commands:
   purge all            Tear down and remove all volumes, images, and orphans
   purge db             Tear down and remove the Postgres data volume
   purge minio          Tear down and remove the MinIO data volume
+  purge minio:truncate  Empty the MinIO object data in place (no teardown, no restart)
   generate openapi     Generate the OpenAPI spec
   generate metadata    Generate NestJS metadata
   release standalone <version>   Build the standalone release image (e.g. 1.2.1-beta-rc3)
@@ -193,8 +195,12 @@ case "${1:-help}" in
         $DOCKER_EXEC pkill -f 'bun run.*/docker-bridge/src/index.ts' || true
         echo "Sent kill signal to docker-bridge. The API service will restart it automatically."
         ;;
+      container)
+        # Restart the whole container (Postgres, MinIO, Vite, and the API).
+        docker compose restart api
+        ;;
       *)
-        echo "Usage: ./dx restart (api|ui|proxies|bridge)" >&2
+        echo "Usage: ./dx restart (api|ui|proxies|bridge|container)" >&2
         exit 1
         ;;
     esac
@@ -328,11 +334,22 @@ case "${1:-help}" in
       db)
         docker compose down && docker volume rm "${COMPOSE_PROJECT_NAME}_pgdata"
         ;;
+      minio:truncate)
+        require_container
+        # Empty each bucket's contents in place; the */ glob skips hidden .minio.sys
+        # so the drive stays formatted and buckets keep existing — no heal, no restart.
+        docker compose exec -T -u root api sh -c '
+          for d in /var/lib/minio/data/*/; do
+            [ -d "$d" ] || continue
+            find "$d" -mindepth 1 -delete
+          done
+        '
+        ;;
       minio)
         docker compose down && docker volume rm "${COMPOSE_PROJECT_NAME}_miniodata"
         ;;
       *)
-        echo "Usage: ./dx purge <all|db|minio>" >&2
+        echo "Usage: ./dx purge <all|db|minio|minio:truncate>" >&2
         exit 1
         ;;
     esac

--- a/packages/api/src/folders/dto/folder-objects-list-query-params.dto.ts
+++ b/packages/api/src/folders/dto/folder-objects-list-query-params.dto.ts
@@ -26,7 +26,7 @@ export const folderObjectsListQueryParamsSchema = z.object({
   includeVideo: z.literal('true').optional(),
   includeAudio: z.literal('true').optional(),
   includeDocument: z.literal('true').optional(),
-  includeUnknown: z.literal('true').optional(),
+  includeOther: z.literal('true').optional(),
 })
 
 export class FolderObjectsListQueryParamsDTO extends createZodDto(

--- a/packages/api/src/folders/services/folder.service.ts
+++ b/packages/api/src/folders/services/folder.service.ts
@@ -900,7 +900,7 @@ export class FolderService {
       includeVideo,
       includeAudio,
       includeDocument,
-      includeUnknown,
+      includeOther,
     }: {
       folderId: string
       search?: string
@@ -912,7 +912,7 @@ export class FolderService {
       includeVideo?: string
       includeAudio?: string
       includeDocument?: string
-      includeUnknown?: string
+      includeOther?: string
     },
   ) {
     const { folder } = await this.getFolderAsUser(actor, folderId)
@@ -939,8 +939,8 @@ export class FolderService {
     if (includeDocument) {
       mediaTypeFilters.push(MediaType.DOCUMENT)
     }
-    if (includeUnknown) {
-      mediaTypeFilters.push(MediaType.UNKNOWN)
+    if (includeOther) {
+      mediaTypeFilters.push(MediaType.OTHER)
     }
 
     if (mediaTypeFilters.length > 0) {
@@ -1423,22 +1423,21 @@ export class FolderService {
       : ''
 
     // Resolve media type from the provided MIME type first, then fall back
-    // to extension-based resolution to gracefully handle MIME-types that are
-    // not in our known MIME-type lists and otherwise produce UNKNOWN
-    // classification even though the extension maps to a recognised type.
+    // to extension-based resolution to gracefully handle MIME-types that
+    // classify as OTHER even though the extension maps to a recognised type.
     const mediaTypeFromProvidedMime = updateRecord.mimeType
       ? mediaTypeFromMimeType(updateRecord.mimeType)
-      : MediaType.UNKNOWN
+      : MediaType.OTHER
     const mediaTypeFromExt = extension
       ? mediaTypeFromMimeType(mimeTypeFromExtension)
-      : MediaType.UNKNOWN
+      : MediaType.OTHER
 
     const insertMediaType =
-      mediaTypeFromProvidedMime !== MediaType.UNKNOWN
+      mediaTypeFromProvidedMime !== MediaType.OTHER
         ? mediaTypeFromProvidedMime
         : mediaTypeFromExt
     const insertMimeType =
-      mediaTypeFromProvidedMime !== MediaType.UNKNOWN
+      mediaTypeFromProvidedMime !== MediaType.OTHER
         ? (updateRecord.mimeType ?? mimeTypeFromExtension)
         : mimeTypeFromExtension || (updateRecord.mimeType ?? '')
 

--- a/packages/api/src/openapi.json
+++ b/packages/api/src/openapi.json
@@ -4536,7 +4536,7 @@
             }
           },
           {
-            "name": "includeUnknown",
+            "name": "includeOther",
             "required": false,
             "in": "query",
             "schema": {
@@ -10314,7 +10314,7 @@
                       "VIDEO",
                       "AUDIO",
                       "DOCUMENT",
-                      "UNKNOWN"
+                      "OTHER"
                     ]
                   }
                 },
@@ -10325,7 +10325,7 @@
                     "VIDEO",
                     "AUDIO",
                     "DOCUMENT",
-                    "UNKNOWN"
+                    "OTHER"
                   ]
                 }
               ]
@@ -18963,7 +18963,7 @@
               "VIDEO",
               "AUDIO",
               "DOCUMENT",
-              "UNKNOWN"
+              "OTHER"
             ]
           },
           "contentMetadata": {

--- a/packages/core-worker/src/analyze-content-worker/analyze-object-handler.test.ts
+++ b/packages/core-worker/src/analyze-content-worker/analyze-object-handler.test.ts
@@ -231,6 +231,12 @@ describe('Analyze Object Handler', () => {
           content: '"IMAGE"',
           mimeType: 'application/json',
         },
+        isBinary: {
+          type: 'inline',
+          sizeBytes: 4,
+          content: 'true',
+          mimeType: 'application/json',
+        },
         embeddedMetadata: {
           type: 'external',
           sizeBytes: 2,

--- a/packages/core-worker/src/analyze-content-worker/analyze-object-handler.ts
+++ b/packages/core-worker/src/analyze-content-worker/analyze-object-handler.ts
@@ -19,6 +19,24 @@ import type z from 'zod'
 
 import { analyzeContent } from './analyze-content'
 
+// Null-byte heuristic over the first 8KB — the same check git uses for text vs binary.
+const BINARY_SNIFF_BYTES = 8192
+const sniffIsBinary = async (filePath: string): Promise<boolean> => {
+  const handle = await fs.promises.open(filePath, 'r')
+  try {
+    const buffer = Buffer.alloc(BINARY_SNIFF_BYTES)
+    const { bytesRead } = await handle.read(buffer, 0, BINARY_SNIFF_BYTES, 0)
+    for (let i = 0; i < bytesRead; i++) {
+      if (buffer[i] === 0) {
+        return true
+      }
+    }
+    return false
+  } finally {
+    await handle.close()
+  }
+}
+
 export const analyzeObject = async (
   folderId: string,
   objectKey: string,
@@ -88,8 +106,9 @@ export const analyzeObject = async (
     }
 
     const originalContentHash = await hashLocalFile(inFilePath)
+    const isBinary = await sniffIsBinary(inFilePath)
     const mediaType =
-      folderObject.mediaType !== MediaType.UNKNOWN
+      folderObject.mediaType !== MediaType.OTHER
         ? folderObject.mediaType
         : mediaTypeFromMimeType(folderObject.mimeType)
     const metadataFilePath = path.join(
@@ -117,6 +136,12 @@ export const analyzeObject = async (
       type: 'inline',
       sizeBytes: Buffer.from(JSON.stringify(mediaType)).length,
       content: JSON.stringify(mediaType),
+      mimeType: 'application/json',
+    }
+    metadataDescription.isBinary = {
+      type: 'inline',
+      sizeBytes: Buffer.from(JSON.stringify(isBinary)).length,
+      content: JSON.stringify(isBinary),
       mimeType: 'application/json',
     }
 

--- a/packages/types/src/api-paths.d.ts
+++ b/packages/types/src/api-paths.d.ts
@@ -4179,7 +4179,7 @@ export interface components {
             sizeBytes: number;
             mimeType: string;
             /** @enum {string} */
-            mediaType: "IMAGE" | "VIDEO" | "AUDIO" | "DOCUMENT" | "UNKNOWN";
+            mediaType: "IMAGE" | "VIDEO" | "AUDIO" | "DOCUMENT" | "OTHER";
             contentMetadata: {
                 [key: string]: {
                     [key: string]: components["schemas"]["InlineMetadataEntryDTO"] | components["schemas"]["ExternalMetadataEntryDTO"];
@@ -7146,7 +7146,7 @@ export interface operations {
                 includeVideo?: "true";
                 includeAudio?: "true";
                 includeDocument?: "true";
-                includeUnknown?: "true";
+                includeOther?: "true";
             };
             header?: never;
             path: {
@@ -10828,7 +10828,7 @@ export interface operations {
                 offset?: number;
                 limit?: number;
                 sort?: ("relevance-desc" | "name-asc" | "name-desc" | "sizeBytes-asc" | "sizeBytes-desc" | "lastModified-asc" | "lastModified-desc")[] | ("relevance-desc" | "name-asc" | "name-desc" | "sizeBytes-asc" | "sizeBytes-desc" | "lastModified-asc" | "lastModified-desc");
-                mediaType?: ("IMAGE" | "VIDEO" | "AUDIO" | "DOCUMENT" | "UNKNOWN")[] | ("IMAGE" | "VIDEO" | "AUDIO" | "DOCUMENT" | "UNKNOWN");
+                mediaType?: ("IMAGE" | "VIDEO" | "AUDIO" | "DOCUMENT" | "OTHER")[] | ("IMAGE" | "VIDEO" | "AUDIO" | "DOCUMENT" | "OTHER");
             };
             header?: never;
             path?: never;

--- a/packages/types/src/apps.types.ts
+++ b/packages/types/src/apps.types.ts
@@ -404,6 +404,19 @@ export const mobileQueryBindingSchema = z
   .strict()
   .meta({ id: 'MobileQueryBinding' })
 
+// Re-runs `query` every `intervalSeconds` while `whilePath` stays truthy, writing
+// each result to `targetPath`. Drives live progress (e.g. a download) without push.
+export const mobilePollBindingSchema = z
+  .object({
+    query: mobileQueryRefSchema,
+    targetPath: z.string().nonempty(),
+    loadingPath: z.string().nonempty().optional(),
+    intervalSeconds: z.number().positive(),
+    whilePath: z.string().nonempty(),
+  })
+  .strict()
+  .meta({ id: 'MobilePollBinding' })
+
 // Collects the component ids referenced by another component's child wiring.
 // Child references live in freeform props, so we read them defensively:
 // `children` is either a string-array (Column/Row) or a List template
@@ -484,6 +497,7 @@ export const mobileRootViewSchema = z
     actionMap: z
       .record(z.string(), z.array(mobileQueryBindingSchema))
       .optional(),
+    pollQueries: z.array(mobilePollBindingSchema).optional(),
   })
   .strict()
   .superRefine((view, ctx) => {

--- a/packages/types/src/content.types.ts
+++ b/packages/types/src/content.types.ts
@@ -5,7 +5,7 @@ export enum MediaType {
   VIDEO = 'VIDEO',
   AUDIO = 'AUDIO',
   DOCUMENT = 'DOCUMENT',
-  UNKNOWN = 'UNKNOWN',
+  OTHER = 'OTHER',
 }
 
 export const mediaTypeSchema = z.enum(MediaType)

--- a/packages/ui/src/components/search-command-palette/search-command-palette.tsx
+++ b/packages/ui/src/components/search-command-palette/search-command-palette.tsx
@@ -38,7 +38,7 @@ const getMediaTypeIcon = (mediaType: MediaType) => {
       return <Music className="size-4" />
     case MediaType.DOCUMENT:
       return <FileText className="size-4" />
-    case MediaType.UNKNOWN: {
+    case MediaType.OTHER: {
       return <FileIcon className="size-4" />
     }
     default:

--- a/packages/ui/src/utils/icons.ts
+++ b/packages/ui/src/utils/icons.ts
@@ -1,26 +1,6 @@
 import { MediaType } from '@lombokapp/types'
-import type {
-  AudioMediaMimeTypes,
-  ImageMediaMimeTypes,
-  VideoMediaMimeTypes,
-} from '@lombokapp/utils'
-import {
-  AUDIO_MEDIA_MIME_TYPES,
-  IMAGE_MEDIA_MIME_TYPES,
-  VIDEO_MEDIA_MIME_TYPES,
-} from '@lombokapp/utils'
+import { mediaTypeFromMimeType } from '@lombokapp/utils'
 import { FileIcon, FileTextIcon, Film, Image, Music } from 'lucide-react'
-
-export const iconForMimeType = (mimeType: string) => {
-  if (AUDIO_MEDIA_MIME_TYPES.includes(mimeType as AudioMediaMimeTypes)) {
-    return Music
-  } else if (IMAGE_MEDIA_MIME_TYPES.includes(mimeType as ImageMediaMimeTypes)) {
-    return Image
-  } else if (VIDEO_MEDIA_MIME_TYPES.includes(mimeType as VideoMediaMimeTypes)) {
-    return Film
-  }
-  return FileIcon
-}
 
 export const iconForMediaType = (mediaType: MediaType) => {
   if (mediaType === MediaType.AUDIO) {
@@ -34,3 +14,6 @@ export const iconForMediaType = (mediaType: MediaType) => {
   }
   return FileIcon
 }
+
+export const iconForMimeType = (mimeType: string) =>
+  iconForMediaType(mediaTypeFromMimeType(mimeType))

--- a/packages/ui/src/views/folder-detail-screen/folder-detail-screen.view.tsx
+++ b/packages/ui/src/views/folder-detail-screen/folder-detail-screen.view.tsx
@@ -86,7 +86,7 @@ const FILTER_OPTIONS: Record<string, ColumnFilterOptions> = {
       { label: 'Videos', value: 'VIDEO' },
       { label: 'Audio', value: 'AUDIO' },
       { label: 'Documents', value: 'DOCUMENT' },
-      { label: 'Unknown', value: 'UNKNOWN' },
+      { label: 'Other', value: 'OTHER' },
     ],
   },
 }
@@ -429,10 +429,8 @@ export const FolderDetailScreen = () => {
               ) && {
                 includeDocument: 'true',
               }),
-              ...(filtersAndSorting.filters['mediaType']?.includes(
-                'UNKNOWN',
-              ) && {
-                includeUnknown: 'true',
+              ...(filtersAndSorting.filters['mediaType']?.includes('OTHER') && {
+                includeOther: 'true',
               }),
               ...{
                 sort: (filtersAndSorting.sorting.length > 0

--- a/packages/ui/src/views/folder-detail-screen/folder-objects-table-columns.tsx
+++ b/packages/ui/src/views/folder-detail-screen/folder-objects-table-columns.tsx
@@ -52,6 +52,7 @@ export const folderObjectsTableColumns: HideableColumnDef<FolderObjectDTO>[] = [
               displayConfig={displayConfig}
               folderObject={row.original}
               objectKey={row.original.objectKey}
+              renderDocumentContent={false}
             />
           </div>
           <div className="flex min-w-0 flex-1 pt-2">

--- a/packages/ui/src/views/folder-detail-screen/justified-objects-grid/justified-objects-grid.tsx
+++ b/packages/ui/src/views/folder-detail-screen/justified-objects-grid/justified-objects-grid.tsx
@@ -705,7 +705,22 @@ function JustifiedGridItem({
           displayConfig={displayConfig}
           folderObject={folderObject}
           objectKey={folderObject.objectKey}
+          renderDocumentContent={false}
         />
+
+        {/* Minimal always-visible filename label (hidden on hover, where the full overlay takes over) */}
+        <div
+          className={cn(
+            'pointer-events-none absolute inset-x-0 bottom-0',
+            'bg-gradient-to-t from-black/60 to-transparent px-2 pb-1.5 pt-4',
+            'transition-opacity duration-200',
+            isHovered ? 'opacity-0' : 'opacity-100',
+          )}
+        >
+          <div className="truncate text-xs font-medium text-white/90 drop-shadow-md">
+            {fileName}
+          </div>
+        </div>
 
         {/* Enhanced gradient overlay */}
         <div

--- a/packages/ui/src/views/folder-object-detail-screen/folder-object-detail-screen.view.tsx
+++ b/packages/ui/src/views/folder-object-detail-screen/folder-object-detail-screen.view.tsx
@@ -79,7 +79,7 @@ export const FolderObjectDetailScreen = ({
     [folderObject?.contentMetadata, folderObject?.hash],
   )
   const IconComponent = iconForMediaType(
-    (folderObject?.mediaType as MediaType | undefined) ?? MediaType.UNKNOWN,
+    (folderObject?.mediaType as MediaType | undefined) ?? MediaType.OTHER,
   )
 
   const previews = React.useMemo(

--- a/packages/ui/src/views/folder-object-preview/can-render.util.ts
+++ b/packages/ui/src/views/folder-object-preview/can-render.util.ts
@@ -1,4 +1,5 @@
 import type { FolderObjectDTO } from '@lombokapp/types'
+import { isRenderableDocumentMimeType } from '@lombokapp/utils'
 
 export function canRenderOriginal(
   folderObject: FolderObjectDTO,
@@ -26,7 +27,7 @@ export function canRenderOriginal(
   }
 
   if (folderObject.mediaType === 'DOCUMENT') {
-    if (folderObject.mimeType === 'application/pdf') {
+    if (isRenderableDocumentMimeType(folderObject.mimeType)) {
       return { result: true }
     }
   }

--- a/packages/ui/src/views/folder-object-preview/folder-object-preview.view.tsx
+++ b/packages/ui/src/views/folder-object-preview/folder-object-preview.view.tsx
@@ -9,6 +9,7 @@ import { cn } from '@lombokapp/ui-toolkit/utils/tailwind'
 import {
   contentIdentifier,
   documentLabelFromMimeType,
+  DocumentMediaMimeTypes,
   isRenderableDocumentMimeType,
   isRenderableTextMimeType,
   mediaTypeFromMimeType,
@@ -53,7 +54,8 @@ export const FolderObjectPreview = ({
   displayMode = 'object-contain',
   folderObject,
   showExplanation = false,
-  maxRenderSizeBytes = 100 * 1024,
+  maxRenderSizeBytes = 256 * 1024,
+  renderDocumentContent = true,
 }: {
   folderId: string
   objectKey: string
@@ -62,6 +64,8 @@ export const FolderObjectPreview = ({
   maxRenderSizeBytes?: number
   showExplanation?: boolean
   folderObject: FolderObjectDTO
+  // When false, document bodies collapse to the type icon — for compact thumbnails.
+  renderDocumentContent?: boolean
 }) => {
   const fileName = objectKey.split('/').at(-1)
   const { getPresignedDownloadUrl } = useLocalFileCacheContext()
@@ -152,16 +156,21 @@ export const FolderObjectPreview = ({
         resolveRenderedVersion()
       const isRenderableDocument = isRenderableDocumentMimeType(mimeType)
       const isTextRenderableDocument = isRenderableTextMimeType(mimeType)
-      await getPresignedDownloadUrl(folderId, renderedContentKey).then(
-        async ({ url }) => {
-          if (isTextRenderableDocument) {
-            const contents = await fetch(url)
-            srcUrl = await contents.text()
-          } else {
-            srcUrl = url
-          }
-        },
-      )
+      // Suppressed document thumbnails render the icon — no need to fetch the body.
+      const skipDocumentBody =
+        !renderDocumentContent && mediaType === MediaType.DOCUMENT
+      if (!skipDocumentBody) {
+        await getPresignedDownloadUrl(folderId, renderedContentKey).then(
+          async ({ url }) => {
+            if (isTextRenderableDocument) {
+              const contents = await fetch(url)
+              srcUrl = await contents.text()
+            } else {
+              srcUrl = url
+            }
+          },
+        )
+      }
       setToRender({
         srcUrl: srcUrl ?? '',
         mimeType,
@@ -171,13 +180,17 @@ export const FolderObjectPreview = ({
         isTextRenderableDocument,
       })
     })()
-  }, [getPresignedDownloadUrl, folderId, objectKey, resolveRenderedVersion])
+  }, [
+    getPresignedDownloadUrl,
+    folderId,
+    objectKey,
+    resolveRenderedVersion,
+    renderDocumentContent,
+  ])
 
   const isCoverView =
     displayMode === 'object-cover' || toRender?.mediaType === MediaType.DOCUMENT
-  const IconComponent = iconForMediaType(
-    toRender?.mediaType ?? MediaType.UNKNOWN,
-  )
+  const IconComponent = iconForMediaType(toRender?.mediaType ?? MediaType.OTHER)
   const overlayLabel = React.useMemo<string | undefined>(() => {
     if (toRender?.mediaType === MediaType.DOCUMENT) {
       return documentLabelFromMimeType(toRender.mimeType)
@@ -276,7 +289,8 @@ export const FolderObjectPreview = ({
               src={toRender.srcUrl}
             />
           </div>
-        ) : toRender?.srcUrl &&
+        ) : renderDocumentContent &&
+          toRender?.srcUrl &&
           toRender.mediaType === MediaType.DOCUMENT &&
           toRender.isTextRenderableDocument ? (
           <div className="size-full overflow-hidden">
@@ -284,9 +298,10 @@ export const FolderObjectPreview = ({
               {toRender.srcUrl}
             </pre>
           </div>
-        ) : toRender?.srcUrl &&
+        ) : renderDocumentContent &&
+          toRender?.srcUrl &&
           toRender.mediaType === MediaType.DOCUMENT &&
-          toRender.mimeType === 'application/pdf' ? (
+          toRender.mimeType === String(DocumentMediaMimeTypes.PDF) ? (
           <React.Suspense fallback={null}>
             <LazyPDFViewer className="size-full" dataURL={toRender.srcUrl} />
           </React.Suspense>

--- a/packages/ui/src/views/folder-object-sidebar/folder-object-sidebar.view.tsx
+++ b/packages/ui/src/views/folder-object-sidebar/folder-object-sidebar.view.tsx
@@ -335,9 +335,11 @@ export const FolderObjectSidebar = ({
                                           `${metadataKey}-${metadataEntry.hash.slice(
                                             0,
                                             8,
-                                          )}.${extensionFromMimeType(
-                                            metadataEntry.mimeType,
-                                          )}`,
+                                          )}.${
+                                            extensionFromMimeType(
+                                              metadataEntry.mimeType,
+                                            ) ?? 'bin'
+                                          }`,
                                         )
                                       }}
                                     >

--- a/packages/utils/src/constants.ts
+++ b/packages/utils/src/constants.ts
@@ -1,48 +1,12 @@
-export enum ImageMediaMimeTypes {
-  JPEG = 'image/jpeg',
-  PNG = 'image/png',
-  GIF = 'image/gif',
-  HEIC = 'image/heic',
-  BMP = 'image/bmp',
-  AVIF = 'image/avif',
-  TIFF = 'image/tiff',
-  SVG = 'image/svg+xml',
-  WEBP = 'image/webp',
-  RAW = 'image/x-dcraw',
-  SONY_RAW = 'image/x-sony-arw',
-}
-
-export enum VideoMediaMimeTypes {
-  MKV = 'video/x-matroska',
-  FLV = 'video/x-flv',
-  MP4 = 'video/mp4',
-  AVI = 'video/x-msvideo',
-  MOV = 'video/quicktime',
-  WEBM = 'video/webm',
-  MPEG = 'video/mpeg',
-  THREEGPP = 'video/3gpp',
-  THREEGPP2 = 'video/3gpp2',
-}
-
-export enum AudioMediaMimeTypes {
-  AAC = 'audio/aac',
-  WAV = 'audio/wav',
-  MP4 = 'audio/mp4',
-  XM4A = 'audio/x-m4a',
-  XWAV = 'audio/x-wav',
-  WEBM = 'audio/webm',
-  MIDI = 'audio/midi',
-  MPEG = 'audio/mpeg',
-  OGG = 'audio/ogg',
-  THREEGPP = 'audio/3gpp',
-  THREEGPP2 = 'audio/3gpp2',
-}
-
 export enum DocumentMediaMimeTypes {
   TXT = 'text/plain',
   PDF = 'application/pdf',
   EPUB = 'application/epub+zip',
   JSON = 'application/json',
+  CSV = 'text/csv',
+  TSV = 'text/tab-separated-values',
+  MPD = 'application/dash+xml',
+  M3U8 = 'application/vnd.apple.mpegurl',
   XLS = 'application/vnd.ms-excel',
   XML = 'application/xml',
   XLSX = 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
@@ -50,115 +14,3 @@ export enum DocumentMediaMimeTypes {
   DOC = 'application/msword',
   DOCX = 'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
 }
-
-export const IMAGE_MEDIA_MIME_TYPES = [
-  ImageMediaMimeTypes.JPEG,
-  ImageMediaMimeTypes.PNG,
-  ImageMediaMimeTypes.HEIC,
-  ImageMediaMimeTypes.GIF,
-  ImageMediaMimeTypes.BMP,
-  ImageMediaMimeTypes.AVIF,
-  ImageMediaMimeTypes.TIFF,
-  ImageMediaMimeTypes.SVG,
-  ImageMediaMimeTypes.WEBP,
-]
-export const VIDEO_MEDIA_MIME_TYPES = [
-  VideoMediaMimeTypes.FLV,
-  VideoMediaMimeTypes.MKV,
-  VideoMediaMimeTypes.MP4,
-  VideoMediaMimeTypes.AVI,
-  VideoMediaMimeTypes.MOV,
-  VideoMediaMimeTypes.WEBM,
-  VideoMediaMimeTypes.MPEG,
-  VideoMediaMimeTypes.THREEGPP,
-  VideoMediaMimeTypes.THREEGPP2,
-]
-export const AUDIO_MEDIA_MIME_TYPES = [
-  AudioMediaMimeTypes.AAC,
-  AudioMediaMimeTypes.WAV,
-  AudioMediaMimeTypes.MP4,
-  AudioMediaMimeTypes.XM4A,
-  AudioMediaMimeTypes.XWAV,
-  AudioMediaMimeTypes.WEBM,
-  AudioMediaMimeTypes.MIDI,
-  AudioMediaMimeTypes.MPEG,
-  AudioMediaMimeTypes.OGG,
-  AudioMediaMimeTypes.THREEGPP,
-  AudioMediaMimeTypes.THREEGPP2,
-]
-export const DOCUMENT_MEDIA_MIME_TYPES = [
-  DocumentMediaMimeTypes.TXT,
-  DocumentMediaMimeTypes.PDF,
-  DocumentMediaMimeTypes.XLS,
-  DocumentMediaMimeTypes.XML,
-  DocumentMediaMimeTypes.EPUB,
-  DocumentMediaMimeTypes.XLSX,
-  DocumentMediaMimeTypes.HTML,
-  DocumentMediaMimeTypes.DOC,
-  DocumentMediaMimeTypes.JSON,
-  DocumentMediaMimeTypes.DOCX,
-]
-
-export const MIME_TYPE_TO_EXTENSION_MAP = {
-  [ImageMediaMimeTypes.JPEG]: 'jpeg',
-  [ImageMediaMimeTypes.BMP]: 'bmp',
-  [ImageMediaMimeTypes.GIF]: 'gif',
-  [ImageMediaMimeTypes.HEIC]: 'heic',
-  [ImageMediaMimeTypes.PNG]: 'png',
-  [ImageMediaMimeTypes.AVIF]: 'avif',
-  [ImageMediaMimeTypes.RAW]: 'raw',
-  [ImageMediaMimeTypes.SONY_RAW]: 'arw',
-  [ImageMediaMimeTypes.TIFF]: 'tiff',
-  [ImageMediaMimeTypes.WEBP]: 'webp',
-
-  [VideoMediaMimeTypes.AVI]: 'avi',
-  [VideoMediaMimeTypes.MKV]: 'mkv',
-  [VideoMediaMimeTypes.MP4]: 'mp4',
-  [VideoMediaMimeTypes.FLV]: 'flv',
-  [VideoMediaMimeTypes.MOV]: 'mov',
-  [VideoMediaMimeTypes.MPEG]: 'mpeg',
-  [VideoMediaMimeTypes.WEBM]: 'webm',
-  [VideoMediaMimeTypes.THREEGPP]: '3ggp',
-  [VideoMediaMimeTypes.THREEGPP2]: '3ggp2',
-
-  [AudioMediaMimeTypes.AAC]: 'aac',
-  [AudioMediaMimeTypes.MIDI]: 'midi',
-  [AudioMediaMimeTypes.MPEG]: 'mp3',
-  [AudioMediaMimeTypes.MP4]: 'm4a',
-  [AudioMediaMimeTypes.XM4A]: 'm4a',
-  [AudioMediaMimeTypes.OGG]: 'ogg',
-  [AudioMediaMimeTypes.WAV]: 'wav',
-  [AudioMediaMimeTypes.XWAV]: 'wav',
-  [AudioMediaMimeTypes.WEBM]: 'webm',
-  [AudioMediaMimeTypes.THREEGPP]: '3gpp',
-  [AudioMediaMimeTypes.THREEGPP2]: '3gpp2',
-
-  [DocumentMediaMimeTypes.TXT]: 'txt',
-  [DocumentMediaMimeTypes.PDF]: 'pdf',
-  [DocumentMediaMimeTypes.XLS]: 'xls',
-  [DocumentMediaMimeTypes.XML]: 'xml',
-  [DocumentMediaMimeTypes.XLSX]: 'xlsx',
-  [DocumentMediaMimeTypes.EPUB]: 'epub',
-  [DocumentMediaMimeTypes.HTML]: 'html',
-  [DocumentMediaMimeTypes.DOC]: 'doc',
-  [DocumentMediaMimeTypes.DOCX]: 'docx',
-  [DocumentMediaMimeTypes.JSON]: 'json',
-}
-
-export const EXTENSION_TO_MIME_TYPE_MAP: Record<
-  string,
-  | ImageMediaMimeTypes
-  | VideoMediaMimeTypes
-  | AudioMediaMimeTypes
-  | DocumentMediaMimeTypes
-> = Object.keys(MIME_TYPE_TO_EXTENSION_MAP).reduce(
-  (acc, next) => {
-    return {
-      ...acc,
-      [MIME_TYPE_TO_EXTENSION_MAP[
-        next as keyof typeof MIME_TYPE_TO_EXTENSION_MAP
-      ]]: next,
-    }
-  },
-  { jpg: ImageMediaMimeTypes.JPEG },
-)

--- a/packages/utils/src/mime.util.test.ts
+++ b/packages/utils/src/mime.util.test.ts
@@ -2,12 +2,6 @@ import { describe, expect, it } from 'bun:test'
 
 import { MediaType } from '../../types'
 import {
-  AudioMediaMimeTypes,
-  DocumentMediaMimeTypes,
-  EXTENSION_TO_MIME_TYPE_MAP,
-  ImageMediaMimeTypes,
-} from './constants'
-import {
   extensionFromMimeType,
   mediaTypeFromExtension,
   mediaTypeFromMimeType,
@@ -51,6 +45,12 @@ describe('mimeFromExtension', () => {
     expect(mimeFromExtension('xml')).toBe('application/xml')
   })
 
+  it('resolves RAW photo extensions via custom types', () => {
+    expect(mimeFromExtension('arw')).toBe('image/x-sony-arw')
+    expect(mimeFromExtension('cr2')).toBe('image/x-canon-cr2')
+    expect(mimeFromExtension('nef')).toBe('image/x-nikon-nef')
+  })
+
   it('returns null for unknown extensions', () => {
     expect(mimeFromExtension('xyz123')).toBeNull()
   })
@@ -72,6 +72,11 @@ describe('mediaTypeFromMimeType', () => {
       'image/tiff',
       'image/svg+xml',
       'image/webp',
+      // types the old hand-maintained array omitted
+      'image/x-sony-arw',
+      'image/x-dcraw',
+      'image/x-icon',
+      'image/heif',
     ])('classifies %s as IMAGE', (mime) => {
       expect(mediaTypeFromMimeType(mime)).toBe(MediaType.IMAGE)
     })
@@ -106,6 +111,7 @@ describe('mediaTypeFromMimeType', () => {
       'audio/midi',
       'audio/3gpp',
       'audio/3gpp2',
+      'audio/flac',
     ])('classifies %s as AUDIO', (mime) => {
       expect(mediaTypeFromMimeType(mime)).toBe(MediaType.AUDIO)
     })
@@ -123,19 +129,24 @@ describe('mediaTypeFromMimeType', () => {
       'application/vnd.ms-excel',
       'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
       'application/vnd.openxmlformats-officedocument.wordprocessingml.document',
+      // any text/* is a document; param-stripping
+      'text/css',
+      'text/markdown',
+      'text/plain; charset=utf-8',
     ])('classifies %s as DOCUMENT', (mime) => {
       expect(mediaTypeFromMimeType(mime)).toBe(MediaType.DOCUMENT)
     })
   })
 
-  describe('UNKNOWN', () => {
-    it('returns UNKNOWN for unrecognised MIME types', () => {
+  describe('OTHER', () => {
+    it('returns OTHER for unrecognised MIME types', () => {
       expect(mediaTypeFromMimeType('application/octet-stream')).toBe(
-        MediaType.UNKNOWN,
+        MediaType.OTHER,
       )
-      expect(mediaTypeFromMimeType('application/zip')).toBe(MediaType.UNKNOWN)
-      expect(mediaTypeFromMimeType('')).toBe(MediaType.UNKNOWN)
-      expect(mediaTypeFromMimeType('text/css')).toBe(MediaType.UNKNOWN)
+      expect(mediaTypeFromMimeType('application/zip')).toBe(MediaType.OTHER)
+      expect(mediaTypeFromMimeType('application/wasm')).toBe(MediaType.OTHER)
+      expect(mediaTypeFromMimeType('')).toBe(MediaType.OTHER)
+      expect(mediaTypeFromMimeType('notamimetype')).toBe(MediaType.OTHER)
     })
   })
 })
@@ -147,6 +158,7 @@ describe('mediaTypeFromExtension', () => {
     expect(mediaTypeFromExtension('gif')).toBe(MediaType.IMAGE)
     expect(mediaTypeFromExtension('webp')).toBe(MediaType.IMAGE)
     expect(mediaTypeFromExtension('jpg')).toBe(MediaType.IMAGE)
+    expect(mediaTypeFromExtension('arw')).toBe(MediaType.IMAGE)
   })
 
   it('classifies video extensions', () => {
@@ -177,47 +189,23 @@ describe('mediaTypeFromExtension', () => {
     expect(mediaTypeFromExtension('Jpg')).toBe(MediaType.IMAGE)
   })
 
-  it('returns UNKNOWN for unrecognised extensions', () => {
-    expect(mediaTypeFromExtension('xyz')).toBe(MediaType.UNKNOWN)
-    expect(mediaTypeFromExtension('')).toBe(MediaType.UNKNOWN)
+  it('returns OTHER for unrecognised extensions', () => {
+    expect(mediaTypeFromExtension('xyz')).toBe(MediaType.OTHER)
+    expect(mediaTypeFromExtension('zzz')).toBe(MediaType.OTHER)
   })
 })
 
 describe('extensionFromMimeType', () => {
   it('returns the canonical extension for known MIME types', () => {
-    expect(extensionFromMimeType('image/jpeg')).toBe('jpeg')
+    expect(extensionFromMimeType('image/jpeg')).toBe('jpg')
     expect(extensionFromMimeType('image/png')).toBe('png')
     expect(extensionFromMimeType('video/mp4')).toBe('mp4')
     expect(extensionFromMimeType('audio/mpeg')).toBe('mp3')
     expect(extensionFromMimeType('audio/mp4')).toBe('m4a')
-    expect(extensionFromMimeType('audio/x-m4a')).toBe('m4a')
     expect(extensionFromMimeType('application/pdf')).toBe('pdf')
   })
 
   it('returns undefined for unknown MIME types', () => {
-    expect(extensionFromMimeType('application/octet-stream')).toBeUndefined()
     expect(extensionFromMimeType('unknown/type')).toBeUndefined()
-  })
-})
-
-describe('EXTENSION_TO_MIME_TYPE_MAP', () => {
-  it('maps m4a to audio/x-m4a', () => {
-    expect(EXTENSION_TO_MIME_TYPE_MAP['m4a']).toBe(AudioMediaMimeTypes.XM4A)
-  })
-
-  it('maps jpg to image/jpeg (explicit seed entry)', () => {
-    expect(EXTENSION_TO_MIME_TYPE_MAP['jpg']).toBe(ImageMediaMimeTypes.JPEG)
-  })
-
-  it('maps mp3 to audio/mpeg', () => {
-    expect(EXTENSION_TO_MIME_TYPE_MAP['mp3']).toBe(AudioMediaMimeTypes.MPEG)
-  })
-
-  it('maps pdf to application/pdf', () => {
-    expect(EXTENSION_TO_MIME_TYPE_MAP['pdf']).toBe(DocumentMediaMimeTypes.PDF)
-  })
-
-  it('has no entry for completely unknown extensions', () => {
-    expect(EXTENSION_TO_MIME_TYPE_MAP['xyz']).toBeUndefined()
   })
 })

--- a/packages/utils/src/mime.util.ts
+++ b/packages/utils/src/mime.util.ts
@@ -2,73 +2,87 @@ import { Mime } from 'mime'
 import otherTypes from 'mime/types/other.js'
 import standardTypes from 'mime/types/standard.js'
 
+import { MediaType } from '../../types'
+import { DocumentMediaMimeTypes } from './constants'
+
 const mime = new Mime({
   ...standardTypes,
   ...otherTypes,
   'video/mp2t': [''],
   'text/typescript': ['ts'],
+  // RAW photo types missing from mime-db; adding them lets ext→mime resolve and
+  // the image/ prefix rule classify them.
+  'image/x-sony-arw': ['arw'],
+  'image/x-dcraw': ['raw'],
+  'image/x-canon-cr2': ['cr2'],
+  'image/x-nikon-nef': ['nef'],
 })
+
+// Force-pin canonical extensions; without this getExtension returns mime-db's
+// first alias (e.g. audio/mpeg → 'mpga' instead of 'mp3').
+mime.define(
+  {
+    'audio/mpeg': ['mp3', 'mpga', 'mp2', 'mp2a', 'm2a', 'm3a'],
+    'image/jpeg': ['jpg', 'jpeg', 'jpe'],
+  },
+  true,
+)
+
+// Curated application/* document types. text/* is handled by the prefix rule.
+const APPLICATION_DOCUMENT_MIME_TYPES = new Set<string>([
+  ...Object.values(DocumentMediaMimeTypes).filter((m) =>
+    m.startsWith('application/'),
+  ),
+  'application/vnd.ms-powerpoint',
+  'application/vnd.openxmlformats-officedocument.presentationml.presentation',
+  'application/vnd.oasis.opendocument.text',
+  'application/vnd.oasis.opendocument.spreadsheet',
+  'application/vnd.oasis.opendocument.presentation',
+  'application/rtf',
+])
 
 export const mimeFromExtension = (extension: string) => {
   return mime.getType(extension)
 }
 
-import { MediaType } from '../../types'
-import type {
-  AudioMediaMimeTypes,
-  ImageMediaMimeTypes,
-  VideoMediaMimeTypes,
-} from './constants'
-import {
-  AUDIO_MEDIA_MIME_TYPES,
-  DOCUMENT_MEDIA_MIME_TYPES,
-  DocumentMediaMimeTypes,
-  EXTENSION_TO_MIME_TYPE_MAP,
-  IMAGE_MEDIA_MIME_TYPES,
-  MIME_TYPE_TO_EXTENSION_MAP,
-  VIDEO_MEDIA_MIME_TYPES,
-} from './constants'
-
-export const mediaTypeFromMimeType = (mimeType: string) => {
-  if (IMAGE_MEDIA_MIME_TYPES.includes(mimeType as ImageMediaMimeTypes)) {
+export const mediaTypeFromMimeType = (mimeType: string): MediaType => {
+  const normalized = mimeType.split(';')[0]?.trim().toLowerCase() ?? ''
+  const slash = normalized.indexOf('/')
+  if (slash < 0) {
+    return MediaType.OTHER
+  }
+  const topLevel = normalized.slice(0, slash)
+  if (topLevel === 'image') {
     return MediaType.IMAGE
-  } else if (VIDEO_MEDIA_MIME_TYPES.includes(mimeType as VideoMediaMimeTypes)) {
+  }
+  if (topLevel === 'video') {
     return MediaType.VIDEO
-  } else if (AUDIO_MEDIA_MIME_TYPES.includes(mimeType as AudioMediaMimeTypes)) {
+  }
+  if (topLevel === 'audio') {
     return MediaType.AUDIO
-  } else if (
-    DOCUMENT_MEDIA_MIME_TYPES.includes(mimeType as DocumentMediaMimeTypes)
-  ) {
+  }
+  if (topLevel === 'text') {
     return MediaType.DOCUMENT
   }
-  return MediaType.UNKNOWN
-}
-
-export const mediaTypeFromExtension = (extension: string) => {
-  const mimeType = EXTENSION_TO_MIME_TYPE_MAP[extension.toLowerCase()]
-  if (!mimeType) {
-    return MediaType.UNKNOWN
-  }
-  if (IMAGE_MEDIA_MIME_TYPES.includes(mimeType as ImageMediaMimeTypes)) {
-    return MediaType.IMAGE
-  } else if (VIDEO_MEDIA_MIME_TYPES.includes(mimeType as VideoMediaMimeTypes)) {
-    return MediaType.VIDEO
-  } else if (AUDIO_MEDIA_MIME_TYPES.includes(mimeType as AudioMediaMimeTypes)) {
-    return MediaType.AUDIO
-  } else if (
-    DOCUMENT_MEDIA_MIME_TYPES.includes(mimeType as DocumentMediaMimeTypes)
-  ) {
+  if (APPLICATION_DOCUMENT_MIME_TYPES.has(normalized)) {
     return MediaType.DOCUMENT
   }
-  return MediaType.UNKNOWN
+  return MediaType.OTHER
 }
+
+export const mediaTypeFromExtension = (extension: string): MediaType =>
+  mediaTypeFromMimeType(mimeFromExtension(extension) ?? '')
 
 export const isRenderableTextMimeType = (mimeType: string) => {
   // Check specific document types that are renderable
   if (
     mimeType === String(DocumentMediaMimeTypes.TXT) ||
     mimeType === String(DocumentMediaMimeTypes.HTML) ||
-    mimeType === String(DocumentMediaMimeTypes.JSON)
+    mimeType === String(DocumentMediaMimeTypes.JSON) ||
+    mimeType === String(DocumentMediaMimeTypes.CSV) ||
+    mimeType === String(DocumentMediaMimeTypes.TSV) ||
+    mimeType === String(DocumentMediaMimeTypes.MPD) ||
+    mimeType === String(DocumentMediaMimeTypes.M3U8)
   ) {
     return true
   }
@@ -83,7 +97,11 @@ export const isRenderableDocumentMimeType = (mimeType: string) => {
     mimeType === String(DocumentMediaMimeTypes.TXT) ||
     mimeType === String(DocumentMediaMimeTypes.HTML) ||
     mimeType === String(DocumentMediaMimeTypes.JSON) ||
-    mimeType === String(DocumentMediaMimeTypes.PDF)
+    mimeType === String(DocumentMediaMimeTypes.PDF) ||
+    mimeType === String(DocumentMediaMimeTypes.CSV) ||
+    mimeType === String(DocumentMediaMimeTypes.TSV) ||
+    mimeType === String(DocumentMediaMimeTypes.MPD) ||
+    mimeType === String(DocumentMediaMimeTypes.M3U8)
   ) {
     return true
   }
@@ -91,11 +109,8 @@ export const isRenderableDocumentMimeType = (mimeType: string) => {
   return false
 }
 
-export const extensionFromMimeType = (mimeType: string): string | undefined => {
-  return MIME_TYPE_TO_EXTENSION_MAP[
-    mimeType as keyof typeof MIME_TYPE_TO_EXTENSION_MAP
-  ]
-}
+export const extensionFromMimeType = (mimeType: string): string | undefined =>
+  mime.getExtension(mimeType) ?? undefined
 
 export const documentLabelFromMimeType = (
   mimeType: string | undefined,


### PR DESCRIPTION
## Summary

Media type classification (`mediaTypeFromMimeType` / `mediaTypeFromExtension`) was driven by hand-maintained allow-lists of exact MIME types plus a separate extension↔MIME map. Any type not explicitly enumerated fell through to `UNKNOWN` even when its top-level type (`image/…`, `video/…`, `audio/…`, `text/…`) made the category obvious. The lists were inevitably incomplete (RAW photo types, `audio/flac`, `image/heif`, MIME parameters, many `text/*` subtypes), so common files were misclassified and shown with the wrong icon and preview behaviour.

Resolves LOM-376.

## Changes

### Classification
- Classify by the MIME **top-level type**: `image`/`video`/`audio` → matching `MediaType`; `text/*` and a curated `application/*` document set → `DOCUMENT`; everything else → `OTHER`. Inputs are lower-cased and parameter-stripped.
- Back extension↔MIME resolution with a single mime-db instance instead of bespoke maps. Pin canonical extensions (`audio/mpeg` → `mp3`, `image/jpeg` → `jpg`) and register RAW photo types absent from mime-db (`arw`/`raw`/`cr2`/`nef`).
- `mediaTypeFromExtension` derives from `mediaTypeFromMimeType(mimeFromExtension(...))`, collapsing two paths into one.
- Rename `MediaType.UNKNOWN` → `OTHER` (and the `includeUnknown` → `includeOther` list-filter query param) since it means "uncategorised", not "lookup failed".

### Content analysis
- Persist an `isBinary` flag in object content metadata via a null-byte sniff over the first 8KB of the downloaded file (the heuristic git uses for text vs binary).

### Preview / rendering
- `FolderObjectPreview` gains `renderDocumentContent` (default `true`); compact grid/table thumbnails pass `false` so document bodies collapse to the type icon and the body fetch is skipped.
- Expand renderable document types (CSV/TSV, DASH `.mpd`, HLS `.m3u8`); `can-render` uses `isRenderableDocumentMimeType` instead of a hard-coded `application/pdf` check.
- Raise the inline text render cap, add an always-visible filename label to grid items, and fall back to a `bin` extension when a MIME type has no known extension.

### Supporting
- Mobile A2UI `MobilePollBinding` schema (interval-polled query gated on a truthy path, for live progress without server push).
- `dx` / `DEVELOPMENT.md` dev-tooling: `restart container`, `purge minio:truncate`, `up:rebuild`, `integration core-worker`, required release version argument, and command-doc fixes.

## Validation
- `./dx check all` — all platform packages pass.
- Unit: `packages/utils` (mime) 89 pass; `packages/api` 263 pass.
- `./dx e2e api` — 613 pass, 0 fail.
- `./dx e2e ui` — 18 specs pass, 0 fail.
- `./dx e2e core-worker` — 2 pass, 0 fail (updated the analyze-object-handler test for the new `isBinary` metadata entry).
