### PR TITLE
fix(LOM-378): treat exiv2 'unknown image type' as unsupported, not an error

### DIFF
--- a/packages/worker-utils/src/metadata.util.ts
+++ b/packages/worker-utils/src/metadata.util.ts
@@ -56,9 +56,12 @@ export async function readFileMetadata(
   // an unsupported file type (e.g., PDF). Return empty metadata instead of throwing.
   if (exitCode !== 0) {
     const errorMessage = stderrText.trim()
-    // Only throw if there's an actual error message. Empty stderr with non-zero
-    // exit code typically means unsupported file type, which we handle gracefully.
-    if (errorMessage) {
+    // exiv2 can't parse vector/unrecognized formats (e.g. SVG) and reports them
+    // as an "unknown image type" — same as the empty-stderr case below, just noisier.
+    const isUnsupportedFormat =
+      !errorMessage || /unknown image type/i.test(errorMessage)
+    // Only throw on genuine errors (e.g. unreadable file), not unsupported formats.
+    if (!isUnsupportedFormat) {
       throw new Error(`exiv2 error: ${errorMessage}`)
     }
     // Unsupported file type - return empty metadata


### PR DESCRIPTION
exiv2 can't parse vector formats like SVG and reports them as "unknown image type" on stderr, which made `readFileMetadata` throw and abort the whole `analyze_object` task. Treat that message the same as the empty-stderr unsupported-format case and return empty metadata.

Stacked on #310. Linear: LOM-378