### PR TITLE
chore(LOM-377): symlink-safe demo-app install check + ignore .seed/dist

### DIFF
--- a/packages/demo-apps/.gitignore
+++ b/packages/demo-apps/.gitignore
@@ -1,0 +1,2 @@
+.seed
+dist

--- a/packages/demo-apps/dev-install.sh
+++ b/packages/demo-apps/dev-install.sh
@@ -55,9 +55,9 @@ APP_NAME="$1"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 APP_DIR="$SCRIPT_DIR/$APP_NAME"
 
-# Validate app directory exists
-if [ ! -d "$APP_DIR" ]; then
-  echo "Error: App directory '$APP_DIR' does not exist"
+# Validate app directory exists (resolves symlinks, since APP_DIR may be one)
+if [ ! -f "$APP_DIR/config.json" ]; then
+  echo "Error: App directory '$APP_DIR' does not contain a config.json"
   exit 1
 fi
 


### PR DESCRIPTION
## Summary

Two dev-tooling-only changes for `packages/demo-apps/`:

- **`dev-install.sh`** — validate the target app by `config.json` presence
  (`[ -f "$APP_DIR/config.json" ]`) instead of a bare directory check
  (`[ -d "$APP_DIR" ]`). This is symlink-safe and confirms the path is a real app dir.
- **`packages/demo-apps/.gitignore`** (new) — ignore locally-generated `.seed` and
  `dist` artifacts. The root `/packages/*/dist` rule does not cover nested
  `packages/demo-apps/<app>/dist`, and `.seed` was uncovered entirely.

No runtime or platform behaviour change.

## Test plan

- `bash -n packages/demo-apps/dev-install.sh` parses cleanly.
- Running `dev-install.sh <app>` against a symlinked app dir resolves and installs.

Closes LOM-377