### PR TITLE
chore(LOM-381): replace MinIO with Garage as the dev/e2e S3 backend

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -5,7 +5,7 @@
 
 # Use local directories for persisted files instead of the default named docker volumes
 #PGDATA_DIR=./.docker/postgres
-#MINIO_DATA_DIR=./.docker/minio
+#GARAGE_DATA_DIR=./.docker/garage
 
 #DOCKER_HOST_CONFIG={}
 
@@ -18,14 +18,18 @@
 # Override the default initial user
 #INITIAL_USER=dev
 
-# Override this is you want to use a custom s3 service during dev
-#DEV_S3_ACCESS_KEY_ID=dummyaccesskeyid
-#DEV_S3_SECRET_ACCESS_KEY=dummysecretaccesskey
+# Override these if you want to use a custom s3 service during dev.
+# Note: the bundled Garage backend requires GK-prefixed access keys + 64-hex secrets.
+#DEV_S3_ACCESS_KEY_ID=GKdeadbeefdeadbeefdeadbeef
+#DEV_S3_SECRET_ACCESS_KEY=deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef
 #DEV_S3_BUCKET_NAME=lombok-dev
 #DEV_S3_PREFIX=dev-local
 #DEV_S3_REGION=auto
 #DEV_S3_ENDPOINT=http://localhost:9000
-#DEV_S3_LABEL='Minio local DEV'
+#DEV_S3_LABEL='Garage local DEV'
+# Garage daemon log verbosity (RUST_LOG level). Defaults to "error" to keep dev
+# output clean; set to info/debug to diagnose the bundled S3 backend.
+#DEV_S3_LOG_LEVEL=error
 
 #PRINT_CORE_WORKER_OUTPUT=false
 #PRINT_CORE_WORKER_NSJAIL_VERBOSE_OUTPUT=false

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -1,11 +1,11 @@
 # Running for development
 
 1. `bun install` -- install dependencies
-2. `./dx up` -- build and start the dev container (includes backend, frontend, PostgreSQL, and MinIO)
+2. `./dx up` -- build and start the dev container (includes backend, frontend, PostgreSQL, and Garage)
 3. Add `lombok.localhost` to your /etc/hosts file (pointing at 127.0.0.1)
 4. Visit <http://localhost:5173>
 
-Everything runs inside a single Docker container. The dev entrypoint automatically starts PostgreSQL, MinIO, the Vite frontend dev server (port 5173), and the NestJS backend (port 3000).
+Everything runs inside a single Docker container. The dev entrypoint automatically starts PostgreSQL, Garage (S3), the Vite frontend dev server (port 5173), and the NestJS backend (port 3000).
 
 After the first build, `./dx up` starts without rebuilding.
 
@@ -19,7 +19,7 @@ Run `./dx` or `./dx help` to see all available commands. Most commands execute i
 ./dx restart ui           # Restart the Vite frontend dev server
 ./dx restart proxies      # Regenerate app frontend proxy overrides and reload nginx
 ./dx restart bridge       # Restart the docker bridge server
-./dx restart container    # Restart the whole container (Postgres, MinIO, Vite, API)
+./dx restart container    # Restart the whole container (Postgres, Garage, Vite, API)
 ./dx db seed              # Seed the database with dev data
 ./dx db reset             # Drop all tables and re-migrate
 ./dx db reset:seed        # Drop all tables, re-migrate, and re-seed
@@ -51,8 +51,8 @@ Run `./dx` or `./dx help` to see all available commands. Most commands execute i
 ./dx kill                 # Force-kill the dev environment
 ./dx install              # Force-reinstall deps on host and in container
 ./dx purge db             # Tear down and remove the Postgres data volume
