### PR TITLE
feat(LOM-380): distinguish and sanitize "%2F" object keys end-to-end

### DIFF
--- a/docs/object-key-percent-2f-handling.md
+++ b/docs/object-key-percent-2f-handling.md
@@ -1,0 +1,160 @@
+# Object keys, `/`, and `%2F` handling
+
+This document describes how Lombok handles S3 object keys that contain a real
+`/` (legitimate nesting) versus keys whose bytes literally contain the sequence
+`%2F`, across the URL/route layer, the presign layer, uploads, and reads.
+
+## Background: why `%2F` is special
+
+S3 object keys are opaque UTF-8 byte strings. Two keys must remain distinct and
+both usable:
+
+- `a/b` — a real slash (nested key).
+- `a%2Fb` — a key whose bytes are literally `a`, `%`, `2`, `F`, `b`.
+
+The problem: when an object key is placed into a **presigned URL path**, a bare
+`%2F` is interpreted **inconsistently across S3-compatible providers**. By the
+URL/S3 spec a path is URL-decoded to obtain the key, so `…/a%2Fb` decodes to the
+key `a/b` — colliding with the real-slash key. Some providers preserve `%2F`,
+some collapse it to `/`. A real `/` is unambiguous and works everywhere.
+
+The policy that follows from this:
+
+- A real `/` is always left literal — it is a path separator everywhere
+  (signed paths, routes, storage). Never touched.
+- `%2F` is only ever a concern at the two boundaries where we **create** keys:
+  PUT presigns and folder prefixes. There we sanitize it. Keys read back from S3
+  (GET/HEAD/DELETE/reindex) are known-valid and pass through literally.
+
+## The single load-bearing encoder
+
+`encodeObjectKeyPreservingSlashes(key)` (in `packages/utils/src/s3.util.ts`):
+
+```ts
+encodeURIComponent(key).replace(/%2F/g, '/')
+```
+
+It percent-encodes every byte **except** real `/`. This is used in two places:
+
+1. **Signed S3 paths** (`packages/api/src/storage/s3.utils.ts`). The encoded key
+   is placed into the path handed to `aws4.sign`, which is also the literal wire
+   URL. Encoding is mandatory: an un-encoded `?`, space, `#`, `%`, etc. would
+   make the URL malformed and break the SigV4 signature. Slashes are kept literal
+   because in SigV4-for-S3 the key's `/` are path separators in the canonical
+   URI (single-encoded, slashes not encoded) — every provider agrees on that,
+   whereas encoding `/`→`%2F` re-enters the inconsistent-`%2F` zone.
+
+   The key consequence: a literal-`%2F` key is double-encoded to `%252F` in the
+   path, so S3 decodes it once back to the verbatim `a%2Fb` key — distinct from a
+   real-slash `a/b` whose path stays `a/b`.
+
+2. **Frontend route links** (folder detail grid/table, event/task detail,
+   search palette). The object-detail route uses the same encoder so a key with
+   `?`/`#`/`%2F` produces a well-formed path segment.
+
+The previous helper `encodeS3ObjectKey` was removed; all call sites now use
+`encodeObjectKeyPreservingSlashes`.
+
+## Read path (reading keys back)
+
+Keys read from S3 are known-valid there, so they pass through literally:
+
+- **Controller single-decode.** `@Param('objectKey')` is already URL-decoded
+  once by Express. The earlier double-`decodeURIComponent` in
+  `folders.controller.ts` was removed (it collapsed `a%2Fb` into `a/b`).
+- **`recoverObjectKey`** (`packages/ui/src/pages/folders/object-key-url.ts`,
+  extracted from `folder-root.tsx` so it is React-free and unit-testable)
+  recovers the key from the raw, still-encoded `pathname` with exactly one
+  decode — react-router's splat param decodes twice and would lose the
+  `a/b` vs `a%2Fb` distinction.
+- **GET/HEAD presign, DELETE, reindex, refresh** all use the key verbatim.
+
+## Write path (`%2F` sanitization)
+
+There are two independent boundaries where keys are created:
+
+### 1. Upload filenames (frontend, leaf only)
+
+`sanitizeUploadFilename(name)` replaces both real `/` and `%2F` (case-insensitive)
+with `_`. Applied at the `uploadFile` chokepoint in
+`local-file-cache.provider.tsx`, so the worker only ever receives a clean leaf
+key. The upload modal (`upload-modal.tsx`) displays and tracks progress under the
+sanitized name so a renamed file shows a single, consistent row.
+
+### 2. PUT presign (backend, `%2F` only)
+
+`POST /api/v1/folders/{folderId}/presigned-urls`:
+
+- The request item is a **discriminated union on `method`**. Only the `PUT`
+  variant carries `dontReplaceEncodedForwardSlashes?: boolean` — the flag is
+  meaningless for GET/HEAD/DELETE and therefore absent there.
+- **PUT, default** (`replaceEncodedForwardSlashes`): `%2F`→`_` in the objectKey
+  before prefix-join/sign.
+- **PUT, `dontReplaceEncodedForwardSlashes: true`**: presign the literal key
+  unchanged — used to overwrite a pre-existing `%2F` object, accepting the
+  provider-dependent behavior.
+- **GET/HEAD**: literal passthrough, no flag, no replacement.
+- **DELETE** (`deleteFolderObjectAsUser`, server-side SDK call): literal,
+  unchanged. Real `/` is never touched by any path.
+
+The presign **response now returns the resolved key per URL**:
+`{ url, objectKey }[]` instead of `string[]`. For PUT this reflects any
+replacement; for GET/HEAD it equals the input. The upload worker (`worker.ts`)
+uses the resolved key for the subsequent `refresh` call and for progress
+display, rather than the original file name.
+
+### Folder prefixes
+
+Folder create rejects any content/metadata location `prefix` containing `%2F`
+(via `hasEncodedForwardSlash`) with a `400`. Folder update only changes the name,
+so it has no prefix to guard.
+
+## Pre-existing `%2F` objects stay usable
+
+Objects whose keys literally contain `%2F` (e.g. ingested by reindex from an
+external tool) remain fully usable: read/delete/refresh go through the SDK or a
+literal-passthrough presign, both of which address the verbatim key thanks to the
+slash-preserving encoder (`a%2Fb` → `%252F` in the path → S3 → `a%2Fb`).
+
+## New shared utilities (`packages/utils/src/s3.util.ts`)
+
+| Function | Behavior |
+| --- | --- |
+| `encodeObjectKeyPreservingSlashes(v)` | `encodeURIComponent`, then restore real `/`. URL/path encoding. |
+| `replaceEncodedForwardSlashes(v)` | `%2F` (ci) → `_`. PUT presign sanitization. |
+| `sanitizeUploadFilename(name)` | `/` and `%2F` (ci) → `_`. Upload filename (leaf). Idempotent. |
+| `hasEncodedForwardSlash(v)` | `/%2f/i.test(v)`. Folder-prefix guard. |
+
+## Tests
+
+- **Unit (`bun:test`)**
+  - `packages/utils/src/s3.util.test.ts` — the four helpers, including idempotence
+    and the `a%2Fb`→`a%252Fb` vs `a/b`→`a/b` distinction.
+  - `packages/ui/src/pages/folders/object-key-url.test.ts` — `recoverObjectKey`
+    real-slash recovery, `a%252Fb`→`a%2Fb`, non-object routes, malformed-percent
+    no-throw, and an inverse-pair round-trip with `encodeObjectKeyPreservingSlashes`.
+- **API e2e (`folder-objects.e2e-spec.ts`)** — PUT default replace; PUT keep-literal
+  round-trip; GET/HEAD literal passthrough; real-`/` untouched; folder-prefix
+  reject (`400`); pre-existing `%2F` get/refresh/delete; clean keys land verbatim
+  in S3 + DB and round-trip distinct content. `test.util.ts` now exposes
+  `folderService` and `s3Service` so the bucket can be listed for verification.
+- **UI e2e (`folder-object-upload-sanitize.ui-e2e-spec.ts`)** — uploads a `%2F`
+  (and lowercase `%2f`) filename via `setInputFiles` and asserts it is listed under
+  the sanitized `a_b.txt` and that its detail page loads. A literal `/` in a
+  filename cannot be exercised through a file input (the browser strips the path
+  component), so that case is covered by the unit tests. The listing assertion
+  re-fetches until the post-upload `refresh` has registered the object, to avoid
+  racing the worker's refresh call.
+
+## Files of note
+
+- Encoder / sanitizers: `packages/utils/src/s3.util.ts`
+- Signed paths: `packages/api/src/storage/s3.utils.ts`
+- Presign service + resolved-key response: `packages/api/src/folders/services/folder.service.ts`,
+  `dto/folder-create-signed-url-input.dto.ts`, `dto/responses/folder-create-signed-urls-response.dto.ts`
+- Prefix guard: `packages/api/src/storage/dto/storage-location-input.dto.ts`
+- Controller single-decode: `packages/api/src/folders/controllers/folders.controller.ts`
+- Read-path key recovery: `packages/ui/src/pages/folders/object-key-url.ts`
+- Upload chokepoint + worker + modal: `packages/ui/src/contexts/local-file-cache/local-file-cache.provider.tsx`,
+  `packages/ui/src/worker.ts`, `packages/ui/src/components/upload-modal/upload-modal.tsx`
+- Route-link encoders: folder grid/table, `event-detail-ui`, `task-detail-ui`, `search-command-palette`

--- a/packages/api/src/folders/controllers/folders.controller.ts
+++ b/packages/api/src/folders/controllers/folders.controller.ts
@@ -327,7 +327,7 @@ export class FoldersController {
     }
     const result = await this.folderService.getFolderObjectAsUser(req.user, {
       folderId,
-      objectKey: decodeURIComponent(objectKey),
+      objectKey,
     })
     return {
       folderObject: transformFolderObjectToDTO(result),
@@ -348,7 +348,7 @@ export class FoldersController {
     }
     await this.folderService.deleteFolderObjectAsUser(req.user, {
       folderId,
-      objectKey: decodeURIComponent(objectKey),
+      objectKey,
     })
   }
 