-./dx purge minio          # Tear down and remove the MinIO data volume
-./dx purge minio:truncate # Empty the MinIO object data in place (no teardown, no restart)
+./dx purge garage         # Tear down and remove the Garage data volume
+./dx purge garage:truncate # Empty the dev bucket in place over S3 (no teardown, no restart)
 ./dx purge all            # Tear down and remove all volumes, images, and orphans
 ```
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Lombok is a **free, open-source, and self-hostable** storage and compute platfor
 ### ✨ Key Features
 
 - **🏠 Self-Hosted**: Deploy on your own hardware or cloud infrastructure
-- **☁️ S3-Compatible**: Use any combination of S3-compatible storage backends at the same time (AWS S3, Cloudflare R2, SeaweedFS, MinIO, etc.)
+- **☁️ S3-Compatible**: Use any combination of S3-compatible storage backends at the same time (AWS S3, Cloudflare R2, SeaweedFS, Garage, MinIO, etc.)
 - **⚡ Custom Apps**: Run custom apps on your data, with worker scripts and embedded UIs
 - **🏗️ Simple Architecture**: Doesn't require deep expertise to run or extend the system
 - **📦 Docker Ready**: Easy deployment with Docker containers (as little as a single Docker run command)

--- a/docker-compose.test.yml
+++ b/docker-compose.test.yml
@@ -9,6 +9,8 @@ services:
       target: test
     environment:
       PLAYWRIGHT_SHOULD_SAVE_SCREENSHOTS: false
+      # Garage daemon verbosity; quiet by default, raise via `GARAGE_LOG_LEVEL=debug ./dx e2e api`.
+      GARAGE_LOG_LEVEL: ${GARAGE_LOG_LEVEL:-error}
     volumes:
       - ./:/usr/src/app
       - /usr/src/app/node_modules

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,13 +27,14 @@ services:
       - CREATE_DATABASE=true
       - RUN_MIGRATIONS=true
       - INITIAL_USER=${INITIAL_USER:-dev}
-      - DEV_S3_ACCESS_KEY_ID=${DEV_S3_ACCESS_KEY_ID:-lombokdevaccesskey}
-      - DEV_S3_SECRET_ACCESS_KEY=${DEV_S3_SECRET_ACCESS_KEY:-lombokdevsecretaccesskey}
+      # Garage requires GK-prefixed access keys + 64-hex secrets (these are dev throwaways).
+      - DEV_S3_ACCESS_KEY_ID=${DEV_S3_ACCESS_KEY_ID:-GKdeadbeefdeadbeefdeadbeef}
+      - DEV_S3_SECRET_ACCESS_KEY=${DEV_S3_SECRET_ACCESS_KEY:-deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef}
       - DEV_S3_BUCKET_NAME=${DEV_S3_BUCKET_NAME:-lombokdevbucket}
       - DEV_S3_PREFIX=${DEV_S3_PREFIX:-dev-local}
       - DEV_S3_REGION=${DEV_S3_REGION:-auto}
       - DEV_S3_ENDPOINT=http://${PLATFORM_HOST:-lombok.localhost}:9000
-      - DEV_S3_LABEL=${DEV_S3_LABEL:-MinioDEV}
+      - DEV_S3_LABEL=${DEV_S3_LABEL:-GarageDEV}
       - PRINT_CORE_WORKER_OUTPUT=${PRINT_CORE_WORKER_OUTPUT:-true}
       - PRINT_CORE_WORKER_NSJAIL_VERBOSE_OUTPUT=${PRINT_CORE_WORKER_NSJAIL_VERBOSE_OUTPUT:-true}
       - LOMBOK_WORKER_LOG=${LOMBOK_WORKER_LOG:-daemon=info,ipc=warn,timing=off,http=info,task=info,user=debug}
@@ -55,7 +56,7 @@ services:
       - /usr/src/app/packages/ui-toolkit/node_modules
       - ${LOCAL_DOCKER_SOCKET:-/var/run/docker.sock}:/var/run/docker.sock
       - ${PGDATA_DIR:-pgdata}:/var/lib/postgresql/data
-      - ${MINIO_DATA_DIR:-miniodata}:/var/lib/minio/data
+      - ${GARAGE_DATA_DIR:-garagedata}:/var/lib/garage
       # Worktree fix: a worktree's `.git` file points to an absolute host path
       # under the parent repo's `.git` dir; mount that path verbatim so `git`
       # inside the container resolves worktree refs. Falls through to a no-op
@@ -64,7 +65,7 @@ services:
     ports:
       - ${HOST_PLATFORM_PORT:-8080}:8080
       - ${HOST_DB_PORT:-5432}:5432
-      - ${HOST_MINIO_PORT:-9000}:9000
+      - ${HOST_S3_PORT:-9000}:9000
     cap_drop: [ALL]
     cap_add:
       - SETUID
@@ -83,4 +84,4 @@ services:
 
 volumes:
   pgdata:
-  miniodata:
+  garagedata:

--- a/docker/app.Dockerfile
+++ b/docker/app.Dockerfile
@@ -1,5 +1,4 @@
-FROM cgr.dev/chainguard/minio:latest AS minio
-FROM cgr.dev/chainguard/minio-client:latest AS mc
+FROM dxflrs/garage:v2.3.0 AS garage
 
 FROM oven/bun:1.3.14-alpine AS base
 
@@ -26,8 +25,8 @@ RUN apk add --no-cache \
   postgresql-pgvector && \
   rm -rf /var/cache/apk/*
 
-COPY --from=minio /usr/bin/minio /usr/local/bin/minio
-COPY --from=mc /usr/bin/mc /usr/local/bin/mc
+COPY --from=garage /garage /usr/local/bin/garage
+COPY packages/api/cmd/garage.toml /etc/garage.toml
 
 # Set up PostgreSQL
 RUN mkdir -p /var/lib/postgresql/data && \
@@ -36,9 +35,9 @@ RUN mkdir -p /var/lib/postgresql/data && \
   chown -R postgres:postgres /run/postgresql && \
   su-exec postgres initdb -D /var/lib/postgresql/data
 
-# Set up MinIO data directory
-RUN mkdir -p /var/lib/minio/data && \
-  chown -R bun:bun /var/lib/minio
+# Set up Garage data directories
+RUN mkdir -p /var/lib/garage/meta /var/lib/garage/data && \
+  chown -R bun:bun /var/lib/garage
 
 RUN chown -R bun:bun . && su-exec bun bun install --frozen-lockfile
 

--- a/dx
+++ b/dx
@@ -109,7 +109,7 @@ Commands:
   restart ui           Restart the Vite frontend dev server
   restart proxies      Regenerate app frontend proxy overrides and reload nginx
   restart bridge       Restart the docker bridge server
-  restart container    Restart the whole container (Postgres, MinIO, Vite, API)
+  restart container    Restart the whole container (Postgres, Garage, Vite, API)
   db seed              Seed the database with dev data
   db reset             Drop all tables and re-migrate
   db reset:seed        Drop all tables, re-migrate, and re-seed
@@ -128,8 +128,8 @@ Commands:
   kill                 Force-kill the dev environment (docker compose kill)
   purge all            Tear down and remove all volumes, images, and orphans
   purge db             Tear down and remove the Postgres data volume
-  purge minio          Tear down and remove the MinIO data volume
-  purge minio:truncate  Empty the MinIO object data in place (no teardown, no restart)
+  purge garage         Tear down and remove the Garage data volume
+  purge garage:truncate  Empty the dev bucket in place over S3 (no teardown, no restart)
   generate openapi     Generate the OpenAPI spec
   generate metadata    Generate NestJS metadata
   release standalone <version>   Build the standalone release image (e.g. 1.2.1-beta-rc3)
@@ -196,7 +196,7 @@ case "${1:-help}" in
         echo "Sent kill signal to docker-bridge. The API service will restart it automatically."
         ;;
       container)
-        # Restart the whole container (Postgres, MinIO, Vite, and the API).
+        # Restart the whole container (Postgres, Garage, Vite, and the API).
         docker compose restart api
         ;;
       *)
@@ -334,22 +334,17 @@ case "${1:-help}" in
       db)
         docker compose down && docker volume rm "${COMPOSE_PROJECT_NAME}_pgdata"
         ;;
-      minio:truncate)
+      garage:truncate)
         require_container
-        # Empty each bucket's contents in place; the */ glob skips hidden .minio.sys
-        # so the drive stays formatted and buckets keep existing — no heal, no restart.
-        docker compose exec -T -u root api sh -c '
-          for d in /var/lib/minio/data/*/; do
-            [ -d "$d" ] || continue
-            find "$d" -mindepth 1 -delete
-          done
-        '
+        # Empty the dev bucket in place over S3 (Garage's store is opaque, so
+        # there's no file tree to rm) — bucket keeps existing, no restart.
+        docker compose exec -T api bun /usr/src/app/packages/api/cmd/garage-truncate-bucket.ts
         ;;
-      minio)
-        docker compose down && docker volume rm "${COMPOSE_PROJECT_NAME}_miniodata"
+      garage)
+        docker compose down && docker volume rm "${COMPOSE_PROJECT_NAME}_garagedata"
         ;;
       *)
-        echo "Usage: ./dx purge <all|db|minio|minio:truncate>" >&2
+        echo "Usage: ./dx purge <all|db|garage|garage:truncate>" >&2
         exit 1
         ;;
     esac

--- a/packages/api/cmd/dev-entrypoint.sh
+++ b/packages/api/cmd/dev-entrypoint.sh
@@ -94,29 +94,17 @@ echo "================================================"
 printenv
 echo ""
 
-# ── MinIO ───────────────────────────────────────────────────
+# ── Garage (S3) ─────────────────────────────────────────────
 echo "================================================"
-echo "MinIO"
+echo "Garage"
 echo "================================================"
-export MINIO_DATA='/var/lib/minio/data'
-export MINIO_ROOT_USER=minioadmin
-export MINIO_ROOT_PASSWORD=minioadmin
-
-mkdir -p "$MINIO_DATA"
-chown -R "$APP_USER":"$APP_USER" "$MINIO_DATA"
-su-exec "$APP_USER" minio server "$MINIO_DATA" > /dev/stdout 2>&1 &
-
-echo "Waiting for MinIO to be ready..."
-until curl -sf http://127.0.0.1:9000/minio/health/live; do
-  sleep 1
-done
-echo "MinIO is ready."
-
-mc alias set localminio http://127.0.0.1:9000 "$MINIO_ROOT_USER" "$MINIO_ROOT_PASSWORD" --quiet
-mc mb --ignore-existing "localminio/${DEV_S3_BUCKET_NAME}"
-mc admin user add localminio "${DEV_S3_ACCESS_KEY_ID}" "${DEV_S3_SECRET_ACCESS_KEY}" 2>/dev/null || true
-mc admin policy attach localminio readwrite --user "${DEV_S3_ACCESS_KEY_ID}" 2>/dev/null || true
-echo "MinIO bucket and user setup complete."
+APP_USER="$APP_USER" \
+GARAGE_S3_ACCESS_KEY_ID="${DEV_S3_ACCESS_KEY_ID}" \
+GARAGE_S3_SECRET_KEY="${DEV_S3_SECRET_ACCESS_KEY}" \
+GARAGE_S3_BUCKET="${DEV_S3_BUCKET_NAME}" \
+GARAGE_S3_KEY_NAME="lombokdev" \
+GARAGE_LOG_LEVEL="${DEV_S3_LOG_LEVEL:-error}" \
+  sh ./packages/api/cmd/garage-provision.sh
 echo ""
 echo "================================================"
 echo "Install dependencies"

--- a/packages/api/cmd/garage-provision.sh
+++ b/packages/api/cmd/garage-provision.sh
@@ -1,0 +1,81 @@
+#!/bin/sh
+# Start a single-node Garage daemon and provision a key + bucket for local
+# dev/e2e. Shared by dev-entrypoint.sh and test-entrypoint.sh. Idempotent so it
+# survives the persisted dev data volume.
+#
+# Inputs (env):
+#   GARAGE_CONFIG_FILE       path to garage.toml (default /etc/garage.toml)
+#   APP_USER                 user that owns the data dirs / runs the daemon (default bun)
+#   GARAGE_S3_ACCESS_KEY_ID  fixed access key to import
+#   GARAGE_S3_SECRET_KEY     fixed secret for that key
+#   GARAGE_S3_BUCKET         bucket to create + grant the key on
+#   GARAGE_S3_KEY_NAME       key label (default lombok)
+#   GARAGE_S3_ENDPOINT       S3 endpoint for the CORS step (default http://127.0.0.1:9000)
+#   GARAGE_KEY_CREATE_BUCKET set to 1 to also grant the key createBucket (e2e harness)
+#   GARAGE_LOG_LEVEL         daemon+CLI log verbosity (RUST_LOG; default "error")
+set -e
+
+export GARAGE_CONFIG_FILE="${GARAGE_CONFIG_FILE:-/etc/garage.toml}"
+# Quiet by default so Garage doesn't flood dev/e2e output; raise to info/debug
+# via GARAGE_LOG_LEVEL when diagnosing. Applies to the daemon and the CLI calls.
+export RUST_LOG="${GARAGE_LOG_LEVEL:-error}"
+APP_USER="${APP_USER:-bun}"
+GARAGE_S3_KEY_NAME="${GARAGE_S3_KEY_NAME:-lombok}"
+GARAGE_S3_ENDPOINT="${GARAGE_S3_ENDPOINT:-http://127.0.0.1:9000}"
+GARAGE_DATA_ROOT='/var/lib/garage'
+LAYOUT_SENTINEL="${GARAGE_DATA_ROOT}/.lombok-layout-applied"
+
+mkdir -p "$GARAGE_DATA_ROOT"
+chown -R "$APP_USER":"$APP_USER" "$GARAGE_DATA_ROOT"
+
+# Daemon runs as APP_USER (owns the data dirs); CLI runs as the current user and
+# reaches the daemon over RPC using the secret in the config file.
+su-exec "$APP_USER" garage server > /dev/stdout 2>&1 &
+
+echo "Waiting for Garage to be ready..."
+until garage status > /dev/null 2>&1; do
+  sleep 1
+done
+echo "Garage daemon is up."
+
+# Cluster layout: assign this lone node a role once, then never again (the
+# next apply would be a new version). Sentinel persists on the dev volume.
+if [ ! -f "$LAYOUT_SENTINEL" ]; then
+  NODE_ID=$(garage node id -q 2>/dev/null | head -1 | cut -d@ -f1)
+  garage layout assign -z dc1 -c 1G "$NODE_ID"
+  garage layout apply --version 1
+  touch "$LAYOUT_SENTINEL"
+  echo "Garage cluster layout applied."
+fi
+
+# Wait for the node to be ready to serve data after layout.
+until garage status > /dev/null 2>&1; do
+  sleep 1
+done
+
+# Key: import the fixed dev/test credentials (idempotent).
+if ! garage key info "$GARAGE_S3_ACCESS_KEY_ID" > /dev/null 2>&1; then
+  garage key import --yes -n "$GARAGE_S3_KEY_NAME" \
+    "$GARAGE_S3_ACCESS_KEY_ID" "$GARAGE_S3_SECRET_KEY"
+fi
+
+if [ "${GARAGE_KEY_CREATE_BUCKET:-0}" = "1" ]; then
+  garage key allow --create-bucket "$GARAGE_S3_ACCESS_KEY_ID"
+fi
+
+# Bucket: create + grant the key full access (idempotent).
+if ! garage bucket info "$GARAGE_S3_BUCKET" > /dev/null 2>&1; then
+  garage bucket create "$GARAGE_S3_BUCKET"
+fi
+garage bucket allow --read --write --owner "$GARAGE_S3_BUCKET" \
+  --key "$GARAGE_S3_ACCESS_KEY_ID"
+
+# CORS: Garage (unlike MinIO) is not permissive by default. Browser-direct
+# presigned uploads/downloads need an explicit rule on the bucket.
+GARAGE_S3_ACCESS_KEY_ID="$GARAGE_S3_ACCESS_KEY_ID" \
+GARAGE_S3_SECRET_KEY="$GARAGE_S3_SECRET_KEY" \
+GARAGE_S3_BUCKET="$GARAGE_S3_BUCKET" \
+GARAGE_S3_ENDPOINT="$GARAGE_S3_ENDPOINT" \
+  su-exec "$APP_USER" bun /usr/src/app/packages/api/cmd/garage-set-cors.ts
+
+echo "Garage key, bucket and CORS setup complete."

--- a/packages/api/cmd/garage-set-cors.ts
+++ b/packages/api/cmd/garage-set-cors.ts
@@ -1,0 +1,42 @@
+// One-shot: apply permissive dev/e2e CORS to the Garage bucket so browser-direct
+// presigned uploads/downloads work. Garage has no permissive default (MinIO did).
+// Run via bun from the provisioning script.
+import { PutBucketCorsCommand, S3Client } from '@aws-sdk/client-s3'
+
+const accessKeyId = process.env.GARAGE_S3_ACCESS_KEY_ID ?? ''
+const secretAccessKey = process.env.GARAGE_S3_SECRET_KEY ?? ''
+const bucket = process.env.GARAGE_S3_BUCKET ?? ''
+const endpoint = process.env.GARAGE_S3_ENDPOINT ?? 'http://127.0.0.1:9000'
+
+if (!accessKeyId || !secretAccessKey || !bucket) {
+  throw new Error(
+    'GARAGE_S3_ACCESS_KEY_ID, GARAGE_S3_SECRET_KEY and GARAGE_S3_BUCKET are required',
+  )
+}
+
+const s3Client = new S3Client({
+  credentials: { accessKeyId, secretAccessKey },
+  endpoint,
+  region: 'auto',
+  forcePathStyle: true,
+})
+
+await s3Client.send(
+  new PutBucketCorsCommand({
+    Bucket: bucket,
+    CORSConfiguration: {
+      CORSRules: [
+        {
+          AllowedOrigins: ['*'],
+          AllowedMethods: ['GET', 'PUT', 'HEAD', 'DELETE'],
+          AllowedHeaders: ['*'],
+          ExposeHeaders: ['ETag'],
+          MaxAgeSeconds: 3600,
+        },
+      ],
+    },
+  }),
+)
+
+// eslint-disable-next-line no-console
+console.log(`Garage CORS applied to bucket "${bucket}".`)

--- a/packages/api/cmd/garage-truncate-bucket.ts
+++ b/packages/api/cmd/garage-truncate-bucket.ts
@@ -1,0 +1,48 @@
+// Empty the dev bucket over S3 (Garage storage is opaque — can't rm files).
+// Used by `./dx purge garage:truncate`. Deletes every object but keeps the bucket.
+import {
+  DeleteObjectCommand,
+  ListObjectsV2Command,
+  type ListObjectsV2CommandOutput,
+  S3Client,
+} from '@aws-sdk/client-s3'
+
+const accessKeyId = process.env.DEV_S3_ACCESS_KEY_ID ?? ''
+const secretAccessKey = process.env.DEV_S3_SECRET_ACCESS_KEY ?? ''
+const bucket = process.env.DEV_S3_BUCKET_NAME ?? ''
+const endpoint = process.env.DEV_S3_ENDPOINT ?? 'http://127.0.0.1:9000'
+const region = process.env.DEV_S3_REGION ?? 'auto'
+
+if (!accessKeyId || !secretAccessKey || !bucket) {
+  throw new Error(
+    'DEV_S3_ACCESS_KEY_ID, DEV_S3_SECRET_ACCESS_KEY and DEV_S3_BUCKET_NAME are required',
+  )
+}
+
+const s3Client: S3Client = new S3Client({
+  credentials: { accessKeyId, secretAccessKey },
+  endpoint,
+  region,
+  forcePathStyle: true,
+})
+
+let continuationToken: string | undefined = undefined
+let deleted = 0
+do {
+  const listed: ListObjectsV2CommandOutput = await s3Client.send(
+    new ListObjectsV2Command({
+      Bucket: bucket,
+      ContinuationToken: continuationToken,
+    }),
+  )
+  for (const obj of listed.Contents ?? []) {
+    await s3Client.send(
+      new DeleteObjectCommand({ Bucket: bucket, Key: obj.Key }),
+    )
+    deleted += 1
+  }
+  continuationToken = listed.NextContinuationToken
+} while (continuationToken)
+
+// eslint-disable-next-line no-console
+console.log(`Emptied bucket "${bucket}" (${deleted} objects deleted).`)

--- a/packages/api/cmd/garage.toml
+++ b/packages/api/cmd/garage.toml
@@ -1,0 +1,18 @@
+# Garage config for the dev + e2e containers (single-node, local only).
+# Not for production — rpc_secret below is a throwaway dev value.
+metadata_dir = "/var/lib/garage/meta"
+data_dir = "/var/lib/garage/data"
+db_engine = "sqlite"
+
+replication_factor = 1
+
+rpc_bind_addr = "127.0.0.1:3901"
+rpc_public_addr = "127.0.0.1:3901"
+rpc_secret = "0000000000000000000000000000000000000000000000000000000000000000"
+
+[s3_api]
+# "auto" matches the SigV4 region the app already signs presigned URLs with
+# (DEV_S3_REGION / test harness both use "auto"), so no app-side region change.
+s3_region = "auto"
+# Bind on 9000 so DEV_S3_ENDPOINT=http://<host>:9000 is unchanged from MinIO.
+api_bind_addr = "[::]:9000"

--- a/packages/api/cmd/test-entrypoint.sh
+++ b/packages/api/cmd/test-entrypoint.sh
@@ -111,27 +111,24 @@ echo "================================================"
 printenv
 echo ""
 
-# ── MinIO ───────────────────────────────────────────────────
+# ── Garage (S3) ─────────────────────────────────────────────
 echo ""
 echo "================================================"
-echo "MinIO"
+echo "Garage"
 echo "================================================"
-export MINIO_DATA='/var/lib/minio/data'
-export MINIO_BROWSER='off'
-export MINIO_ROOT_USER=lomboktestadmin
-export MINIO_ROOT_PASSWORD=lomboktestadmin
+# Fixed test credentials (Garage requires GK-prefixed keys + 64-hex secrets).
+# The harness mints per-suite buckets over S3, so the key is granted createBucket.
+export TEST_S3_ACCESS_KEY_ID="GKcafebabecafebabecafebabe"
+export TEST_S3_SECRET_ACCESS_KEY="cafebabecafebabecafebabecafebabecafebabecafebabecafebabecafebabe"
 
-mkdir -p "$MINIO_DATA"
-chmod -R 777 "$MINIO_DATA"
-su-exec "$APP_USER" minio server "$MINIO_DATA" > /dev/stdout 2>&1 &
-echo "Minio started."
-
-echo "Waiting for MinIO to be ready..."
-until curl -sf http://127.0.0.1:9000/minio/health/live; do
-  echo "MinIO not ready yet, waiting..."
-  sleep 2
-done
-echo "MinIO is ready."
+APP_USER="$APP_USER" \
+GARAGE_S3_ACCESS_KEY_ID="$TEST_S3_ACCESS_KEY_ID" \
+GARAGE_S3_SECRET_KEY="$TEST_S3_SECRET_ACCESS_KEY" \
+GARAGE_S3_BUCKET="lomboktestbucket" \
+GARAGE_S3_KEY_NAME="lomboktest" \
+GARAGE_KEY_CREATE_BUCKET="1" \
+GARAGE_LOG_LEVEL="${GARAGE_LOG_LEVEL:-error}" \
+  sh ./packages/api/cmd/garage-provision.sh
 
 # ── Tests ───────────────────────────────────────────────────
 echo ""

--- a/packages/api/src/storage/access-keys.e2e-spec.ts
+++ b/packages/api/src/storage/access-keys.e2e-spec.ts
@@ -4,6 +4,10 @@ import {
   buildTestModule,
   createTestFolder,
   createTestUser,
+  TEST_S3_ACCESS_KEY_ID,
+  TEST_S3_ENDPOINT,
+  TEST_S3_REGION,
+  TEST_S3_SECRET_ACCESS_KEY,
 } from 'src/test/test.util'
 
 import { buildAccessKeyHashId } from './access-key.utils'
@@ -55,14 +59,14 @@ describe('Access Keys', () => {
     expect(listAccessKeysResponse.data.result.length).toEqual(1)
     expect(listAccessKeysResponse.data.result[0]?.accessKeyHashId).toEqual(
       buildAccessKeyHashId({
-        accessKeyId: 'lomboktestadmin',
-        secretAccessKey: 'lomboktestadmin',
-        region: 'auto',
-        endpoint: 'http://127.0.0.1:9000',
+        accessKeyId: TEST_S3_ACCESS_KEY_ID,
+        secretAccessKey: TEST_S3_SECRET_ACCESS_KEY,
+        region: TEST_S3_REGION,
+        endpoint: TEST_S3_ENDPOINT,
       }),
     )
     expect(listAccessKeysResponse.data.result[0]?.accessKeyId).toEqual(
-      'lomboktestadmin',
+      TEST_S3_ACCESS_KEY_ID,
     )
     expect(listAccessKeysResponse.data.result[0]?.endpointDomain).toEqual(
       '127.0.0.1:9000',

--- a/packages/api/src/test/test.util.ts
+++ b/packages/api/src/test/test.util.ts
@@ -1,5 +1,16 @@
+import { execFile } from 'node:child_process'
+import { promisify } from 'node:util'
+
+import {
+  DeleteBucketCommand,
+  DeleteObjectCommand,
+  ListObjectsV2Command,
+  type ListObjectsV2CommandOutput,
+  PutBucketCorsCommand,
+} from '@aws-sdk/client-s3'
 import type { FolderDTO } from '@lombokapp/types'
 import { SignedURLsRequestMethod } from '@lombokapp/types'
+import { mimeFromExtension } from '@lombokapp/utils'
 import type { Type } from '@nestjs/common'
 import type { TestingModuleBuilder } from '@nestjs/testing'
 import { Test } from '@nestjs/testing'
@@ -48,11 +59,21 @@ import { NoPrefixConsoleLogger } from '../shared/no-prefix-console-logger'
 import type { TestApiClient, TestModule } from './test.types'
 import { buildSupertestApiClient } from './test-api-client'
 
-const MINIO_LOCAL_PATH = process.env.MINIO_DATA ?? ''
-const MINIO_ACCESS_KEY_ID = process.env.MINIO_ROOT_USER ?? ''
-const MINIO_SECRET_ACCESS_KEY = process.env.MINIO_ROOT_PASSWORD ?? ''
-const MINIO_ENDPOINT = 'http://127.0.0.1:9000'
-const MINIO_REGION = 'auto'
+export const TEST_S3_ACCESS_KEY_ID = process.env.TEST_S3_ACCESS_KEY_ID ?? ''
+export const TEST_S3_SECRET_ACCESS_KEY =
+  process.env.TEST_S3_SECRET_ACCESS_KEY ?? ''
+export const TEST_S3_ENDPOINT = 'http://127.0.0.1:9000'
+export const TEST_S3_REGION = 'auto'
+
+const execFileAsync = promisify(execFile)
+
+// Create test buckets via the Garage CLI (global alias) rather than the S3
+// CreateBucket API (key-local alias). Garage resolves a bucket's CORS rule for
+// *unsigned* requests — i.e. the browser's CORS preflight — only through the
+// global namespace, so a key-local bucket returns no Access-Control-Allow-*
+// headers and the browser blocks the direct presigned upload.
+const garageCli = (...args: string[]) =>
+  execFileAsync('garage', args, { timeout: 10_000 })
 
 const mockDockerClientService = buildMockDockerClientService()
 
@@ -78,7 +99,47 @@ export async function buildTestModule({
     )
   }
   const dbName = `test_db_${testModuleKey}`
-  const bucketPathsToRemove: string[] = []
+  const bucketsToRemove: string[] = []
+
+  const testS3AdminClient = () =>
+    configureS3Client({
+      accessKeyId: TEST_S3_ACCESS_KEY_ID,
+      secretAccessKey: TEST_S3_SECRET_ACCESS_KEY,
+      endpoint: TEST_S3_ENDPOINT,
+      region: TEST_S3_REGION,
+    })
+
+  // Empty + drop test buckets over S3 (Garage storage is opaque — no fs rm).
+  // Best-effort: bucket names are unique per call, so failures never collide.
+  const removeTestBuckets = async (bucketNames: string[]) => {
+    const s3Client = testS3AdminClient()
+    await Promise.all(
+      bucketNames.map(async (bucketName) => {
+        try {
+          let continuationToken: string | undefined = undefined
+          do {
+            const listed: ListObjectsV2CommandOutput = await s3Client.send(
+              new ListObjectsV2Command({
+                Bucket: bucketName,
+                ContinuationToken: continuationToken,
+              }),
+            )
+            await Promise.all(
+              (listed.Contents ?? []).map((obj) =>
+                s3Client.send(
+                  new DeleteObjectCommand({ Bucket: bucketName, Key: obj.Key }),
+                ),
+              ),
+            )
+            continuationToken = listed.NextContinuationToken
+          } while (continuationToken)
+          await s3Client.send(new DeleteBucketCommand({ Bucket: bucketName }))
+        } catch {
+          // best-effort teardown
+        }
+      }),
+    )
+  }
   let httpServer: Server | undefined = undefined
 
   // Stable, suite-unique starting position for app install sequences. Hashing
@@ -185,22 +246,48 @@ export async function buildTestModule({
     createFiles: { objectKey: string; content: Buffer | string }[] = [],
   ) {
     const bucketName = `test-bucket-${(Math.random() + 1).toString(36).substring(7)}`
-    const bucketPath = path.join(MINIO_LOCAL_PATH, bucketName)
-    bucketPathsToRemove.push(bucketPath)
+    bucketsToRemove.push(bucketName)
 
-    if (fs.existsSync(bucketPath)) {
-      throw new Error('Test bucket somehow already exists.')
-    }
+    // Global-alias bucket via the CLI (see garageCli) + grant the test key
+    // full access, mirroring how the dev/e2e default bucket is provisioned.
+    await garageCli('bucket', 'create', bucketName)
+    await garageCli(
+      'bucket',
+      'allow',
+      '--read',
+      '--write',
+      '--owner',
+      bucketName,
+      '--key',
+      TEST_S3_ACCESS_KEY_ID,
+    )
 
-    fs.mkdirSync(bucketPath)
+    // Garage (unlike MinIO) has no permissive default CORS, and the app runs a
+    // CORS preflight before browser uploads — so each test bucket needs a rule.
+    await testS3AdminClient().send(
+      new PutBucketCorsCommand({
+        Bucket: bucketName,
+        CORSConfiguration: {
+          CORSRules: [
+            {
+              AllowedOrigins: ['*'],
+              AllowedMethods: ['GET', 'PUT', 'HEAD', 'DELETE'],
+              AllowedHeaders: ['*'],
+              ExposeHeaders: ['ETag'],
+              MaxAgeSeconds: 3600,
+            },
+          ],
+        },
+      }),
+    )
 
     const uploadUrls = createS3PresignedUrls(
       createFiles.map(({ objectKey }) => {
         return {
-          accessKeyId: MINIO_ACCESS_KEY_ID,
-          secretAccessKey: MINIO_SECRET_ACCESS_KEY,
-          endpoint: MINIO_ENDPOINT,
-          region: MINIO_REGION,
+          accessKeyId: TEST_S3_ACCESS_KEY_ID,
+          secretAccessKey: TEST_S3_SECRET_ACCESS_KEY,
+          endpoint: TEST_S3_ENDPOINT,
+          region: TEST_S3_REGION,
           bucket: bucketName,
           expirySeconds: 3000,
           method: SignedURLsRequestMethod.PUT,
@@ -213,8 +300,16 @@ export async function buildTestModule({
       uploadUrls.map((uploadUrl, i) => {
         // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
         const createFile = createFiles[i]!
+        // Send a Content-Type like the browser does. Garage stores exactly the
+        // header it receives (no application/octet-stream default), and the
+        // analyze worker requires a content-type on the GET to hash the object.
         return fetch(uploadUrl, {
           method: 'PUT',
+          headers: {
+            'Content-Type':
+              mimeFromExtension(createFile.objectKey) ??
+              'application/octet-stream',
+          },
           body:
             typeof createFile.content === 'string'
               ? createFile.content
@@ -232,10 +327,10 @@ export async function buildTestModule({
         isAdmin: true,
       } as User,
       {
-        accessKeyId: MINIO_ACCESS_KEY_ID,
-        secretAccessKey: MINIO_SECRET_ACCESS_KEY,
-        endpoint: MINIO_ENDPOINT,
-        region: MINIO_REGION,
+        accessKeyId: TEST_S3_ACCESS_KEY_ID,
+        secretAccessKey: TEST_S3_SECRET_ACCESS_KEY,
+        endpoint: TEST_S3_ENDPOINT,
+        region: TEST_S3_REGION,
         bucket: bucketName,
         prefix: null,
       },
@@ -325,24 +420,15 @@ export async function buildTestModule({
     },
     apiClient: buildSupertestApiClient(app),
     shutdown: async () => {
-      // remove created minio buckets
-      for (const p of bucketPathsToRemove) {
-        fs.rmSync(p, { recursive: true })
-      }
-
-      // shutdown the app
+      await removeTestBuckets(bucketsToRemove.splice(0))
       if (httpServer) {
         httpServer.close()
       }
       await app.close()
     },
     cleanupMinioTestBuckets: () => {
-      for (const p of bucketPathsToRemove) {
-        if (fs.existsSync(p)) {
-          fs.rmSync(p, { recursive: true })
-        }
-      }
-      bucketPathsToRemove.length = 0
+      // Fire-and-forget: this caller can't await.
+      void removeTestBuckets(bucketsToRemove.splice(0))
     },
     resolveDep<T extends Type>(token: T) {
       // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
@@ -353,17 +439,17 @@ export async function buildTestModule({
       await services.ormService.resetTestDb()
     },
     testS3ClientConfig: () => ({
-      accessKeyId: MINIO_ACCESS_KEY_ID,
-      secretAccessKey: MINIO_SECRET_ACCESS_KEY,
-      endpoint: MINIO_ENDPOINT,
-      region: MINIO_REGION,
+      accessKeyId: TEST_S3_ACCESS_KEY_ID,
+      secretAccessKey: TEST_S3_SECRET_ACCESS_KEY,
+      endpoint: TEST_S3_ENDPOINT,
+      region: TEST_S3_REGION,
     }),
     testS3Client: () =>
       configureS3Client({
-        accessKeyId: MINIO_ACCESS_KEY_ID,
-        secretAccessKey: MINIO_SECRET_ACCESS_KEY,
-        endpoint: MINIO_ENDPOINT,
-        region: MINIO_REGION,
+        accessKeyId: TEST_S3_ACCESS_KEY_ID,
+        secretAccessKey: TEST_S3_SECRET_ACCESS_KEY,
+        endpoint: TEST_S3_ENDPOINT,
+        region: TEST_S3_REGION,
       }),
     /**
      * Compute the identifier (composed `<slug>-<id>` form) of the first app
@@ -448,10 +534,10 @@ export async function buildTestModule({
     ) => {
       return createS3PresignedUrls(
         presignedRequests.map((presignedRequest) => ({
-          endpoint: MINIO_ENDPOINT,
-          accessKeyId: MINIO_ACCESS_KEY_ID,
-          secretAccessKey: MINIO_SECRET_ACCESS_KEY,
-          region: MINIO_REGION,
+          endpoint: TEST_S3_ENDPOINT,
+          accessKeyId: TEST_S3_ACCESS_KEY_ID,
+          secretAccessKey: TEST_S3_SECRET_ACCESS_KEY,
+          region: TEST_S3_REGION,
           bucket: presignedRequest.bucket,
           objectKey: presignedRequest.objectKey,
           method: presignedRequest.method,
@@ -591,11 +677,11 @@ export function testS3Location({
   prefix?: string | null
 }) {
   return {
-    accessKeyId: MINIO_ACCESS_KEY_ID,
-    secretAccessKey: MINIO_SECRET_ACCESS_KEY,
-    endpoint: MINIO_ENDPOINT,
+    accessKeyId: TEST_S3_ACCESS_KEY_ID,
+    secretAccessKey: TEST_S3_SECRET_ACCESS_KEY,
+    endpoint: TEST_S3_ENDPOINT,
     bucket: bucketName,
-    region: MINIO_REGION,
+    region: TEST_S3_REGION,
     prefix,
   }
 }

--- a/packages/api/tsconfig.json
+++ b/packages/api/tsconfig.json
@@ -41,6 +41,7 @@
     "src/**/*.ts",
     "src/**/*.json",
     "script/*.ts",
+    "cmd/*.ts",
     "test/**/*.ts",
     "eslint.config.ts",
     "script/db-seeds/*.ts"

--- a/packages/ui/src/utils/file.ts
+++ b/packages/ui/src/utils/file.ts
@@ -1,8 +1,10 @@
 export function downloadData(downloadURL: string, name: string) {
-  // Try to fetch the file as a Blob so we can trigger a download
-  // without navigating and while preserving the provided filename.
-  // If this fails due to CORS, fall back to using a hidden iframe.
-  void fetch(downloadURL, { credentials: 'include' })
+  // Fetch the file as a Blob so we can trigger a download without navigating
+  // and while preserving the provided filename. The URL is a presigned S3 URL
+  // (auth is in the signature), so the request must be non-credentialed: a
+  // cross-origin credentialed fetch is rejected against a wildcard CORS origin,
+  // which is what S3 backends like Garage return.
+  void fetch(downloadURL)
     .then((response) => {
       if (!response.ok) {
         throw new Error('Failed to fetch download URL')


### PR DESCRIPTION
Swap the bundled S3 store from MinIO to Garage for both the dev container and the e2e harness. Garage replaces minio+mc with a single binary, using its own CLI for key/bucket provisioning plus the S3 PutBucketCors API for CORS.

- Dockerfile: single dxflrs/garage stage + `garage.toml`.
- `garage-provision.sh`: single-node daemon, layout, key import, bucket create/allow, CORS; shared by dev + test entrypoints (idempotent).
- Garage requires GK-prefixed access keys + 64-hex secrets, so dev/test creds are GK-format.
- `test.util.ts`: create/empty/drop test buckets over the S3 API instead of `fs.mkdirSync` into MinIO's on-disk layout.
- `dx`: `purge garage` / `garage:truncate`; compose/.env/docs renames.
- Fix object downloads: stop sending credentials on the presigned-S3 fetch (wildcard CORS rejects credentialed requests).

> Note: the e2e image must be rebuilt for this branch (the Garage binary is baked into the image, not bind-mounted).

Stacked on #312. Linear: LOM-381