@@ -391,7 +391,7 @@ export class FoldersController {
     const folderObject =
       await this.folderService.refreshFolderObjectS3MetadataAsUser(req.user, {
         folderId,
-        objectKey: decodeURIComponent(objectKey),
+        objectKey,
       })
 
     return {

--- a/packages/api/src/folders/dto/folder-create-signed-url-input.dto.ts
+++ b/packages/api/src/folders/dto/folder-create-signed-url-input.dto.ts
@@ -3,11 +3,30 @@ import { objectIdentifierSchema } from '@lombokapp/utils'
 import { createZodDto } from 'nestjs-zod'
 import { z } from 'zod'
 
+// Discriminated on `method` so the PUT-only `dontReplaceEncodedForwardSlashes`
+// flag exists only where it is meaningful. By default PUT replaces "%2F" → "_"
+// in the key; `true` presigns the literal key (including any "%2F") unchanged.
+// GET/HEAD/DELETE carry no such flag — their keys pass through literally.
 export const createSignedUrlInputSchema = z.array(
-  z.object({
-    objectIdentifier: objectIdentifierSchema,
-    method: z.enum(SignedURLsRequestMethod),
-  }),
+  z.discriminatedUnion('method', [
+    z.object({
+      objectIdentifier: objectIdentifierSchema,
+      method: z.literal(SignedURLsRequestMethod.PUT),
+      dontReplaceEncodedForwardSlashes: z.boolean().optional(),
+    }),
+    z.object({
+      objectIdentifier: objectIdentifierSchema,
+      method: z.literal(SignedURLsRequestMethod.GET),
+    }),
+    z.object({
+      objectIdentifier: objectIdentifierSchema,
+      method: z.literal(SignedURLsRequestMethod.HEAD),
+    }),
+    z.object({
+      objectIdentifier: objectIdentifierSchema,
+      method: z.literal(SignedURLsRequestMethod.DELETE),
+    }),
+  ]),
 )
 
 export class FolderCreateSignedUrlInputDTO extends createZodDto(

--- a/packages/api/src/folders/dto/responses/folder-create-signed-urls-response.dto.ts
+++ b/packages/api/src/folders/dto/responses/folder-create-signed-urls-response.dto.ts
@@ -2,5 +2,15 @@ import { createZodDto } from 'nestjs-zod'
 import { z } from 'zod'
 
 export class FolderCreateSignedUrlsResponse extends createZodDto(
-  z.object({ urls: z.array(z.string()) }),
+  z.object({
+    urls: z.array(
+      z.object({
+        // The presigned URL.
+        url: z.string(),
+        // The resolved object key the URL targets. Reflects any PUT "%2F"
+        // replacement; equals the input key for GET/HEAD.
+        objectKey: z.string(),
+      }),
+    ),
+  }),
 ) {}

--- a/packages/api/src/folders/folder-objects.e2e-spec.ts
+++ b/packages/api/src/folders/folder-objects.e2e-spec.ts
@@ -1,6 +1,6 @@
 import { MediaType, SignedURLsRequestMethod } from '@lombokapp/types'
-import { encodeS3ObjectKey } from '@lombokapp/utils'
 import { afterAll, afterEach, beforeAll, describe, expect, it } from 'bun:test'
+import { configureS3Client } from 'src/storage/s3.service'
 import { CoreTaskName } from 'src/task/task.constants'
 import type { TestApiClient, TestModule } from 'src/test/test.types'
 import {
@@ -223,7 +223,7 @@ describe('Folder Objects', () => {
           params: {
             path: {
               folderId,
-              objectKey: encodeS3ObjectKey('recording.m4a'),
+              objectKey: 'recording.m4a',
             },
           },
         },
@@ -259,7 +259,7 @@ describe('Folder Objects', () => {
           params: {
             path: {
               folderId,
-              objectKey: encodeS3ObjectKey('photo.jpg'),
+              objectKey: 'photo.jpg',
             },
           },
         },
@@ -295,7 +295,7 @@ describe('Folder Objects', () => {
           params: {
             path: {
               folderId,
-              objectKey: encodeS3ObjectKey('video.mp4'),
+              objectKey: 'video.mp4',
             },
           },
         },
@@ -353,6 +353,475 @@ describe('Folder Objects', () => {
       expect(byKey['song.mp3']!.mediaType).toBe(MediaType.AUDIO)
       expect(byKey['image.png']!.mediaType).toBe(MediaType.IMAGE)
       expect(byKey['document.pdf']!.mediaType).toBe(MediaType.DOCUMENT)
+    })
+  })
+
+  describe('Object key encoding round-trip', () => {
+    // Keys are opaque S3 byte strings: a real-slash key and a key whose name
+    // literally contains "%2F" are distinct and must both resolve. Each layer
+    // must encode/decode exactly once. openapi-fetch encodes the path param
+    // once, so we pass the raw stored key here.
+    it('resolves slash and literal-"%2F" keys distinctly via GET', async () => {
+      const {
+        session: { accessToken },
+      } = await createTestUser(testModule!, {
+        username: 'objectkey_roundtrip_user',
+        password: '123',
+      })
+
+      const slashKey = 'videos/career.mp4__clips/clip-4.mp4'
+      const literalKey = 'videos%2Fcareer.mp4__clips%2Fclip-4.mp4'
+
+      const testFolder = await createTestFolder({
+        folderName: 'Object Key Encoding Folder',
+        testModule,
+        accessToken,
+        mockFiles: [
+          { objectKey: slashKey, content: 'slash content' },
+          { objectKey: literalKey, content: 'literal content' },
+        ],
+        apiClient,
+      })
+
+      await reindexTestFolder({
+        accessToken,
+        apiClient,
+        folderId: testFolder.folder.id,
+      })
+      await testModule!.waitForTasks('completed', {
+        taskIdentifiers: [CoreTaskName.ReindexFolder],
+      })
+
+      // Both keys are stored verbatim and remain distinct.
+      const { data: listData } = await apiClient(accessToken).GET(
+        '/api/v1/folders/{folderId}/objects',
+        { params: { path: { folderId: testFolder.folder.id } } },
+      )
+      const storedKeys = listData!.result.map((o) => o.objectKey).sort()
+      expect(storedKeys).toEqual([literalKey, slashKey].sort())
+
+      // GET with the raw key resolves to that exact object, not the other one.
+      const slashGet = await apiClient(accessToken).GET(
+        '/api/v1/folders/{folderId}/objects/{objectKey}',
+        {
+          params: {
+            path: { folderId: testFolder.folder.id, objectKey: slashKey },
+          },
+        },
+      )
+      expect(slashGet.response.status).toBe(200)
+      expect(slashGet.data!.folderObject.objectKey).toBe(slashKey)
+
+      const literalGet = await apiClient(accessToken).GET(
+        '/api/v1/folders/{folderId}/objects/{objectKey}',
+        {
+          params: {
+            path: { folderId: testFolder.folder.id, objectKey: literalKey },
+          },
+        },
+      )
+      expect(literalGet.response.status).toBe(200)
+      expect(literalGet.data!.folderObject.objectKey).toBe(literalKey)
+    })
+  })
+
+  describe('"%2F" handling on presign + folder prefix', () => {
+    // List the raw keys stored in a folder's content bucket (verbatim, as S3
+    // sees them) by resolving the folder's content location and listing it.
+    async function listContentBucketKeys(folderId: string): Promise<string[]> {
+      const folder = await testModule!.services.folderService.getFolder({
+        folderId,
+        includeContentLocation: true,
+      })
+      const loc = folder.contentLocation
+      const s3Client = configureS3Client({
+        accessKeyId: loc.accessKeyId,
+        secretAccessKey: loc.secretAccessKey,
+        endpoint: loc.endpoint,
+        region: loc.region,
+      })
+      const res = await testModule!.services.s3Service.s3ListBucketObjects({
+        s3Client,
+        bucketName: loc.bucket,
+        prefix: loc.prefix,
+      })
+      return res.result.map((o) => o.key)
+    }
+
+    it('PUT presign replaces "%2F" → "_" by default and returns the resolved key', async () => {
+      const {
+        session: { accessToken },
+      } = await createTestUser(testModule!, {
+        username: 'pct_put_default',
+        password: '123',
+      })
+      const testFolder = await createTestFolder({
+        folderName: 'PUT default replace',
+        testModule,
+        accessToken,
+        apiClient,
+      })
+
+      const res = await apiClient(accessToken).POST(
+        '/api/v1/folders/{folderId}/presigned-urls',
+        {
+          params: { path: { folderId: testFolder.folder.id } },
+          body: [
+            {
+              method: SignedURLsRequestMethod.PUT,
+              objectIdentifier: { kind: 'content', objectKey: 'a%2Fb' },
+            },
+          ],
+        },
+      )
+
+      expect(res.response.status).toBe(201)
+      const entry = res.data!.urls[0]!
+      expect(entry.objectKey).toBe('a_b')
+      expect(entry.url).toContain('/a_b?')
+      expect(entry.url).not.toContain('a%2Fb')
+    })
+
+    it('PUT presign with dontReplaceEncodedForwardSlashes keeps the literal key (overwrite case)', async () => {
+      const {
+        session: { accessToken },
+      } = await createTestUser(testModule!, {
+        username: 'pct_put_literal',
+        password: '123',
+      })
+      const testFolder = await createTestFolder({
+        folderName: 'PUT keep literal',
+        testModule,
+        accessToken,
+        apiClient,
+      })
+
+      const literalKey = 'a%2Fb'
+
+      const putRes = await apiClient(accessToken).POST(
+        '/api/v1/folders/{folderId}/presigned-urls',
+        {
+          params: { path: { folderId: testFolder.folder.id } },
+          body: [
+            {
+              method: SignedURLsRequestMethod.PUT,
+              objectIdentifier: { kind: 'content', objectKey: literalKey },
+              dontReplaceEncodedForwardSlashes: true,
+            },
+          ],
+        },
+      )
+      expect(putRes.response.status).toBe(201)
+      const putEntry = putRes.data!.urls[0]!
+      expect(putEntry.objectKey).toBe(literalKey)
+      // The literal "%2F" is encoded as "%252F" in the signed path so S3
+      // decodes it once back to the verbatim "%2F" key.
+      expect(putEntry.url).toContain('/a%252Fb?')
+
+      const uploadResponse = await fetch(putEntry.url, {
+        method: 'PUT',
+        body: 'literal-bytes',
+      })
+      expect(uploadResponse.status).toBe(200)
+
+      // GET passes the literal key through unchanged and round-trips the bytes.
+      const getRes = await apiClient(accessToken).POST(
+        '/api/v1/folders/{folderId}/presigned-urls',
+        {
+          params: { path: { folderId: testFolder.folder.id } },
+          body: [
+            {
+              method: SignedURLsRequestMethod.GET,
+              objectIdentifier: { kind: 'content', objectKey: literalKey },
+            },
+          ],
+        },
+      )
+      const getEntry = getRes.data!.urls[0]!
+      expect(getEntry.objectKey).toBe(literalKey)
+      const fetched = await fetch(getEntry.url)
+      expect(fetched.status).toBe(200)
+      expect(await fetched.text()).toBe('literal-bytes')
+    })
+
+    it('GET/HEAD presign passes a pre-existing "%2F" key through literally', async () => {
+      const {
+        session: { accessToken },
+      } = await createTestUser(testModule!, {
+        username: 'pct_get_passthrough',
+        password: '123',
+      })
+      const literalKey = 'seed%2Fkey.txt'
+      const testFolder = await createTestFolder({
+        folderName: 'GET passthrough',
+        testModule,
+        accessToken,
+        mockFiles: [{ objectKey: literalKey, content: 'seeded-content' }],
+        apiClient,
+      })
+      await reindexTestFolder({
+        accessToken,
+        apiClient,
+        folderId: testFolder.folder.id,
+      })
+      await testModule!.waitForTasks('completed', {
+        taskIdentifiers: [CoreTaskName.ReindexFolder],
+      })
+
+      for (const method of [
+        SignedURLsRequestMethod.GET,
+        SignedURLsRequestMethod.HEAD,
+      ]) {
+        const res = await apiClient(accessToken).POST(
+          '/api/v1/folders/{folderId}/presigned-urls',
+          {
+            params: { path: { folderId: testFolder.folder.id } },
+            body: [
+              {
+                method,
+                objectIdentifier: { kind: 'content', objectKey: literalKey },
+              },
+            ],
+          },
+        )
+        const entry = res.data!.urls[0]!
+        expect(entry.objectKey).toBe(literalKey)
+        // "%2F" is encoded as "%252F" in the signed path (literal passthrough).
+        expect(entry.url).toContain('/seed%252Fkey.txt?')
+      }
+
+      const getRes = await apiClient(accessToken).POST(
+        '/api/v1/folders/{folderId}/presigned-urls',
+        {
+          params: { path: { folderId: testFolder.folder.id } },
+          body: [
+            {
+              method: SignedURLsRequestMethod.GET,
+              objectIdentifier: { kind: 'content', objectKey: literalKey },
+            },
+          ],
+        },
+      )
+      const fetched = await fetch(getRes.data!.urls[0]!.url)
+      expect(fetched.status).toBe(200)
+      expect(await fetched.text()).toBe('seeded-content')
+    })
+
+    it('leaves real "/" keys untouched on PUT and GET', async () => {
+      const {
+        session: { accessToken },
+      } = await createTestUser(testModule!, {
+        username: 'pct_real_slash',
+        password: '123',
+      })
+      const testFolder = await createTestFolder({
+        folderName: 'Real slash untouched',
+        testModule,
+        accessToken,
+        apiClient,
+      })
+
+      const key = 'a/b/c.txt'
+
+      const putRes = await apiClient(accessToken).POST(
+        '/api/v1/folders/{folderId}/presigned-urls',
+        {
+          params: { path: { folderId: testFolder.folder.id } },
+          body: [
+            {
+              method: SignedURLsRequestMethod.PUT,
+              objectIdentifier: { kind: 'content', objectKey: key },
+            },
+          ],
+        },
+      )
+      const putEntry = putRes.data!.urls[0]!
+      expect(putEntry.objectKey).toBe(key)
+      expect(putEntry.url).toContain('/a/b/c.txt?')
+      const uploadResponse = await fetch(putEntry.url, {
+        method: 'PUT',
+        body: 'slash-bytes',
+      })
+      expect(uploadResponse.status).toBe(200)
+
+      const getRes = await apiClient(accessToken).POST(
+        '/api/v1/folders/{folderId}/presigned-urls',
+        {
+          params: { path: { folderId: testFolder.folder.id } },
+          body: [
+            {
+              method: SignedURLsRequestMethod.GET,
+              objectIdentifier: { kind: 'content', objectKey: key },
+            },
+          ],
+        },
+      )
+      const getEntry = getRes.data!.urls[0]!
+      expect(getEntry.objectKey).toBe(key)
+      const fetched = await fetch(getEntry.url)
+      expect(await fetched.text()).toBe('slash-bytes')
+    })
+
+    it('rejects folder creation when a location prefix contains "%2F"', async () => {
+      const {
+        session: { accessToken },
+      } = await createTestUser(testModule!, {
+        username: 'pct_prefix_reject',
+        password: '123',
+      })
+      const contentBucket = await testModule!.initMinioTestBucket()
+      const metadataBucket = await testModule!.initMinioTestBucket()
+
+      const res = await apiClient(accessToken).POST('/api/v1/folders', {
+        body: {
+          name: 'Bad Prefix Folder',
+          contentLocation: testS3Location({
+            bucketName: contentBucket,
+            prefix: 'bad%2Fprefix',
+          }),
+          metadataLocation: testS3Location({ bucketName: metadataBucket }),
+        },
+      })
+      expect(res.response.status).toBe(400)
+    })
+
+    it('keeps a pre-existing "%2F" object fully usable (get, refresh, delete)', async () => {
+      const {
+        session: { accessToken },
+      } = await createTestUser(testModule!, {
+        username: 'pct_preexisting_usable',
+        password: '123',
+      })
+      const literalKey = 'pre%2Fexisting.txt'
+      const testFolder = await createTestFolder({
+        folderName: 'Pre-existing usable',
+        testModule,
+        accessToken,
+        mockFiles: [{ objectKey: literalKey, content: 'still-usable' }],
+        apiClient,
+      })
+      await reindexTestFolder({
+        accessToken,
+        apiClient,
+        folderId: testFolder.folder.id,
+      })
+      await testModule!.waitForTasks('completed', {
+        taskIdentifiers: [CoreTaskName.ReindexFolder],
+      })
+
+      const getObject = await apiClient(accessToken).GET(
+        '/api/v1/folders/{folderId}/objects/{objectKey}',
+        {
+          params: {
+            path: { folderId: testFolder.folder.id, objectKey: literalKey },
+          },
+        },
+      )
+      expect(getObject.response.status).toBe(200)
+      expect(getObject.data!.folderObject.objectKey).toBe(literalKey)
+
+      const refresh = await apiClient(accessToken).POST(
+        '/api/v1/folders/{folderId}/objects/{objectKey}/refresh',
+        {
+          params: {
+            path: { folderId: testFolder.folder.id, objectKey: literalKey },
+          },
+        },
+      )
+      expect(refresh.response.status).toBe(201)
+      expect(refresh.data!.folderObject.objectKey).toBe(literalKey)
+
+      const del = await apiClient(accessToken).DELETE(
+        '/api/v1/folders/{folderId}/objects/{objectKey}',
+        {
+          params: {
+            path: { folderId: testFolder.folder.id, objectKey: literalKey },
+          },
+        },
+      )
+      expect(del.response.status).toBe(200)
+    })
+
+    it('uploads clean keys verbatim (S3 + DB) and round-trips distinct content', async () => {
+      const {
+        session: { accessToken },
+      } = await createTestUser(testModule!, {
+        username: 'pct_verbatim_upload',
+        password: '123',
+      })
+      const testFolder = await createTestFolder({
+        folderName: 'Verbatim upload',
+        testModule,
+        accessToken,
+        apiClient,
+      })
+
+      const keyA = 'normal.txt'
+      const keyB = 'nested/path/file.txt'
+
+      const putRes = await apiClient(accessToken).POST(
+        '/api/v1/folders/{folderId}/presigned-urls',
+        {
+          params: { path: { folderId: testFolder.folder.id } },
+          body: [
+            {
+              method: SignedURLsRequestMethod.PUT,
+              objectIdentifier: { kind: 'content', objectKey: keyA },
+            },
+            {
+              method: SignedURLsRequestMethod.PUT,
+              objectIdentifier: { kind: 'content', objectKey: keyB },
+            },
+          ],
+        },
+      )
+      expect(putRes.data!.urls[0]!.objectKey).toBe(keyA)
+      expect(putRes.data!.urls[1]!.objectKey).toBe(keyB)
+
+      await fetch(putRes.data!.urls[0]!.url, { method: 'PUT', body: 'AAA' })
+      await fetch(putRes.data!.urls[1]!.url, { method: 'PUT', body: 'BBB' })
+
+      // S3 holds the keys verbatim.
+      const bucketKeys = await listContentBucketKeys(testFolder.folder.id)
+      expect(bucketKeys.sort()).toEqual([keyA, keyB].sort())
+
+      // Refresh registers them verbatim in the DB.
+      for (const objectKey of [keyA, keyB]) {
+        await apiClient(accessToken).POST(
+          '/api/v1/folders/{folderId}/objects/{objectKey}/refresh',
+          {
+            params: { path: { folderId: testFolder.folder.id, objectKey } },
+          },
+        )
+      }
+      const listData = await apiClient(accessToken).GET(
+        '/api/v1/folders/{folderId}/objects',
+        { params: { path: { folderId: testFolder.folder.id } } },
+      )
+      const dbKeys = listData.data!.result.map((o) => o.objectKey).sort()
+      expect(dbKeys).toEqual([keyA, keyB].sort())
+
+      // Distinct keys map back to distinct content via GET.
+      const getRes = await apiClient(accessToken).POST(
+        '/api/v1/folders/{folderId}/presigned-urls',
+        {
+          params: { path: { folderId: testFolder.folder.id } },
+          body: [
+            {
+              method: SignedURLsRequestMethod.GET,
+              objectIdentifier: { kind: 'content', objectKey: keyA },
+            },
+            {
+              method: SignedURLsRequestMethod.GET,
+              objectIdentifier: { kind: 'content', objectKey: keyB },
+            },
+          ],
+        },
+      )
+      const fetchedA = await fetch(getRes.data!.urls[0]!.url)
+      const fetchedB = await fetch(getRes.data!.urls[1]!.url)
+      expect(await fetchedA.text()).toBe('AAA')
+      expect(await fetchedB.text()).toBe('BBB')
     })
   })
 

--- a/packages/api/src/folders/folders.e2e-spec.ts
+++ b/packages/api/src/folders/folders.e2e-spec.ts
@@ -571,12 +571,18 @@ describe('Folders', () => {
 
     const expectedContentUrlPrefix = `${storageProvisionInput.endpoint}/${storageProvisionInput.bucket}/${storageProvisionInput.prefix}/.lombok_folder_content_${folderCreateResponse.data?.folder.id}/someobjectkey?`
     expect(
-      presignedUrls.data?.urls[0]?.slice(0, expectedContentUrlPrefix.length),
+      presignedUrls.data?.urls[0]?.url.slice(
+        0,
+        expectedContentUrlPrefix.length,
+      ),
     ).toBe(expectedContentUrlPrefix)
 
     const expectedMetadataUrlPrefix = `${storageProvisionInput.endpoint}/${storageProvisionInput.bucket}/${storageProvisionInput.prefix}/.lombok_folder_metadata_${folderCreateResponse.data?.folder.id}/someobjectkey/somehash`
     expect(
-      presignedUrls.data?.urls[1]?.slice(0, expectedMetadataUrlPrefix.length),
+      presignedUrls.data?.urls[1]?.url.slice(
+        0,
+        expectedMetadataUrlPrefix.length,
+      ),
     ).toBe(expectedMetadataUrlPrefix)
   })
 
@@ -642,12 +648,18 @@ describe('Folders', () => {
 
     const expectedContentUrlPrefix = `${userPresignConfig.endpoint}/${userPresignContentBucket}/content_prefix/someobjectkey`
     expect(
-      presignedUrls.data?.urls[0]?.slice(0, expectedContentUrlPrefix.length),
+      presignedUrls.data?.urls[0]?.url.slice(
+        0,
+        expectedContentUrlPrefix.length,
+      ),
     ).toBe(expectedContentUrlPrefix)
 
     const expectedMetadataUrlPrefix = `${userPresignConfig.endpoint}/${userPresignMetadataBucket}/metadata_prefix/someobjectkey/somehash?`
     expect(
-      presignedUrls.data?.urls[1]?.slice(0, expectedMetadataUrlPrefix.length),
+      presignedUrls.data?.urls[1]?.url.slice(
+        0,
+        expectedMetadataUrlPrefix.length,
+      ),
     ).toBe(expectedMetadataUrlPrefix)
   })
 
@@ -709,11 +721,17 @@ describe('Folders', () => {
 
     const expectedContentUrlPrefix = `${sepConfig.endpoint}/${sepContentBucket}/someobjectkey?`
     expect(
-      presignedUrls.data?.urls[0]?.slice(0, expectedContentUrlPrefix.length),
+      presignedUrls.data?.urls[0]?.url.slice(
+        0,
+        expectedContentUrlPrefix.length,
+      ),
     ).toBe(expectedContentUrlPrefix)
     const expectedMetadataUrlPrefix = `${sepConfig.endpoint}/${sepMetadataBucket}/someobjectkey/somehash?`
     expect(
-      presignedUrls.data?.urls[1]?.slice(0, expectedMetadataUrlPrefix.length),
+      presignedUrls.data?.urls[1]?.url.slice(
+        0,
+        expectedMetadataUrlPrefix.length,
+      ),
     ).toBe(expectedMetadataUrlPrefix)
   })
 

--- a/packages/api/src/folders/services/folder.service.ts
+++ b/packages/api/src/folders/services/folder.service.ts
@@ -21,6 +21,7 @@ import {
   mediaTypeFromMimeType,
   mimeFromExtension,
   type ObjectIdentifier,
+  replaceEncodedForwardSlashes,
   safeZodParse,
 } from '@lombokapp/utils'
 import {
@@ -105,6 +106,14 @@ export interface ContentMetadataPayload {
 export interface SignedURLsRequest {
   objectIdentifier: ObjectIdentifier
   method: SignedURLsRequestMethod
+  // Only honored for PUT: keep the literal key (including any "%2F") unchanged.
+  dontReplaceEncodedForwardSlashes?: boolean
+}
+
+export interface SignedURLResult {
+  url: string
+  // Resolved object key the URL targets (reflects any PUT "%2F" replacement).
+  objectKey: string
 }
 
 export enum FolderObjectSort {
@@ -1238,21 +1247,17 @@ export class FolderService {
       folderId: string
       urls: SignedURLsRequest[]
     },
-  ): Promise<string[]> {
+  ): Promise<SignedURLResult[]> {
     const { folder, permissions } = await this.getFolderAsUser(actor, folderId)
 
-    return createS3PresignedUrls(
-      urls.map(({ objectIdentifier, method }) => {
+    // Resolve each request to its final (relative) object key, applying the
+    // PUT-only "%2F" → "_" sanitization unless explicitly opted out.
+    const resolved = urls.map(
+      ({ objectIdentifier, method, dontReplaceEncodedForwardSlashes }) => {
         const isMetadata = objectIdentifier.kind === 'metadata'
         const location = isMetadata
           ? folder.metadataLocation
           : folder.contentLocation
-        const absoluteObjectKey = isMetadata
-          ? joinStoragePrefix(
-              location.prefix,
-              `${objectIdentifier.objectKey}/${objectIdentifier.metadataHash}`,
-            )
-          : joinStoragePrefix(location.prefix, objectIdentifier.objectKey)
 
         // deny access to write operations for anyone without edit perms
         if (
@@ -1270,15 +1275,41 @@ export class FolderService {
           throw new FolderMetadataWriteUnauthorisedException()
         }
 
+        // Default-sanitize "%2F" on PUT (key creation); GET/HEAD/metadata pass
+        // through literally since those keys were read back from S3.
+        const resolvedObjectKey =
+          method === SignedURLsRequestMethod.PUT &&
+          !dontReplaceEncodedForwardSlashes
+            ? replaceEncodedForwardSlashes(objectIdentifier.objectKey)
+            : objectIdentifier.objectKey
+
+        const absoluteObjectKey = isMetadata
+          ? joinStoragePrefix(
+              location.prefix,
+              `${resolvedObjectKey}/${objectIdentifier.metadataHash}`,
+            )
+          : joinStoragePrefix(location.prefix, resolvedObjectKey)
+
         return {
-          ...location,
-          region: location.region,
-          method,
-          objectKey: absoluteObjectKey,
-          expirySeconds: 3600,
+          resolvedObjectKey,
+          signRequest: {
+            ...location,
+            region: location.region,
+            method,
+            objectKey: absoluteObjectKey,
+            expirySeconds: 3600,
+          },
         }
-      }),
+      },
     )
+
+    const signedUrls = createS3PresignedUrls(resolved.map((r) => r.signRequest))
+
+    return resolved.map((r, i) => ({
+      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+      url: signedUrls[i]!,
+      objectKey: r.resolvedObjectKey,
+    }))
   }
 
   async queueReindexFolderAsUser(actor: User, folderId: string) {

--- a/packages/api/src/notification/util/notification-content.util.ts
+++ b/packages/api/src/notification/util/notification-content.util.ts
@@ -1,5 +1,5 @@
 import { CoreEvent } from '@lombokapp/types'
-import { encodeS3ObjectKey } from '@lombokapp/utils'
+import { encodeObjectKeyPreservingSlashes } from '@lombokapp/utils'
 import type { Event } from 'src/event/entities/event.entity'
 
 const DEFAULT_EVENT_TITLES: Record<string, string> = {
@@ -127,7 +127,7 @@ export function buildNotificationPath(
   const objectKey = event.targetLocationObjectKey
   if (folderId) {
     if (objectKey != null && objectKey.length > 0 && !events) {
-      return `/folders/${folderId}/objects/${encodeS3ObjectKey(objectKey)}`
+      return `/folders/${folderId}/objects/${encodeObjectKeyPreservingSlashes(objectKey)}`
     }
     return `/folders/${folderId}`
   }

--- a/packages/api/src/openapi.json
+++ b/packages/api/src/openapi.json
@@ -14831,64 +14831,74 @@
       "FolderCreateSignedUrlInputDTO": {
         "type": "array",
         "items": {
-          "type": "object",
-          "properties": {
-            "objectIdentifier": {
-              "oneOf": [
-                {
-                  "type": "object",
-                  "properties": {
-                    "kind": {
-                      "type": "string",
-                      "const": "content"
-                    },
-                    "objectKey": {
-                      "type": "string",
-                      "minLength": 1
-                    }
-                  },
-                  "required": [
-                    "kind",
-                    "objectKey"
-                  ]
+          "oneOf": [
+            {
+              "type": "object",
+              "properties": {
+                "objectIdentifier": {
+                  "$ref": "#/components/schemas/ObjectIdentifier"
                 },
-                {
-                  "type": "object",
-                  "properties": {
-                    "kind": {
-                      "type": "string",
-                      "const": "metadata"
-                    },
-                    "objectKey": {
-                      "type": "string",
-                      "minLength": 1
-                    },
-                    "metadataHash": {
-                      "type": "string",
-                      "minLength": 1
-                    }
-                  },
-                  "required": [
-                    "kind",
-                    "objectKey",
-                    "metadataHash"
-                  ]
+                "method": {
+                  "type": "string",
+                  "const": "PUT"
+                },
+                "dontReplaceEncodedForwardSlashes": {
+                  "type": "boolean"
                 }
+              },
+              "required": [
+                "objectIdentifier",
+                "method"
               ]
             },
-            "method": {
-              "type": "string",
-              "enum": [
-                "PUT",
-                "DELETE",
-                "GET",
-                "HEAD"
+            {
+              "type": "object",
+              "properties": {
+                "objectIdentifier": {
+                  "$ref": "#/components/schemas/ObjectIdentifier"
+                },
+                "method": {
+                  "type": "string",
+                  "const": "GET"
+                }
+              },
+              "required": [
+                "objectIdentifier",
+                "method"
+              ]
+            },
+            {
+              "type": "object",
+              "properties": {
+                "objectIdentifier": {
+                  "$ref": "#/components/schemas/ObjectIdentifier"
+                },
+                "method": {
+                  "type": "string",
+                  "const": "HEAD"
+                }
+              },
+              "required": [
+                "objectIdentifier",
+                "method"
+              ]
+            },
+            {
+              "type": "object",
+              "properties": {
+                "objectIdentifier": {
+                  "$ref": "#/components/schemas/ObjectIdentifier"
+                },
+                "method": {
+                  "type": "string",
+                  "const": "DELETE"
+                }
+              },
+              "required": [
+                "objectIdentifier",
+                "method"
               ]
             }
-          },
-          "required": [
-            "objectIdentifier",
-            "method"
           ]
         }
       },
@@ -14898,7 +14908,19 @@
           "urls": {
             "type": "array",
             "items": {
-              "type": "string"
+              "type": "object",
+              "properties": {
+                "url": {
+                  "type": "string"
+                },
+                "objectKey": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "url",
+                "objectKey"
+              ]
             }
           }
         },
@@ -18539,6 +18561,49 @@
           "folderDetailViews"
         ],
         "additionalProperties": false
+      },
+      "ObjectIdentifier": {
+        "oneOf": [
+          {
+            "type": "object",
+            "properties": {
+              "kind": {
+                "type": "string",
+                "const": "content"
+              },
+              "objectKey": {
+                "type": "string",
+                "minLength": 1
+              }
+            },
+            "required": [
+              "kind",
+              "objectKey"
+            ]
+          },
+          {
+            "type": "object",
+            "properties": {
+              "kind": {
+                "type": "string",
+                "const": "metadata"
+              },
+              "objectKey": {
+                "type": "string",
+                "minLength": 1
+              },
+              "metadataHash": {
+                "type": "string",
+                "minLength": 1
+              }
+            },
+            "required": [
+              "kind",
+              "objectKey",
+              "metadataHash"
+            ]
+          }
+        ]
       },
       "Message": {
         "type": "object",

--- a/packages/api/src/storage/dto/storage-location-input.dto.ts
+++ b/packages/api/src/storage/dto/storage-location-input.dto.ts
@@ -1,3 +1,4 @@
+import { hasEncodedForwardSlash } from '@lombokapp/utils'
 import { createZodDto } from 'nestjs-zod'
 import { z } from 'zod'
 
@@ -15,6 +16,10 @@ export const storageLocationInputDTOSchema = z
           (prefix) => prefix.at(0) !== '/' && prefix.at(-1) !== '/',
           'Prefix cannot start or end with "/".',
         )
+        .refine(
+          (prefix) => !hasEncodedForwardSlash(prefix),
+          'Prefix cannot contain "%2F".',
+        )
         .nullable(),
     }),
     z.object({
@@ -23,7 +28,13 @@ export const storageLocationInputDTOSchema = z
     z.object({
       userLocationId: z.guid(),
       userLocationBucketOverride: z.string(),
-      userLocationPrefixOverride: z.string().nullable(),
+      userLocationPrefixOverride: z
+        .string()
+        .refine(
+          (prefix) => !hasEncodedForwardSlash(prefix),
+          'Prefix cannot contain "%2F".',
+        )
+        .nullable(),
     }),
   ])
   .meta({ id: 'StorageLocationInput' })

--- a/packages/api/src/storage/s3.utils.ts
+++ b/packages/api/src/storage/s3.utils.ts
@@ -1,5 +1,5 @@
 import type { SignedURLsRequestMethod } from '@lombokapp/types'
-import { encodeS3ObjectKey } from '@lombokapp/utils'
+import { encodeObjectKeyPreservingSlashes } from '@lombokapp/utils'
 import aws4 from 'aws4'
 
 export function createS3PresignedUrls(
@@ -37,7 +37,10 @@ export function createS3PresignedUrls(
         service: 's3',
         region: request.region,
         method: request.method,
-        path: `/${request.bucket}/${encodeS3ObjectKey(request.objectKey)}?${queryString}`,
+        // Encode the key for the signed path while preserving real "/"
+        // separators. A literal "%2F" in the key thus becomes "%252F", so S3
+        // decodes it once back to the verbatim "%2F" key (rather than to "/").
+        path: `/${request.bucket}/${encodeObjectKeyPreservingSlashes(request.objectKey)}?${queryString}`,
         host: hostnames[request.endpoint],
         signQuery: true,
       },

--- a/packages/api/src/test/test.util.ts
+++ b/packages/api/src/test/test.util.ts
@@ -27,12 +27,13 @@ import { DockerClientService } from 'src/docker/services/client/docker-client.se
 import { DockerWorkerHookService } from 'src/docker/services/docker-worker-hook.service'
 import { buildMockDockerClientService } from 'src/docker/tests/docker.e2e-mocks'
 import { EventService } from 'src/event/services/event.service'
+import { FolderService } from 'src/folders/services/folder.service'
 import { OrmService, TEST_DB_PREFIX } from 'src/orm/orm.service'
 import { ServerConfigurationService } from 'src/server/services/server-configuration.service'
 import { HttpExceptionFilter } from 'src/shared/http-exception-filter'
 import { getLogLevelsFromMinimum } from 'src/shared/logger-levels.util'
 import { runWithThreadContext } from 'src/shared/thread-context'
-import { configureS3Client } from 'src/storage/s3.service'
+import { configureS3Client, S3Service } from 'src/storage/s3.service'
 import { createS3PresignedUrls } from 'src/storage/s3.utils'
 import { tasksTable } from 'src/task/entities/task.entity'
 import { CoreTaskService } from 'src/task/services/core-task.service'
@@ -171,6 +172,8 @@ export async function buildTestModule({
     coreTaskService: await app.resolve(CoreTaskService),
     eventService: await app.resolve(EventService),
     taskService: await app.resolve(TaskService),
+    folderService: await app.resolve(FolderService),
+    s3Service: await app.resolve(S3Service),
     ormService: await app.resolve(OrmService),
     kvService: await app.resolve(KVService),
   }

--- a/packages/api/test/ui/folder-object-upload-sanitize.ui-e2e-spec.ts
+++ b/packages/api/test/ui/folder-object-upload-sanitize.ui-e2e-spec.ts
@@ -1,0 +1,206 @@
+import type { Page } from '@playwright/test'
+import { afterAll, afterEach, beforeAll, describe, expect, it } from 'bun:test'
+
+import { createTestFolder, createTestUser } from '../../src/test/test.util'
+import type { UITestModule } from '../../src/test/ui-test.types'
+import {
+  buildUITestModule,
+  fillLoginForm,
+  submitLoginForm,
+} from '../../src/test/ui-test.util'
+
+const TEST_MODULE_KEY = 'ui_folder_upload_sanitize'
+
+/**
+ * Block until every uploading file shows 100% in the modal so the S3 PUT +
+ * reindex/refresh pipeline is drained before the test returns. (See
+ * file-upload.ui-e2e-spec.ts for why dangling subprocesses are a problem.)
+ */
+async function waitForUploadProgressComplete(
+  page: Page,
+  expectedFileCount: number,
+  timeoutMs = 20000,
+): Promise<void> {
+  const rows = page.getByTestId('upload-progress-percent')
+  await rows.first().waitFor({ state: 'attached', timeout: timeoutMs })
+  await page.waitForFunction(
+    (expected: number) => {
+      const els = Array.from(
+        document.querySelectorAll('[data-testid="upload-progress-percent"]'),
+      )
+      if (els.length < expected) {
+        return false
+      }
+      return els.every((el) => el.textContent.trim() === '100%')
+    },
+    expectedFileCount,
+    { timeout: timeoutMs },
+  )
+}
+
+async function setupFolderAndOpenUploadModal(
+  page: Page,
+  testModule: UITestModule,
+  folderName: string,
+): Promise<string> {
+  const username = `sanitizeuser${Date.now()}${Math.random().toString(36).slice(2, 8)}`
+  const password = `testpass${Math.random().toString(36).slice(2, 8)}`
+
+  const { session } = await createTestUser(testModule, { username, password })
+
+  const { folder } = await createTestFolder({
+    testModule,
+    folderName,
+    accessToken: session.accessToken,
+    mockFiles: [],
+    apiClient: testModule.apiClient,
+  })
+
+  await page.goto(`${testModule.frontendBaseUrl}/login`, { timeout: 5000 })
+  await page.waitForTimeout(1000)
+  await fillLoginForm(page, username, password)
+  await submitLoginForm(page)
+  await page.waitForURL(`${testModule.frontendBaseUrl}/folders`, {
+    timeout: 10000,
+  })
+
+  await page.goto(`${testModule.frontendBaseUrl}/folders/${folder.id}`)
+  await page.waitForLoadState()
+
+  const actionsButton = page.getByTestId('folder-actions-trigger')
+  await actionsButton.waitFor({ state: 'visible', timeout: 5000 })
+  await actionsButton.click({ force: true })
+  await page.waitForTimeout(500)
+
+  const uploadMenuItem = page
+    .locator('[role="menuitem"]:has-text("Upload"), button:has-text("Upload")')
+    .first()
+  await uploadMenuItem.waitFor({ state: 'visible', timeout: 3000 })
+  await uploadMenuItem.click()
+  await page.waitForTimeout(500)
+
+  return folder.id
+}
+
+/**
+ * After the S3 PUT reaches 100% the worker still has to fire `refresh`, which
+ * registers the object in the DB. A single folder reload races that write, so
+ * re-fetch the listing (the SPA only fetches once per load) until the object's
+ * link appears.
+ */
+async function waitForListedObject(
+  page: Page,
+  folderUrl: string,
+  hrefKey: string,
+  timeoutMs = 20000,
+): Promise<boolean> {
+  const deadline = Date.now() + timeoutMs
+  while (Date.now() < deadline) {
+    await page.goto(folderUrl)
+    await page.waitForLoadState()
+    const link = page.locator(`a[href*="/objects/${hrefKey}"]`).first()
+    const visible = await link
+      .waitFor({ state: 'visible', timeout: 3000 })
+      .then(() => true)
+      .catch(() => false)
+    if (visible) {
+      return true
+    }
+  }
+  return false
+}
+
+describe('UI E2E - Folder Object Upload Filename Sanitize', () => {
+  let testModule: UITestModule | undefined
+
+  beforeAll(async () => {
+    testModule = await buildUITestModule({
+      testModuleKey: TEST_MODULE_KEY,
+      // debug: true,
+    })
+  })
+
+  afterEach(
+    async () => {
+      if (testModule) {
+        await testModule.resetAppState()
+      }
+    },
+    { timeout: 30000 },
+  )
+
+  afterAll(async () => {
+    if (testModule) {
+      await testModule.shutdown()
+    }
+  })
+
+  it('sanitizes a "%2F" filename to "_" on upload and lists it as a plain key', async () => {
+    const page = await testModule!.getFreshPage()
+
+    const folderId = await setupFolderAndOpenUploadModal(
+      page,
+      testModule!,
+      `Sanitize %2F ${Date.now()}`,
+    )
+
+    const fileInput = page.locator('input[type="file"]').first()
+    await fileInput.waitFor({ state: 'attached', timeout: 3000 })
+
+    await fileInput.setInputFiles({
+      name: 'a%2Fb.txt',
+      mimeType: 'text/plain',
+      buffer: Buffer.from('encoded-slash content'),
+    })
+
+    await waitForUploadProgressComplete(page, 1)
+
+    // The object is listed under the sanitized key "a_b.txt".
+    const listed = await waitForListedObject(
+      page,
+      `${testModule!.frontendBaseUrl}/folders/${folderId}`,
+      'a_b.txt',
+    )
+    expect(listed).toBe(true)
+
+    // The detail page for the sanitized (plain ".txt") key loads.
+    await page.goto(
+      `${testModule!.frontendBaseUrl}/folders/${folderId}/objects/a_b.txt`,
+    )
+    await page.waitForLoadState()
+    const detailKey = page.locator('text=/a_b.txt/').first()
+    await detailKey.waitFor({ state: 'visible', timeout: 10000 })
+    expect(await detailKey.isVisible()).toBe(true)
+  }, 45000)
+
+  // A literal "/" in a filename can't be exercised through a file input — the
+  // browser strips the path component — so we cover the case-insensitive "%2f"
+  // form here; the "/"→"_" replacement is covered by the unit tests.
+  it('sanitizes a lowercase "%2f" filename to "_" on upload and lists it as a plain key', async () => {
+    const page = await testModule!.getFreshPage()
+
+    const folderId = await setupFolderAndOpenUploadModal(
+      page,
+      testModule!,
+      `Sanitize %2f ${Date.now()}`,
+    )
+
+    const fileInput = page.locator('input[type="file"]').first()
+    await fileInput.waitFor({ state: 'attached', timeout: 3000 })
+
+    await fileInput.setInputFiles({
+      name: 'a%2fb.txt',
+      mimeType: 'text/plain',
+      buffer: Buffer.from('lowercase-encoded-slash content'),
+    })
+
+    await waitForUploadProgressComplete(page, 1)
+
+    const listed = await waitForListedObject(
+      page,
+      `${testModule!.frontendBaseUrl}/folders/${folderId}`,
+      'a_b.txt',
+    )
+    expect(listed).toBe(true)
+  }, 45000)
+})

--- a/packages/types/src/api-paths.d.ts
+++ b/packages/types/src/api-paths.d.ts
@@ -3140,22 +3140,29 @@ export interface components {
         FolderObjectGetResponse: {
             folderObject: components["schemas"]["FolderObject"];
         };
-        FolderCreateSignedUrlInputDTO: {
-            objectIdentifier: {
-                /** @constant */
-                kind: "content";
-                objectKey: string;
-            } | {
-                /** @constant */
-                kind: "metadata";
-                objectKey: string;
-                metadataHash: string;
-            };
-            /** @enum {string} */
-            method: "PUT" | "DELETE" | "GET" | "HEAD";
-        }[];
+        FolderCreateSignedUrlInputDTO: ({
+            objectIdentifier: components["schemas"]["ObjectIdentifier"];
+            /** @constant */
+            method: "PUT";
+            dontReplaceEncodedForwardSlashes?: boolean;
+        } | {
+            objectIdentifier: components["schemas"]["ObjectIdentifier"];
+            /** @constant */
+            method: "GET";
+        } | {
+            objectIdentifier: components["schemas"]["ObjectIdentifier"];
+            /** @constant */
+            method: "HEAD";
+        } | {
+            objectIdentifier: components["schemas"]["ObjectIdentifier"];
+            /** @constant */
+            method: "DELETE";
+        })[];
         FolderCreateSignedUrlsResponse: {
-            urls: string[];
+            urls: {
+                url: string;
+                objectKey: string;
+            }[];
         };
         FolderShareGetResponse: {
             share: components["schemas"]["Share"];
@@ -4076,6 +4083,16 @@ export interface components {
                 };
                 root?: components["schemas"]["MobileRoot"];
             };
+        };
+        ObjectIdentifier: {
+            /** @constant */
+            kind: "content";
+            objectKey: string;
+        } | {
+            /** @constant */
+            kind: "metadata";
+            objectKey: string;
+            metadataHash: string;
         };
         Message: {
             /** @enum {string} */

--- a/packages/ui/src/components/event-detail-ui/event-detail-ui.tsx
+++ b/packages/ui/src/components/event-detail-ui/event-detail-ui.tsx
@@ -8,6 +8,7 @@ import {
   CardTitle,
 } from '@lombokapp/ui-toolkit/components/card'
 import { cn } from '@lombokapp/ui-toolkit/utils/tailwind'
+import { encodeObjectKeyPreservingSlashes } from '@lombokapp/utils'
 import { Link } from 'react-router'
 
 import { DateDisplay } from '@/src/components/date-display'
@@ -195,7 +196,7 @@ export function EventDetailUI({
                               Object:{' '}
                               {isFolderOwner ? (
                                 <Link
-                                  to={`/folders/${eventData.targetLocation.folderId}/objects/${eventData.targetLocation.objectKey}`}
+                                  to={`/folders/${eventData.targetLocation.folderId}/objects/${encodeObjectKeyPreservingSlashes(eventData.targetLocation.objectKey)}`}
                                   className="text-primary hover:underline"
                                 >
                                   {eventData.targetLocation.objectKey}

--- a/packages/ui/src/components/search-command-palette/search-command-palette.tsx
+++ b/packages/ui/src/components/search-command-palette/search-command-palette.tsx
@@ -14,7 +14,7 @@ import {
   DialogTitle,
 } from '@lombokapp/ui-toolkit/components/dialog'
 import { cn } from '@lombokapp/ui-toolkit/utils/tailwind'
-import { encodeS3ObjectKey, formatBytes } from '@lombokapp/utils'
+import { encodeObjectKeyPreservingSlashes, formatBytes } from '@lombokapp/utils'
 import {
   FileIcon,
   FileQuestion,
@@ -118,7 +118,7 @@ export function SearchCommandPalette() {
   const handleResultSelect = React.useCallback(
     (folderId: string, objectKey: string) => {
       void navigate(
-        `/folders/${folderId}/objects/${encodeS3ObjectKey(objectKey)}`,
+        `/folders/${folderId}/objects/${encodeObjectKeyPreservingSlashes(objectKey)}`,
       )
       handleOpenChange(false)
     },

--- a/packages/ui/src/components/task-detail-ui/task-detail-ui.tsx
+++ b/packages/ui/src/components/task-detail-ui/task-detail-ui.tsx
@@ -27,6 +27,7 @@ import {
   TooltipTrigger,
 } from '@lombokapp/ui-toolkit/components/tooltip'
 import { cn } from '@lombokapp/ui-toolkit/utils/tailwind'
+import { encodeObjectKeyPreservingSlashes } from '@lombokapp/utils'
 import {
   AlertCircle,
   Check,
@@ -1244,7 +1245,7 @@ export function TaskDetailUI({
                             Object:{' '}
                             {isFolderOwner ? (
                               <Link
-                                to={`/folders/${taskData.targetLocation.folderId}/objects/${taskData.targetLocation.objectKey}`}
+                                to={`/folders/${taskData.targetLocation.folderId}/objects/${encodeObjectKeyPreservingSlashes(taskData.targetLocation.objectKey)}`}
                                 className="text-primary hover:underline"
                               >
                                 {taskData.targetLocation.objectKey}

--- a/packages/ui/src/components/upload-modal/upload-modal.tsx
+++ b/packages/ui/src/components/upload-modal/upload-modal.tsx
@@ -8,6 +8,7 @@ import {
   DialogTitle,
 } from '@lombokapp/ui-toolkit/components/dialog'
 import { cn } from '@lombokapp/ui-toolkit/utils/tailwind'
+import { sanitizeUploadFilename } from '@lombokapp/utils'
 import React from 'react'
 import type { FileRejection } from 'react-dropzone'
 
@@ -49,13 +50,16 @@ const UploadModal = ({
     }
   }, [modalData.isOpen])
 
-  // Keep track of files that have progress data
+  // Keep track of files that have progress data. Progress is reported under the
+  // sanitized (resolved) key, so match dropped files by their sanitized name.
   React.useEffect(() => {
     // Only add files from progress that aren't already in uploadingFiles
     const filesFromProgress = Object.keys(modalData.uploadingProgress)
       .filter((filename) => {
         // Check if this file is already in uploadingFiles
-        return !uploadingFiles.some((file) => file.name === filename)
+        return !uploadingFiles.some(
+          (file) => sanitizeUploadFilename(file.name) === filename,
+        )
       })
       .map((filename) => {
         // Create a File-like object for display purposes
@@ -94,27 +98,28 @@ const UploadModal = ({
             <div className="mt-4 flex flex-col gap-3 rounded-md border border-gray-200 p-3">
               <h3 className="text-sm font-medium">Uploading files</h3>
               <div className="flex max-h-[200px] flex-col gap-3 overflow-y-auto pr-1">
-                {uploadingFiles.map((uploadingFile, i) => (
-                  <div key={`${uploadingFile.name}_${i}`} className="text-sm">
-                    <div className="mb-1 flex justify-between">
-                      <span className="max-w-[80%] truncate">
-                        {uploadingFile.name}
-                      </span>
-                      <span
-                        className="ml-2 whitespace-nowrap text-xs font-medium text-muted-foreground"
-                        data-testid="upload-progress-percent"
-                      >
-                        {`${Math.round(modalData.uploadingProgress[uploadingFile.name] ?? 0)}%`}
-                      </span>
+                {uploadingFiles.map((uploadingFile, i) => {
+                  // The upload pipeline sanitizes the filename ("/" and "%2F" →
+                  // "_"); display and look up progress under that resolved name.
+                  const displayName = sanitizeUploadFilename(uploadingFile.name)
+                  const progress = modalData.uploadingProgress[displayName] ?? 0
+                  return (
+                    <div key={`${displayName}_${i}`} className="text-sm">
+                      <div className="mb-1 flex justify-between">
+                        <span className="max-w-[80%] truncate">
+                          {displayName}
+                        </span>
+                        <span
+                          className="ml-2 whitespace-nowrap text-xs font-medium text-muted-foreground"
+                          data-testid="upload-progress-percent"
+                        >
+                          {`${Math.round(progress)}%`}
+                        </span>
+                      </div>
+                      <ProgressBar progress={progress} className="h-2" />
                     </div>
-                    <ProgressBar
-                      progress={
-                        modalData.uploadingProgress[uploadingFile.name] ?? 0
-                      }
-                      className="h-2"
-                    />
-                  </div>
-                ))}
+                  )
+                })}
               </div>
             </div>
           )}

--- a/packages/ui/src/contexts/local-file-cache/local-file-cache.provider.tsx
+++ b/packages/ui/src/contexts/local-file-cache/local-file-cache.provider.tsx
@@ -2,6 +2,7 @@ import {
   contentIdentifier,
   type ObjectIdentifier,
   objectIdentifierKey,
+  sanitizeUploadFilename,
 } from '@lombokapp/utils'
 import React from 'react'
 
@@ -138,11 +139,14 @@ export const LocalFileCacheContextProvider = ({
 
   const uploadFile = React.useCallback(
     (folderId: string, objectKey: string, file: File) => {
+      // Sanitize the upload filename (leaf): "/" and "%2F" → "_".
       postMessage.current([
         'UPLOAD',
         {
           folderId,
-          objectIdentifier: contentIdentifier(objectKey),
+          objectIdentifier: contentIdentifier(
+            sanitizeUploadFilename(objectKey),
+          ),
           uploadFile: file,
         },
       ])

--- a/packages/ui/src/pages/folders/folder-root.tsx
+++ b/packages/ui/src/pages/folders/folder-root.tsx
@@ -1,4 +1,4 @@
-import { useParams } from 'react-router'
+import { useLocation, useParams } from 'react-router'
 
 import { FolderContextProvider, useFolderContext } from '@/src/contexts/folder'
 
@@ -11,15 +11,17 @@ import { FolderSettingsScreen } from '../../views/folder-settings-screen/folder-
 import { FolderTaskDetailScreen } from '../../views/folder-task-detail-screen/folder-task-detail-screen.view'
 import { FolderTasksScreen } from '../../views/folder-tasks-screen/folder-tasks-screen.view'
 import { FocusedFolderObjectContextProvider } from './focused-folder-object.provider'
+import { recoverObjectKey } from './object-key-url'
 
 function FolderObjectRootInner() {
   const params = useParams()
+  const { pathname } = useLocation()
   const pathParts = params['*']?.split('/') ?? []
   const isFolderObjectDetailPage =
     pathParts.length > 2 && pathParts[1] === 'objects'
   const folderContext = useFolderContext()
   const focusedFolderObjectKey = isFolderObjectDetailPage
-    ? pathParts.slice(2).join('/')
+    ? recoverObjectKey(pathname)
     : undefined
   return focusedFolderObjectKey ? (
     <FocusedFolderObjectContextProvider
@@ -38,12 +40,13 @@ function FolderObjectRootInner() {
 
 function FolderRootInner() {
   const params = useParams()
+  const { pathname } = useLocation()
   const pathParts = params['*']?.split('/') ?? []
   const isFolderDetailPage = pathParts.length === 1
   const isFolderObjectDetailPage =
     pathParts.length > 2 && pathParts[1] === 'objects'
   const focusedFolderObjectKey = isFolderObjectDetailPage
-    ? pathParts.slice(2).join('/')
+    ? recoverObjectKey(pathname)
     : undefined
 
   const isTaskListPage = pathParts.length === 2 && pathParts[1] === 'tasks'

--- a/packages/ui/src/pages/folders/object-key-url.test.ts
+++ b/packages/ui/src/pages/folders/object-key-url.test.ts
@@ -1,0 +1,40 @@
+import { encodeObjectKeyPreservingSlashes } from '@lombokapp/utils'
+import { describe, expect, it } from 'bun:test'
+
+import { recoverObjectKey } from './object-key-url'
+
+describe('recoverObjectKey', () => {
+  it('recovers a real-slash multi-segment key', () => {
+    expect(recoverObjectKey('/folders/FID/objects/videos/clip-4.mp4')).toBe(
+      'videos/clip-4.mp4',
+    )
+  })
+
+  it('recovers a literal-"%2F" key (single decode of "%252F")', () => {
+    expect(recoverObjectKey('/folders/FID/objects/a%252Fb')).toBe('a%2Fb')
+  })
+
+  it('returns undefined for a non-object route', () => {
+    expect(recoverObjectKey('/folders/FID/tasks/abc')).toBeUndefined()
+    expect(recoverObjectKey('/folders/FID')).toBeUndefined()
+  })
+
+  it('does not throw on a malformed percent-encoding', () => {
+    expect(recoverObjectKey('/folders/FID/objects/a%2')).toBe('a%2')
+  })
+
+  it('is the inverse of encodeObjectKeyPreservingSlashes', () => {
+    for (const key of [
+      'simple.txt',
+      'videos/clip-4.mp4',
+      'a%2Fb',
+      'with space & symbols?.png',
+    ]) {
+      expect(
+        recoverObjectKey(
+          `/folders/FID/objects/${encodeObjectKeyPreservingSlashes(key)}`,
+        ),
+      ).toBe(key)
+    }
+  })
+})

--- a/packages/ui/src/pages/folders/object-key-url.ts
+++ b/packages/ui/src/pages/folders/object-key-url.ts
@@ -1,0 +1,15 @@
+// Recover the object key from the raw (still-encoded) pathname with exactly one
+// decode. We can't use the splat param: react-router decodes it twice, which
+// collapses a literal "%2F" in the key into a real "/" — losing the distinction
+// between key "a/b" and key "a%2Fb".
+export function recoverObjectKey(pathname: string): string | undefined {
+  const match = /^\/folders\/[^/]+\/objects\/(.+)$/.exec(pathname)
+  if (!match) {
+    return undefined
+  }
+  try {
+    return decodeURIComponent(match[1] ?? '')
+  } catch {
+    return match[1]
+  }
+}

--- a/packages/ui/src/views/folder-detail-screen/folder-objects-table-columns.tsx
+++ b/packages/ui/src/views/folder-detail-screen/folder-objects-table-columns.tsx
@@ -1,6 +1,6 @@
 import type { FolderObjectDTO } from '@lombokapp/types'
 import type { HideableColumnDef } from '@lombokapp/ui-toolkit/components/data-table'
-import { encodeS3ObjectKey } from '@lombokapp/utils'
+import { encodeObjectKeyPreservingSlashes } from '@lombokapp/utils'
 import React from 'react'
 
 import { TableLinkColumn } from '@/src/components/table-link-column/table-link-column'
@@ -12,7 +12,7 @@ export const folderObjectsTableColumns: HideableColumnDef<FolderObjectDTO>[] = [
     id: 'link',
     cell: ({ row }) => (
       <TableLinkColumn
-        to={`/folders/${row.original.folderId}/objects/${encodeS3ObjectKey(row.original.objectKey)}`}
+        to={`/folders/${row.original.folderId}/objects/${encodeObjectKeyPreservingSlashes(row.original.objectKey)}`}
       />
     ),
     enableSorting: false,

--- a/packages/ui/src/views/folder-detail-screen/justified-objects-grid/justified-objects-grid.tsx
+++ b/packages/ui/src/views/folder-detail-screen/justified-objects-grid/justified-objects-grid.tsx
@@ -2,7 +2,7 @@ import { type FolderObjectDTO } from '@lombokapp/types'
 import { MediaType } from '@lombokapp/types'
 import { cn } from '@lombokapp/ui-toolkit/utils/tailwind'
 import {
-  encodeS3ObjectKey,
+  encodeObjectKeyPreservingSlashes,
   formatBytes,
   mediaTypeFromMimeType,
 } from '@lombokapp/utils'
@@ -678,7 +678,7 @@ function JustifiedGridItem({
 
   return (
     <Link
-      to={`/folders/${folderObject.folderId}/objects/${encodeS3ObjectKey(folderObject.objectKey)}`}
+      to={`/folders/${folderObject.folderId}/objects/${encodeObjectKeyPreservingSlashes(folderObject.objectKey)}`}
       className={cn(
         'group relative block overflow-hidden rounded-lg bg-card transition-all duration-200',
         'hover:shadow-xl hover:shadow-black/10 hover:-translate-y-1',

--- a/packages/ui/src/views/folder-object-detail-screen/folder-object-detail-screen.view.tsx
+++ b/packages/ui/src/views/folder-object-detail-screen/folder-object-detail-screen.view.tsx
@@ -312,7 +312,7 @@ export const FolderObjectDetailScreen = ({
                   <AppUI
                     getAccessTokens={getAccessTokens}
                     appIdentifier={selectedContributedView.appIdentifier}
-                    pathAndQuery={`${selectedContributedView.path}?folderId=${folderId}&objectKey=${objectKey}`}
+                    pathAndQuery={`${selectedContributedView.path}?folderId=${folderId}&objectKey=${encodeURIComponent(objectKey)}`}
                     host={API_HOST}
                     scheme={protocol}
                   />

--- a/packages/ui/src/worker.ts
+++ b/packages/ui/src/worker.ts
@@ -1,10 +1,6 @@
 import type { LombokApiClient, paths } from '@lombokapp/types'
 import { SignedURLsRequestMethod } from '@lombokapp/types'
-import {
-  encodeS3ObjectKey,
-  type ObjectIdentifier,
-  objectIdentifierKey,
-} from '@lombokapp/utils'
+import { type ObjectIdentifier, objectIdentifierKey } from '@lombokapp/utils'
 import createFetchClient from 'openapi-fetch'
 
 export enum LogLevel {
@@ -242,7 +238,7 @@ const maybeSendBatch = (folderId: string) => {
                 )
               : undefined
             if (entry?.callbacks.resolve) {
-              entry.callbacks.resolve(result)
+              entry.callbacks.resolve(result.url)
             }
           })
         }
@@ -356,6 +352,9 @@ const messageHandler = (event: MessageEvent<AsyncWorkerMessage>) => {
         if (!uploadSlot) {
           return
         }
+        // The server may have sanitized the key (e.g. "%2F" → "_") on PUT.
+        // Use the resolved key it returned for progress display and refresh.
+        const resolvedObjectKey = uploadSlot.objectKey
         await new Promise<void>((resolve, reject) => {
           const xhr = new XMLHttpRequest()
 
@@ -368,7 +367,7 @@ const messageHandler = (event: MessageEvent<AsyncWorkerMessage>) => {
                 'UPLOAD_PROGRESS',
                 {
                   progress: percentCompleted,
-                  objectKey: uploadFile.name,
+                  objectKey: resolvedObjectKey,
                 },
               ])
             }
@@ -386,7 +385,7 @@ const messageHandler = (event: MessageEvent<AsyncWorkerMessage>) => {
             reject(e instanceof Error ? e : new Error(String(e)))
           })
 
-          xhr.open('PUT', uploadSlot)
+          xhr.open('PUT', uploadSlot.url)
           xhr.setRequestHeader('Content-Type', uploadFile.type)
           xhr.setRequestHeader('Content-Encoding', 'base64')
           xhr.send(uploadFile)
@@ -399,7 +398,7 @@ const messageHandler = (event: MessageEvent<AsyncWorkerMessage>) => {
             params: {
               path: {
                 folderId,
-                objectKey: encodeS3ObjectKey(objectIdentifier.objectKey),
+                objectKey: resolvedObjectKey,
               },
             },
           },
@@ -409,7 +408,7 @@ const messageHandler = (event: MessageEvent<AsyncWorkerMessage>) => {
           level: LogLevel.INFO,
           folderId,
           objectIdentifier: objectIdentifierKey(objectIdentifier),
-          message: `Upload of '${objectIdentifier.objectKey}' complete`,
+          message: `Upload of '${resolvedObjectKey}' complete`,
         })
       })
   } else if (message[0] === 'GET_PRESIGNED_DOWNLOAD_URL') {

--- a/packages/utils/src/s3.util.test.ts
+++ b/packages/utils/src/s3.util.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it } from 'bun:test'
+
+import {
+  encodeObjectKeyPreservingSlashes,
+  hasEncodedForwardSlash,
+  replaceEncodedForwardSlashes,
+  sanitizeUploadFilename,
+} from './s3.util'
+
+describe('sanitizeUploadFilename', () => {
+  it('replaces a real "/" with "_"', () => {
+    expect(sanitizeUploadFilename('a/b.txt')).toBe('a_b.txt')
+  })
+
+  it('replaces "%2F" with "_"', () => {
+    expect(sanitizeUploadFilename('a%2Fb.txt')).toBe('a_b.txt')
+  })
+
+  it('replaces lowercase "%2f" with "_"', () => {
+    expect(sanitizeUploadFilename('a%2fb.txt')).toBe('a_b.txt')
+  })
+
+  it('handles mixed and multiple occurrences', () => {
+    expect(sanitizeUploadFilename('a%2Fb/c%2fd/e')).toBe('a_b_c_d_e')
+  })
+
+  it('is idempotent', () => {
+    const once = sanitizeUploadFilename('a%2Fb/c')
+    expect(sanitizeUploadFilename(once)).toBe(once)
+  })
+
+  it('leaves normal filenames untouched', () => {
+    expect(sanitizeUploadFilename('report.txt')).toBe('report.txt')
+  })
+
+  it('leaves spaces, unicode, "." and "+" untouched', () => {
+    expect(sanitizeUploadFilename('my file (café) v1.2+final.tar.gz')).toBe(
+      'my file (café) v1.2+final.tar.gz',
+    )
+  })
+})
+
+describe('replaceEncodedForwardSlashes', () => {
+  it('replaces "%2F" with "_"', () => {
+    expect(replaceEncodedForwardSlashes('a%2Fb')).toBe('a_b')
+  })
+
+  it('replaces lowercase "%2f" with "_"', () => {
+    expect(replaceEncodedForwardSlashes('a%2fb')).toBe('a_b')
+  })
+
+  it('replaces multiple occurrences', () => {
+    expect(replaceEncodedForwardSlashes('a%2Fb%2fc')).toBe('a_b_c')
+  })
+
+  it('leaves real "/" untouched', () => {
+    expect(replaceEncodedForwardSlashes('a/b/c')).toBe('a/b/c')
+  })
+
+  it('leaves other characters and other percent-encodings untouched', () => {
+    expect(replaceEncodedForwardSlashes('a%20b%252Fc')).toBe('a%20b%252Fc')
+  })
+
+  it('is idempotent', () => {
+    const once = replaceEncodedForwardSlashes('a%2Fb')
+    expect(replaceEncodedForwardSlashes(once)).toBe(once)
+  })
+})
+
+describe('hasEncodedForwardSlash', () => {
+  it('is true for "%2F"', () => {
+    expect(hasEncodedForwardSlash('a%2Fb')).toBe(true)
+  })
+
+  it('is true for lowercase "%2f"', () => {
+    expect(hasEncodedForwardSlash('a%2fb')).toBe(true)
+  })
+
+  it('is false for a real "/"', () => {
+    expect(hasEncodedForwardSlash('a/b')).toBe(false)
+  })
+
+  it('is false for a plain string', () => {
+    expect(hasEncodedForwardSlash('ab')).toBe(false)
+  })
+
+  it('is false for a double-encoded "%252F"', () => {
+    expect(hasEncodedForwardSlash('a%252Fb')).toBe(false)
+  })
+})
+
+describe('encodeObjectKeyPreservingSlashes', () => {
+  it('keeps real "/" separators', () => {
+    expect(encodeObjectKeyPreservingSlashes('a/b/c.txt')).toBe('a/b/c.txt')
+  })
+
+  it('encodes special characters', () => {
+    expect(encodeObjectKeyPreservingSlashes('a b?c')).toBe('a%20b%3Fc')
+  })
+
+  it('encodes a literal "%2F" distinctly from a real "/"', () => {
+    expect(encodeObjectKeyPreservingSlashes('a%2Fb')).toBe('a%252Fb')
+    expect(encodeObjectKeyPreservingSlashes('a/b')).toBe('a/b')
+    expect(encodeObjectKeyPreservingSlashes('a%2Fb')).not.toBe(
+      encodeObjectKeyPreservingSlashes('a/b'),
+    )
+  })
+
+  it('round-trips a literal-"%2F" key via decodeURIComponent', () => {
+    const key = 'a%2Fb'
+    expect(decodeURIComponent(encodeObjectKeyPreservingSlashes(key))).toBe(key)
+  })
+})

--- a/packages/utils/src/s3.util.ts
+++ b/packages/utils/src/s3.util.ts
@@ -1,3 +1,22 @@
-export const encodeS3ObjectKey = (objectKey: string) => {
+// Browser-URL encoding only: encode the key for use in a URL path while
+// keeping real "/" separators readable (e.g. for navigation links).
+export const encodeObjectKeyPreservingSlashes = (objectKey: string) => {
   return encodeURIComponent(objectKey).replace(/%2F/g, '/')
 }
+
+// Replace a literal "%2F" (any case) in a key with "_". "%2F" bytes inside a
+// key are interpreted inconsistently across S3 providers when placed in a
+// presigned URL, so we sanitize them at the boundaries where we create keys.
+// Real "/" (legitimate nesting) is left untouched.
+export const replaceEncodedForwardSlashes = (value: string): string =>
+  value.replace(/%2f/gi, '_')
+
+// Sanitize an upload filename (leaf only): replace both real "/" and literal
+// "%2F" with "_". Idempotent.
+export const sanitizeUploadFilename = (name: string): string =>
+  name.replace(/%2f/gi, '_').replace(/\//g, '_')
+
+// True if the value contains a literal "%2F" (any case). Used to reject such
+// sequences in folder prefixes.
+export const hasEncodedForwardSlash = (value: string): boolean =>
+  /%2f/i.test(value)


### PR DESCRIPTION
S3 keys containing a literal "%2F" are interpreted inconsistently across providers in a presigned URL path (decoded to "/"), while a real "/" is unambiguous. Treat the two as distinct keys and sanitize "%2F" only at the boundaries where keys are created.

- Slash-preserving encoding for signed S3 paths (literal "%2F" double-encodes to "%252F"; real "/" stays a separator).
- Single-decode read path + React-free `recoverObjectKey`.
- PUT presign: discriminated-union request with PUT-only `dontReplaceEncodedForwardSlashes`; response returns the resolved `{ url, objectKey }`.
- Frontend sanitizes upload filenames at the chokepoint; folder create rejects "%2F" in location prefixes.
- Unit + API e2e (folder-objects %2F scenarios) + UI e2e (upload filename sanitize) + docs.

Stacked on #311. Linear: LOM-380